### PR TITLE
Added ability to attach media to models within Relation::$morphMap array

### DIFF
--- a/src/Conversion/ConversionCollection.php
+++ b/src/Conversion/ConversionCollection.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\MediaLibrary\Conversion;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\MediaLibrary\Exceptions\UnknownConversion;
 use Spatie\MediaLibrary\HasMedia\Interfaces\HasMediaConversions;
 use Spatie\MediaLibrary\Media;
@@ -55,7 +57,7 @@ class ConversionCollection extends Collection
      */
     protected function addConversionsFromRelatedModel(Media $media)
     {
-        $modelName = $media->model_type;
+        $modelName = Arr::get(Relation::morphMap(), $media->model_type, $media->model_type);
 
         /*
          * To prevent an sql query create a new model instead

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -185,6 +185,6 @@ class IntegrationTest extends TestCase
             ->addMedia($this->getTestJpg())
             ->toMediaLibrary();
 
-        $this->assertEquals('default', $media->collection_name);
+        $this->assertEquals($this->testModelWithMorphMap->getMorphClass(), $media->model_type);
     }
 }

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -175,4 +175,16 @@ class IntegrationTest extends TestCase
             $this->assertEquals($index + 1, $media[$index]->order_column);
         }
     }
+
+    /**
+     * @test
+     */
+    public function it_can_add_file_to_model_with_morph_map()
+    {
+        $media = $this->testModelWithMorphMap
+            ->addMedia($this->getTestJpg())
+            ->toMediaLibrary();
+
+        $this->assertEquals('default', $media->collection_name);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Test;
 
 use File;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Schema\Blueprint;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -23,6 +24,11 @@ abstract class TestCase extends Orchestra
      */
     protected $testModelWithoutMediaConversions;
 
+    /**
+     * @var \Spatie\MediaLibrary\Test\TestModelWithMorphMap
+     */
+    protected $testModelWithMorphMap;
+
     public function setUp()
     {
         parent::setUp();
@@ -34,6 +40,7 @@ abstract class TestCase extends Orchestra
         $this->testModel = TestModel::first();
         $this->testModelWithConversion = TestModelWithConversion::first();
         $this->testModelWithoutMediaConversions = TestModelWithoutMediaConversions::first();
+        $this->testModelWithMorphMap = TestModelWithMorphMap::first();
     }
 
     /**
@@ -77,6 +84,8 @@ abstract class TestCase extends Orchestra
         });
 
         $app['config']->set('app.key', '6rE9Nz59bGRbeMATftriyQjrpF7DcOQm');
+
+        $this->setUpMorphMap();
     }
 
     /**
@@ -130,5 +139,12 @@ abstract class TestCase extends Orchestra
     public function getTestJpg()
     {
         return $this->getTestFilesDirectory('test.jpg');
+    }
+
+    private function setUpMorphMap()
+    {
+        Relation::morphMap([
+            'test-model-with-morph-map' => TestModelWithMorphMap::class,
+        ]);
     }
 }

--- a/tests/TestModelWithMorphMap.php
+++ b/tests/TestModelWithMorphMap.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\MediaLibrary\HasMedia\Interfaces\HasMedia;
+use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
+
+class TestModelWithMorphMap extends Model implements HasMedia
+{
+    use HasMediaTrait;
+
+    protected $table = 'test_models';
+    protected $guarded = [];
+    public $timestamps = false;
+}


### PR DESCRIPTION
Parent issue: #69

There is 2 ways to define model morph class alias:
1. Add it to [Relation::$morphMap array](https://github.com/laravel/framework/pull/9891)
2. Define it in model's attribute $morphClass

This PR solving retrieving of concrete class name from alias only for 1st case. I'm not sure about the way to solve the 2nd one without rewriting code a lot. Maybe I missed an easier way...