### PR TITLE
Add mediaIds option to regenerate command

### DIFF
--- a/src/Commands/RegenerateCommand.php
+++ b/src/Commands/RegenerateCommand.php
@@ -14,7 +14,7 @@ class RegenerateCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'medialibrary:regenerate {modelType?}';
+    protected $signature = 'medialibrary:regenerate {modelType?} {--mediaIds=*}';
 
     /**
      * The console command description.
@@ -33,6 +33,11 @@ class RegenerateCommand extends Command
      */
     protected $fileManipulator;
 
+    /**
+     * RegenerateCommand constructor.
+     * @param MediaRepository $mediaRepository
+     * @param FileManipulator $fileManipulator
+     */
     public function __construct(MediaRepository $mediaRepository, FileManipulator $fileManipulator)
     {
         parent::__construct();
@@ -41,6 +46,9 @@ class RegenerateCommand extends Command
         $this->fileManipulator = $fileManipulator;
     }
 
+    /**
+     * Handle regeneration
+     */
     public function handle()
     {
         $this->getMediaToBeRegenerated()->map(function (Media $media) {
@@ -51,12 +59,22 @@ class RegenerateCommand extends Command
         $this->info('All done!');
     }
 
+    /**
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getMediaToBeRegenerated()
     {
-        if ($this->argument('modelType') == '') {
+        $modelType = $this->argument('modelType');
+        $mediaIds = $this->option('mediaIds');
+
+        if ($modelType == '' && !$mediaIds) {
             return $this->mediaRepository->all();
         }
 
-        return $this->mediaRepository->getByModelType($this->argument('modelType'));
+        if ($mediaIds) {
+            return $this->mediaRepository->getByIds($mediaIds);
+        }
+
+        return $this->mediaRepository->getByModelType($modelType);
     }
 }

--- a/src/MediaRepository.php
+++ b/src/MediaRepository.php
@@ -131,6 +131,18 @@ class MediaRepository
     }
 
     /**
+     * Get media by ids
+     *
+     * @param $mediaIds
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getByIds($mediaIds)
+    {
+        return $this->model->whereIn('id', $mediaIds)->get();
+    }
+
+    /**
      * Get all media for the given type and collection name.
      *
      * @param string $modelType

--- a/tests/Commands/RegenerateCommandTest.php
+++ b/tests/Commands/RegenerateCommandTest.php
@@ -24,4 +24,33 @@ class RegenerateCommandTest extends TestCase
 
         $this->assertFileExists($derivedImage);
     }
+
+    /**
+     * @test
+     */
+    public function it_can_regenerate_files_by_media_ids()
+    {
+        $media = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->preservingOriginal()
+            ->toCollection('images');
+
+        $media2 = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->toCollection('images');
+
+        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/thumb.jpg");
+        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/thumb.jpg");
+
+        unlink($derivedImage);
+        unlink($derivedImage2);
+
+        $this->assertFileNotExists($derivedImage);
+        $this->assertFileNotExists($derivedImage2);
+
+        Artisan::call('medialibrary:regenerate', ['--mediaIds' => [2]]);
+
+        $this->assertFileNotExists($derivedImage);
+        $this->assertFileExists($derivedImage2);
+    }
 }


### PR DESCRIPTION
A added the ability to pass media ids array to `medialibrary:regenerate` command. When this can be needed? Let's say we uploaded our images and added them to medialibrary, and then we wanted to add them to the queue for compressing/processing with some remote API later. We compress only main image, and after that we need ability to regenerate conversions for our new replaced compressed/processed image/images. For now we can only regenerate all media images or by the model type.