### PR TITLE
Added support of classes morphMap

### DIFF
--- a/src/Conversion/ConversionCollection.php
+++ b/src/Conversion/ConversionCollection.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\MediaLibrary\Conversion;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\MediaLibrary\Exceptions\UnknownConversion;
 use Spatie\MediaLibrary\HasMedia\Interfaces\HasMediaConversions;
 use Spatie\MediaLibrary\Media;
@@ -55,7 +57,7 @@ class ConversionCollection extends Collection
      */
     protected function addConversionsFromRelatedModel(Media $media)
     {
-        $modelName = $media->model_type;
+        $modelName = Arr::get(Relation::morphMap(), $media->model_type, $media->model_type);
 
         /*
          * To prevent an sql query create a new model instead


### PR DESCRIPTION
There is an exception in case when trying to add media to class which exists in `Relation::$morphMap` array.

```php
class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        Relation::morphMap([
            'page' => \App\Models\Page::class,
        ]);
    }
}
```

If model exists in morphMap array - this alias will be written in polymorphic tables as `*_type` column value.

I haven't found any clean way to fix it and just copied `\Illuminate\Database\Eloquent\Model::getActualClassNameForMorph()` method at this moment.