### PR TITLE
When deleting, also delete conversions in custom paths

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -119,7 +119,13 @@ class Filesystem
      */
     public function removeFiles(Media $media)
     {
-        $this->filesystem->disk($media->disk)->deleteDirectory($this->getMediaDirectory($media));
+        $mediaDirectory = $this->getMediaDirectory($media);
+        $conversionsDirectory = $this->getMediaDirectory($media, true);
+
+        $this->filesystem->disk($media->disk)->deleteDirectory($mediaDirectory);
+
+        if(substr($conversionsDirectory, 0, strlen($mediaDirectory)) != $mediaDirectory)
+            $this->filesystem->disk($media->disk)->deleteDirectory($conversionsDirectory);
     }
 
     /**


### PR DESCRIPTION
Now, when deleting, it is performed check whether the conversions are located in a subdirectory of the original files or outside. If they are in another place they are also deleted.