### PR TITLE
Fix for comparing a cast array to a non-cast array

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -19,7 +19,7 @@ class Media extends Model
 
     public $imageProfileUrls = [];
 
-    public $previousManipulations = [];
+    public $hasModifiedManipulations = false;
 
     /**
      * The attributes that should be casted to native types.

--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -11,7 +11,7 @@ class MediaObserver
 
     public function updating(Media $media)
     {
-        $media->previousManipulations = $media->getOriginal('manipulations');
+        $media->hasModifiedManipulations = $media->isDirty('manipulations');
 
         if ($media->file_name != $media->getOriginal('file_name')) {
             app(Filesystem::class)->renameFile($media, $media->getOriginal('file_name'));
@@ -24,7 +24,7 @@ class MediaObserver
             return;
         }
 
-        if ($media->manipulations != $media->previousManipulations) {
+        if ($media->hasModifiedManipulations) {
             app(FileManipulator::class)->createDerivedFiles($media);
         }
     }


### PR DESCRIPTION
I was running into an error that I tracked down to these lines in `MediaObserver.php`:

```php
    public function updating(Media $media)
    {
        $media->previousManipulations = $media->getOriginal('manipulations');
        //...
    }

    public function updated(Media $media)
    {
        //...
        if ($media->manipulations != $media->previousManipulations) {
            //...
        }
    }
```
The issue is that `$media->manipulations` is cast to an array, but Eloquent's `getOriginal` method doesn't seem to do any casting.  In my case, the original value was the string "[]" but the compared value was an empty array (i.e. after being cast).

Because Eloquent doesn't appear to let you access the uncast values of attributes directly, and since what you are really checking here is whether the _manipulations_ attribute changed during the update, I think a safer way would be to just use the `isDirty()` method that Eloquent provides (which incidentally, compares current and original attributes without performing any casting).