### PR TITLE
Add ability to subscribe for the model deletion

### DIFF
--- a/src/Listeners/MediaListener.php
+++ b/src/Listeners/MediaListener.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\MediaLibrary\Listeners;
+
+use Spatie\MediaLibrary\HasMedia\Interfaces\HasMediaConversions;
+use Spatie\MediaLibrary\Media;
+
+class MediaListener
+{
+    /**
+     * Handle entity deleting events.
+     * @param $entity
+     */
+    public function onEntityDeleting($entity)
+    {
+        if ($entity instanceof HasMediaConversions) {
+            $entity->media()->get()->map(function (Media $media) {
+                $media->delete();
+            });
+        }
+    }
+
+    /**
+     * Register the listeners for the subscriber.
+     *
+     * @param  \Illuminate\Events\Dispatcher $events
+     */
+    public function subscribe($events)
+    {
+        $events->listen(
+            'eloquent.deleting*',
+            'Spatie\MediaLibrary\Listeners\MediaListener@onEntityDeleting'
+        );
+    }
+}


### PR DESCRIPTION
Hello, guys! I've added some functionality in my application and wanted to share it.

This will allow to easily add one line of code to `$subscribe` array in `EventServiceProviders` and perform cascade media deletion in case of owner model being deleted. More details [about Event Subscribers](https://laravel.com/docs/5.2/events#event-subscribers) could be found in documentation.

Code will look like this:

**app/Providers/EventServiceProvider.php**
```php
<?php

namespace App\Providers;

class EventServiceProvider extends ServiceProvider
{
    protected $subscribe = [
        \Spatie\MediaLibrary\Listeners\MediaListener::class,
    ];
}
```

This solution is good because it's optional and could be attached only if needed.