### PR TITLE
Use Database Path for Publishing Migrations.

### DIFF
--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -32,7 +32,7 @@ class MediaLibraryServiceProvider extends ServiceProvider
             $timestamp = date('Y_m_d_His', time());
 
             $this->publishes([
-                __DIR__.'/../resources/migrations/create_media_table.php.stub' => $this->app->basePath().'/'.'database/migrations/'.$timestamp.'_create_media_table.php',
+                __DIR__.'/../resources/migrations/create_media_table.php.stub' => database_path('migrations/'.$timestamp.'_create_media_table.php'),
             ], 'migrations');
         }
     }


### PR DESCRIPTION
The current method always publishes the migrations to a hardcoded path (`<basePath>/database/migrations`). But in cases where the database path is different from the standard and default, the vendor publish command ends up always publishing this migrations file.

Using `database_path` method would publish to the right directory as per the config (default or custom path).