### PR TITLE
[Fix] Use FQCN for Laravel facades instead of using the aliases.

### DIFF
--- a/resources/migrations/create_media_table.php.stub
+++ b/resources/migrations/create_media_table.php.stub
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\MediaLibrary;
 
-use File;
+use Illuminate\Support\Facades\File;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Spatie\Glide\GlideImage;
 use Spatie\MediaLibrary\Conversion\Conversion;


### PR DESCRIPTION
It's a good practice to use the FQCN for facades instead of just relying on the alias as this prevents issues when applications have removed the aliases, like how i do.

> I believe i catched all of them, at least from my usage anyway.