### PR TITLE
Add getPath method to Media model to retrieve the full path on disk to the media item

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -62,6 +62,26 @@ class Media extends Model implements SortableInterface
     }
 
     /**
+     * Get the original path to a media-file.
+     *
+     * @param string $conversionName
+     *
+     * @return string
+     *
+     * @throws \Spatie\MediaLibrary\Exceptions\UnknownConversion
+     */
+    public function getPath($conversionName = '')
+    {
+        $urlGenerator = UrlGeneratorFactory::createForMedia($this);
+
+        if ($conversionName != '') {
+            $urlGenerator->setConversion(ConversionCollectionFactory::createForMedia($this)->getByName($conversionName));
+        }
+
+        return $urlGenerator->getPath();
+    }
+
+    /**
      * Determine the type of a file.
      *
      * @return string

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -23,6 +23,16 @@ class LocalUrlGenerator extends BaseUrlGenerator implements UrlGenerator
     }
 
     /**
+     * Get the path for the profile of a media item.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->getStoragePath().'/'.$this->getPathRelativeToRoot();
+    }
+
+    /**
      * Get the directory where all files of the media item are stored.
      *
      * @return \Spatie\String\Str

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -15,4 +15,14 @@ class S3UrlGenerator extends BaseUrlGenerator implements UrlGenerator
     {
         return config('laravel-medialibrary.s3.domain').'/'.$this->getPathRelativeToRoot();
     }
+
+    /**
+     * Get the path for the profile of a media item.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->getPathRelativeToRoot();
+    }
 }

--- a/tests/Media/GetPathTest.php
+++ b/tests/Media/GetPathTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test\Media;
+
+use Spatie\MediaLibrary\Test\TestCase;
+
+class GetPathTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_get_a_path_of_an_original_item()
+    {
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+
+        $this->assertEquals($media->getPath(), $this->getMediaDirectory()."/{$media->id}/test.jpg");
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_a_path_of_a_derived_image()
+    {
+        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibrary();
+
+        $conversionName = 'thumb';
+
+        $this->assertEquals($this->getMediaDirectory()."/{$media->id}/conversions/{$conversionName}.jpg", $media->getPath($conversionName));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_exception_when_getting_a_path_for_an_unknown_conversion()
+    {
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+
+        $this->setExpectedException(\Spatie\MediaLibrary\Exceptions\UnknownConversion::class);
+
+        $media->getPath('unknownConversionName');
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_the_default_collection()
+    {
+        $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+
+        $this->assertCount(1, $this->testModel->getMedia());
+    }
+}


### PR DESCRIPTION
Hi, me again :)

I came across a need to not only retrieve the public-facing URL to a media item, but also to retrieve the full path on disk to it. I thought the easiest way to do that would be to create a `getPath()` method on the Media model, like the already existing `getUrl()` method.

There are a couple of concerns I have about this PR:

- The responsibilities of `LocalUrlGenerator` and `S3UrlGenerator` is now mixed between generating URLs and generating paths to the file. Separating concerns into a `LocalUrlGenerator` and `LocalPathGenerator` seems really redundant, though.
- I wasn't quite sure what to return in the `getPath()` method of `S3UrlGenerator`. In the end I settled on just returning the relative path, as that's how you would usually access an object stored on S3.
- The `it_can_get_the_default_collection` test on `GetPathTest.php` seems to be a duplicate of the same method in `GetUrlTestphp`, I'm not 100% sure what this method does as it doesn't seem to be relevant to the `getPath()` or `getUrl()` methods.

I'm happy to discuss the above issues and if you think they require action I'll work on the PR some more. 

Thanks,
Chris