### PR TITLE
Feature/path strategy

### DIFF
--- a/resources/config/laravel-medialibrary.php
+++ b/resources/config/laravel-medialibrary.php
@@ -29,7 +29,12 @@ return [
      * When urls to files get generated this class will be called. Leave empty
      * if your files are stored locally above the site root or on s3.
      */
-    'custom_url_generator_class' => '',
+    'custom_url_generator_class' => null,
+
+    /*
+     * The class that contains the strategy for determining a media file's path.
+     */
+    'custom_path_generator_class' => null,
 
     's3' => [
         /*

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -22,6 +22,7 @@ class FileAdder
      * @var Filesystem
      */
     protected $fileSystem;
+
     /**
      * @var Repository
      */
@@ -51,6 +52,7 @@ class FileAdder
      * @var string
      */
     protected $pathToFile;
+
     /**
      * @var string
      */
@@ -121,7 +123,7 @@ class FileAdder
     }
 
     /**
-     * When adding the file the medialibrary, the original file
+     * When adding the file to the media library, the original file
      * will be preserved.
      *
      * @return $this

--- a/src/PathGenerator/BasePathGenerator.php
+++ b/src/PathGenerator/BasePathGenerator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\MediaLibrary\PathGenerator;
+
+use Spatie\MediaLibrary\Media;
+
+class BasePathGenerator implements PathGenerator
+{
+    /**
+     * Get the path for the given media, relative to the root storage path.
+     *
+     * @param Media $media
+     *
+     * @return string
+     */
+    public function getPath(Media $media)
+    {
+        return $this->getBasePath($media) . '/';
+    }
+
+    /**
+     * Get the path for conversions of the given media, relative to the root storage path.
+     *
+     * @param \Spatie\MediaLibrary\Media $media
+     *
+     * @return string
+     */
+    public function getPathForConversions(Media $media)
+    {
+        return $this->getBasePath($media) . '/conversions/';
+    }
+
+    /**
+     * Get a (unique) base path for the given media.
+     *
+     * @param \Spatie\MediaLibrary\Media $media
+     *
+     * @return mixed
+     */
+    protected function getBasePath(Media $media)
+    {
+        return $media->getKey();
+    }
+}

--- a/src/PathGenerator/PathGenerator.php
+++ b/src/PathGenerator/PathGenerator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\MediaLibrary\PathGenerator;
+
+use Spatie\MediaLibrary\Conversion\Conversion;
+use Spatie\MediaLibrary\Media;
+
+interface PathGenerator
+{
+    /**
+     * Get the path for the given media, relative to the root storage path.
+     *
+     * @param Media $media
+     * @return string
+     */
+    public function getPath(Media $media);
+
+    /**
+     * Get the path for conversions of the given media, relative to the root storage path.
+     *
+     * @param Media $media
+     * @return string
+     */
+    public function getPathForConversions(Media $media);
+}

--- a/src/PathGenerator/PathGeneratorFactory.php
+++ b/src/PathGenerator/PathGeneratorFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\MediaLibrary\PathGenerator;
+
+class PathGeneratorFactory
+{
+    public static function create()
+    {
+        $pathGeneratorClass = BasePathGenerator::class;
+        $customPathClass = config('laravel-medialibrary.custom_path_generator_class');
+
+        if ($customPathClass && class_exists($customPathClass) && is_subclass_of($customPathClass, PathGenerator::class)) {
+            $pathGeneratorClass = $customPathClass;
+        }
+
+        return app($pathGeneratorClass);
+    }
+}

--- a/src/UrlGenerator/BaseUrlGenerator.php
+++ b/src/UrlGenerator/BaseUrlGenerator.php
@@ -4,6 +4,7 @@ namespace Spatie\MediaLibrary\UrlGenerator;
 
 use Illuminate\Contracts\Config\Repository as Config;
 use Spatie\MediaLibrary\Conversion\Conversion;
+use Spatie\MediaLibrary\PathGenerator\PathGenerator;
 
 abstract class BaseUrlGenerator
 {
@@ -16,6 +17,11 @@ abstract class BaseUrlGenerator
      * @var \Spatie\MediaLibrary\Conversion\Conversion
      */
     protected $conversion;
+
+    /**
+     * @var \Spatie\MediaLibrary\PathGenerator\PathGenerator
+     */
+    protected $pathGenerator;
 
     /**
      * @var \Illuminate\Contracts\Config\Repository
@@ -55,19 +61,29 @@ abstract class BaseUrlGenerator
     }
 
     /**
+     * @param \Spatie\MediaLibrary\PathGenerator\PathGenerator $pathGenerator
+     *
+     * @return $this
+     */
+    public function setPathGenerator(PathGenerator $pathGenerator)
+    {
+        $this->pathGenerator = $pathGenerator;
+
+        return $this;
+    }
+
+    /**
      * Get the path to the requested file relative to the root of the media directory.
      *
      * @return string
      */
     public function getPathRelativeToRoot()
     {
-        $path = $this->media->id;
-
         if (is_null($this->conversion)) {
-            return $path.'/'.$this->media->file_name;
+            return $this->pathGenerator->getPath($this->media) . $this->media->file_name;
         }
 
-        return $path.'/conversions/'.$this->conversion->getName().'.'.
-            $this->conversion->getResultExtension($this->media->extension);
+        return $this->pathGenerator->getPathForConversions($this->media) .
+            $this->conversion->getName() . '.' . $this->conversion->getResultExtension($this->media->extension);
     }
 }

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -15,14 +15,4 @@ class S3UrlGenerator extends BaseUrlGenerator implements UrlGenerator
     {
         return config('laravel-medialibrary.s3.domain').'/'.$this->getPathRelativeToRoot();
     }
-
-    /**
-     * Get the path for the profile of a media item.
-     *
-     * @return string
-     */
-    public function getPath()
-    {
-        return $this->getPathRelativeToRoot();
-    }
 }

--- a/src/UrlGenerator/UrlGenerator.php
+++ b/src/UrlGenerator/UrlGenerator.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\MediaLibrary\UrlGenerator;
 
+use Spatie\MediaLibrary\PathGenerator\PathGenerator;
+
 interface UrlGenerator
 {
     /**
@@ -12,4 +14,13 @@ interface UrlGenerator
      * @throws UrlCouldNotBeDeterminedException
      */
     public function getUrl();
+
+    /**
+     * Set the path generator class.
+     *
+     * @param \Spatie\MediaLibrary\PathGenerator\PathGenerator $pathGenerator
+     *
+     * @return mixed
+     */
+    public function setPathGenerator(PathGenerator $pathGenerator);
 }

--- a/src/UrlGenerator/UrlGeneratorFactory.php
+++ b/src/UrlGenerator/UrlGeneratorFactory.php
@@ -3,8 +3,6 @@
 namespace Spatie\MediaLibrary\UrlGenerator;
 
 use Spatie\MediaLibrary\Media;
-use Spatie\MediaLibrary\PathGenerator\BasePathGenerator;
-use Spatie\MediaLibrary\PathGenerator\PathGenerator;
 use Spatie\MediaLibrary\PathGenerator\PathGeneratorFactory;
 
 class UrlGeneratorFactory

--- a/src/UrlGenerator/UrlGeneratorFactory.php
+++ b/src/UrlGenerator/UrlGeneratorFactory.php
@@ -3,6 +3,9 @@
 namespace Spatie\MediaLibrary\UrlGenerator;
 
 use Spatie\MediaLibrary\Media;
+use Spatie\MediaLibrary\PathGenerator\BasePathGenerator;
+use Spatie\MediaLibrary\PathGenerator\PathGenerator;
+use Spatie\MediaLibrary\PathGenerator\PathGeneratorFactory;
 
 class UrlGeneratorFactory
 {
@@ -10,15 +13,17 @@ class UrlGeneratorFactory
     {
         $urlGeneratorClass = 'Spatie\MediaLibrary\UrlGenerator\\'.ucfirst($media->getDiskDriverName()).'UrlGenerator';
 
-        $customClass = config('laravel-medialibrary.custom_url_generator_class');
+        $customUrlClass = config('laravel-medialibrary.custom_url_generator_class');
 
-        if ($customClass != '' && class_exists($customClass) && is_subclass_of($customClass, UrlGenerator::class)) {
-            $urlGeneratorClass = $customClass;
+        if ($customUrlClass && class_exists($customUrlClass) && is_subclass_of($customUrlClass, UrlGenerator::class)) {
+            $urlGeneratorClass = $customUrlClass;
         }
 
         $urlGenerator = app($urlGeneratorClass);
 
-        $urlGenerator->setMedia($media);
+        $pathGenerator = PathGeneratorFactory::create();
+
+        $urlGenerator->setMedia($media)->setPathGenerator($pathGenerator);
 
         return $urlGenerator;
     }

--- a/tests/PathGenerator/BasePathGeneratorTest.php
+++ b/tests/PathGenerator/BasePathGeneratorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test\PathGenerator;
+
+use Spatie\MediaLibrary\Conversion\ConversionCollectionFactory;
+use Spatie\MediaLibrary\PathGenerator\BasePathGenerator;
+use Spatie\MediaLibrary\Test\TestCase;
+use Spatie\MediaLibrary\UrlGenerator\LocalUrlGenerator;
+
+class BasePathGeneratorTest extends TestCase
+{
+    protected $config;
+
+    /**
+     * @var \Spatie\MediaLibrary\Media
+     */
+    protected $media;
+
+    /**
+     * @var \Spatie\MediaLibrary\Conversion\Conversion
+     */
+    protected $conversion;
+
+    /**
+     * @var LocalUrlGenerator
+     */
+    protected $urlGenerator;
+
+    /**
+     * @var BasePathGenerator
+     */
+    protected $pathGenerator;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->config = app('config');
+
+        // because BaseUrlGenerator is abstract we'll use LocalUrlGenerator to test the methods of base
+        $this->urlGenerator = new LocalUrlGenerator($this->config);
+
+        // but we'll use a custom pathGenerator
+        $this->pathGenerator = new CustomPathGenerator();
+
+        $this->urlGenerator->setPathGenerator($this->pathGenerator);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_the_custom_path_for_media_without_conversions()
+    {
+        $media = $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibrary();
+
+        $this->urlGenerator->setMedia($media);
+
+        $pathRelativeToRoot = md5($media->id) . '/' . $media->file_name;
+
+        $this->assertEquals($pathRelativeToRoot, $this->urlGenerator->getPathRelativeToRoot());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_the_custom_path_for_media_with_conversions()
+    {
+        $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibrary();
+        $conversion = ConversionCollectionFactory::createForMedia($media)->getByName('thumb');
+
+        $this->urlGenerator
+            ->setMedia($media)
+            ->setConversion($conversion);
+
+        $pathRelativeToRoot = md5($media->id).'/c/'.$conversion->getName().'.'.$conversion->getResultExtension($media->extension);
+
+        $this->assertEquals($pathRelativeToRoot, $this->urlGenerator->getPathRelativeToRoot());
+    }
+}

--- a/tests/PathGenerator/CustomPathGenerator.php
+++ b/tests/PathGenerator/CustomPathGenerator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test\PathGenerator;
+
+use Spatie\MediaLibrary\Media;
+use Spatie\MediaLibrary\PathGenerator\PathGenerator;
+
+class CustomPathGenerator implements PathGenerator
+{
+    /**
+     * Get the path for the given media, relative to the root storage path.
+     *
+     * @param Media $media
+     *
+     * @return string
+     */
+    public function getPath(Media $media)
+    {
+        return md5($media->id) . '/';
+    }
+
+    /**
+     * Get the path for conversions of the given media, relative to the root storage path.
+     *
+     * @param Media $media
+     *
+     * @return string
+     */
+    public function getPathForConversions(Media $media)
+    {
+        return md5($media->id). '/c/';
+    }
+}

--- a/tests/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/UrlGenerator/BaseUrlGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Test\UrlGenerator;
 
 use Spatie\MediaLibrary\Conversion\ConversionCollectionFactory;
+use Spatie\MediaLibrary\PathGenerator\BasePathGenerator;
 use Spatie\MediaLibrary\Test\TestCase;
 use Spatie\MediaLibrary\UrlGenerator\LocalUrlGenerator;
 
@@ -23,7 +24,12 @@ class BaseUrlGeneratorTest extends TestCase
     /**
      * @var LocalUrlGenerator
      */
-    protected $generator;
+    protected $urlGenerator;
+
+    /**
+     * @var BasePathGenerator
+     */
+    protected $pathGenerator;
 
     public function setUp()
     {
@@ -36,11 +42,14 @@ class BaseUrlGeneratorTest extends TestCase
         $this->conversion = ConversionCollectionFactory::createForMedia($this->media)->getByName('thumb');
 
         // because BaseUrlGenerator is abstract we'll use LocalUrlGenerator to test the methods of base
-        $this->generator = new LocalUrlGenerator($this->config);
+        $this->urlGenerator = new LocalUrlGenerator($this->config);
+        $this->pathGenerator = new BasePathGenerator();
 
-        $this->generator
+        $this->urlGenerator
             ->setMedia($this->media)
-            ->setConversion($this->conversion);
+            ->setConversion($this->conversion)
+            ->setPathGenerator($this->pathGenerator);
+
     }
 
     /**
@@ -50,6 +59,6 @@ class BaseUrlGeneratorTest extends TestCase
     {
         $pathRelativeToRoot = $this->media->id.'/conversions/'.$this->conversion->getName().'.'.$this->conversion->getResultExtension($this->media->extension);
 
-        $this->assertEquals($pathRelativeToRoot, $this->generator->getPathRelativeToRoot());
+        $this->assertEquals($pathRelativeToRoot, $this->urlGenerator->getPathRelativeToRoot());
     }
 }


### PR DESCRIPTION
This PR is a solution for #94.

It takes the logic for building paths and URLs and extracts it into it's own class.  You can then use a custom PathGenerator class to save files to directories like:

```
/62/93/62933a2951ef01f4eafd9bdf4d3cd2f0/file.jpg
```

instead of:

```
/1/file.jpg
```