### PR TITLE
Fix bug when using a custom class (defined via string in config)

### DIFF
--- a/src/UrlGenerator/UrlGeneratorFactory.php
+++ b/src/UrlGenerator/UrlGeneratorFactory.php
@@ -14,7 +14,7 @@ class UrlGeneratorFactory
         $customUrlClass = config('laravel-medialibrary.custom_url_generator_class');
 
         $urlGenerator = self::isAValidUrlGeneratorClass($customUrlClass)
-            ? $customUrlClass
+            ? app($customUrlClass)
             : app($urlGeneratorClass);
 
         $pathGenerator = PathGeneratorFactory::create();


### PR DESCRIPTION
When you simplified the big if statement with 2fe6fae, you forgot to instantiate the custom class, if it was specified.  This fixes that.