### PR TITLE
Add configurable headers when uploading media to a remote disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ return [
          */
         'domain' => 'https://xxxxxxx.s3.amazonaws.com',
     ],
+
+    'remote' => [
+        /**
+         * Any extra headers that should be included when uploading media to
+         * a remote disk. Even though supported headers may vary between
+         * different drivers, a sensible default has been provided.
+         *
+         * Supported by S3: CacheControl, Expires, StorageClass,
+         * ServerSideEncryption, Metadata, ACL, ContentEncoding
+         */
+        'extra_headers' => [
+            'CacheControl' => 'max-age=604800',
+        ]
+    ]
 ];
 ```
 

--- a/resources/config/laravel-medialibrary.php
+++ b/resources/config/laravel-medialibrary.php
@@ -42,4 +42,18 @@ return [
          */
         'domain' => 'https://xxxxxxx.s3.amazonaws.com',
     ],
+
+    'remote' => [
+        /**
+         * Any extra headers that should be included when uploading media to
+         * a remote disk. Even though supported headers may vary between
+         * different drivers, a sensible default has been provided.
+         *
+         * Supported by S3: CacheControl, Expires, StorageClass,
+         * ServerSideEncryption, Metadata, ACL, ContentEncoding
+         */
+        'extra_headers' => [
+            'CacheControl' => 'max-age=604800',
+        ]
+    ]
 ];

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -71,10 +71,14 @@ class Filesystem
                 ->disk($media->disk)
                 ->put($destination, fopen($file, 'r+'));
         } else {
+            $config = array_merge([
+                'ContentType' => File::getMimeType($file)
+            ], $this->config->get('laravel-medialibrary.remote.extra_headers'));
+
             $this->filesystem
                 ->disk($media->disk)
                 ->getDriver()
-                ->put($destination, fopen($file, 'r+'), ['ContentType' => File::getMimeType($file)]);
+                ->put($destination, fopen($file, 'r+'), $config);
         }
     }
 


### PR DESCRIPTION
This commit resolves issue #132 and allows the developer to specify any additional headers to include when uploading media to a remote disk.

The Spatie\MediaLibrary\Filesystem::copyToMediaLibrary method has been updated to merge any headers set in the updated laravel-medialibrary config file with the default 'Content-Type' header.

---

Your opinion regarding tests would be appreciated - I've tested this manually, but couldn't find automated tests for this class to contribute to. Would you say that this change is simple enough to accept as is?

Correct me if I'm wrong but the only way I can foresee to test this change would be through a mock object, that might end up in a brittle test.

Let me know!