### PR TITLE
Support for Relation::morpMap()

### DIFF
--- a/src/Conversion/ConversionCollection.php
+++ b/src/Conversion/ConversionCollection.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\MediaLibrary\Conversion;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Exceptions\UnknownConversion;
 use Spatie\MediaLibrary\HasMedia\Interfaces\HasMediaConversions;
@@ -55,7 +57,7 @@ class ConversionCollection extends Collection
      */
     protected function addConversionsFromRelatedModel(Media $media)
     {
-        $modelName = $media->model_type;
+        $modelName = Arr::get(Relation::morphMap(), $media->model_type, $media->model_type);
 
         /*
          * To prevent an sql query create a new model instead


### PR DESCRIPTION
The media model uses polymorphic relationship. When morphMap is used the addConversionsFromRelatedModel method on the ConversionCollection fails. By specifying a morphMap you can use whatever type name you wish. 
```php
Relation::morphMap([
    'news' => \App\News::class
]);
```
When using this the model_type would be "news" instead of "App\News", hence the error. Getting the FQCN from the morphMap fixes that.

This guy explains morphMap: https://nicolaswidart.com/blog/laravel-52-morph-map