### PR TITLE
Delete preserving media

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -299,4 +299,14 @@ trait HasMediaTrait
 
         return true;
     }
+
+    /**
+     * Delete the model, but preserve all the associated media.
+     *
+     * @return bool
+     */
+    public function deletePreservingFiles()
+    {
+        return parent::delete();
+    }
 }

--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -305,7 +305,7 @@ trait HasMediaTrait
      *
      * @return bool
      */
-    public function deletePreservingFiles()
+    public function deletePreservingMedia()
     {
         return parent::delete();
     }

--- a/tests/HasMediaConversionsTrait/DeleteMediaTest.php
+++ b/tests/HasMediaConversionsTrait/DeleteMediaTest.php
@@ -97,7 +97,7 @@ class DeleteMediaTest extends TestCase
             $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
         });
 
-        $this->testModelWithoutMediaConversions->deletePreservingFiles();
+        $this->testModelWithoutMediaConversions->deletePreservingMedia();
 
         $ids->map(function ($id) {
             $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));

--- a/tests/HasMediaConversionsTrait/DeleteMediaTest.php
+++ b/tests/HasMediaConversionsTrait/DeleteMediaTest.php
@@ -85,4 +85,23 @@ class DeleteMediaTest extends TestCase
             $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
         });
     }
+
+    /**
+     * @test
+     */
+    public function it_will_not_remove_the_files_when_deleting_a_subject_and_preserving_media()
+    {
+        $ids = $this->testModelWithoutMediaConversions->getMedia('images')->lists('id');
+
+        $ids->map(function ($id) {
+            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        });
+
+        $this->testModelWithoutMediaConversions->deletePreservingFiles();
+
+        $ids->map(function ($id) {
+            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        });
+    }
+
 }

--- a/tests/HasMediaTrait/DeleteMediaTest.php
+++ b/tests/HasMediaTrait/DeleteMediaTest.php
@@ -87,7 +87,7 @@ class DeleteMediaTest extends TestCase
             $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
         });
 
-        $this->testModel->deletePreservingFiles();
+        $this->testModel->deletePreservingMedia();
 
         $ids->map(function ($id) {
             $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));

--- a/tests/HasMediaTrait/DeleteMediaTest.php
+++ b/tests/HasMediaTrait/DeleteMediaTest.php
@@ -74,4 +74,23 @@ class DeleteMediaTest extends TestCase
             $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
         });
     }
+
+
+    /**
+     * @test
+     */
+    public function it_will_not_remove_the_files_when_deleting_a_subject_and_preserving_media()
+    {
+        $ids = $this->testModel->getMedia('images')->lists('id');
+
+        $ids->map(function ($id) {
+            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        });
+
+        $this->testModel->deletePreservingFiles();
+
+        $ids->map(function ($id) {
+            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        });
+    }
 }


### PR DESCRIPTION
Adds a `deletePreservingMedia()` method to the `HasMediaTrait`, so that deleting a model doesn't necessarily mean that associate media are deleted as well (see #152).