### PR TITLE
Proposal: Add a route url generator for media files

### DIFF
--- a/src/UrlGenerator/RouteUrlGenerator.php
+++ b/src/UrlGenerator/RouteUrlGenerator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\MediaLibrary\UrlGenerator;
+
+use Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDetermined;
+use Spatie\MediaLibrary\UrlGenerator\LocalUrlGenerator;
+use Route;
+
+class RouteUrlGenerator extends LocalUrlGenerator
+{
+    /**
+     * Get the url for the profile of a media item.
+     *
+     * @return string
+     *
+     * @throws \Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDetermined
+     */
+    public function getUrl()
+    {
+        $disk = $this->media->disk;
+        $collection = $this->media->collection_name ?? false;
+
+        if ($collection && Route::has($disk.'.show.'.$collection)) {
+            return route($disk.'.show.'.$collection, [
+                $this->media->model, $this->media
+            ]);
+        }
+
+        if (Route::has($disk.'.show')) {
+            return route($disk.'.show', [
+                $this->media->model,
+                $this->media
+            ]);
+        }
+
+        throw new UrlCouldNotBeDetermined('The show media route for "'.$disk.'" has not been set');
+    }
+}


### PR DESCRIPTION
This allows this user to generate urls using a default media route (per disk), or an optional collection based route. This easily allows the user to set the media files into a storage path outside of the public web root and apply middleware to check authorization etc when accessing the media

If this is something you want to accept ill update the docs as well but some examples below

Example use:
update config and set 
`'custom_url_generator_class' =>  Spatie\MediaLibrary\UrlGenerator\RouteUrlGenerator::class,`

setup the default media route:
```
Route::get('files/{media}', [
        'as' => 'media.show', // media here is the disk name
        'uses' => 'SomeController@someMethod'
]);
```
and optionally set up collection routes, e.g (where "avatars" is the collection name)
```
Route::get('users/{user}/avatars/{media}', [
        'as' => 'media.avatars.show', // media here is the disk name
        'uses' => 'SomeController@someMethod'
]);
```