### PR TITLE
Set laravel glide dependency to ^3.0 and fix failing tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "illuminate/console": "^5.1",
     "illuminate/database": "^5.1",
     "illuminate/support": "^5.1",
-    "spatie/laravel-glide": "^2.2.4",
+    "spatie/laravel-glide": "^3.0",
     "spatie/pdf-to-image": "^1.0",
     "spatie/string": "^2.0"
 

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -103,9 +103,8 @@ class FileManipulator
         File::copy($copiedOriginalFile, $conversionTempFile);
 
         foreach ($conversion->getManipulations() as $manipulation) {
-            (new GlideImage())
-                ->load($conversionTempFile, $manipulation)
-                ->useAbsoluteSourceFilePath()
+            GlideImage::create($conversionTempFile)
+                ->modify($manipulation)
                 ->save($conversionTempFile);
         }
 


### PR DESCRIPTION
Hello again Freek! Another pull request for you, I'll explain:

*The Problem*
The 3.12.1 tag of this package updates composer.json to allow v3.0 of your laravel-glide package. You rectified this in the next patch, but Composer still prefers to use v3.12.1 in some instances because of the dependencies on laravel glide, and prevents forcing the use of a later version because of version inconsistencies:

```
After running $ composer require spatie/laravel-medialibrary:^3.13

Problem 1
    - Conclusion: don't install spatie/laravel-glide 2.2.6
    - Installation request for spatie/laravel-medialibrary ^3.13 -> satisfiable by spatie/laravel-medialibrary[3.13.3].
    - Conclusion: don't install symfony/http-foundation v3.0.1|install spatie/laravel-glide 2.2.6
    - Conclusion: remove symfony/http-foundation v3.0.1|install spatie/laravel-glide 2.2.6
    - spatie/laravel-medialibrary 3.13.3 requires spatie/laravel-glide ^2.2.4 -> satisfiable by spatie/laravel-glide[2.2.4, 2.2.5, 2.2.6, 2.2.7, 2.2.8, 2.x-dev].
    - spatie/laravel-glide 2.2.4 requires league/glide 0.3.* -> satisfiable by league/glide[0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.3.5].
...
```

*Solving by fixing composer dependencies*
While I thought this would be simple to do by following composer's error log, I never managed to require higher than v13.12.1 in conjunction with Laravel 5.2.

If the problem should simple be solved by Composer, then this pull request might be redundant.

*Setting Laravel Glide Dependency to ^3.0*
The PR that allowed the new version of Laravel Glide did not take into consideration the BC between v2 and v3, which caused problems.

My PR forces this package to require Laravel Glide ^3.0 and takes into consideration the changes in the Laravel Glide API.

The failing tests caused by requiring Laravel Glide ^3.0 have been made to pass by fixing the code in the Spatie\MediaLibrary\FileManipulator class. I've tested this through phpunit, and in a real project using both a local filesystem, and S3 filesystem - I was able to successfully upload images with multiple conversions in both cases.

Let me know your thoughts on this one.

Thanks for taking the time to read this.