### PR TITLE
Added support of morphMap method

### DIFF
--- a/src/Conversion/ConversionCollection.php
+++ b/src/Conversion/ConversionCollection.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\MediaLibrary\Conversion;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\MediaLibrary\Exceptions\UnknownConversion;
 use Spatie\MediaLibrary\HasMedia\Interfaces\HasMediaConversions;
 use Spatie\MediaLibrary\Media;
@@ -55,7 +57,7 @@ class ConversionCollection extends Collection
      */
     protected function addConversionsFromRelatedModel(Media $media)
     {
-        $modelName = $media->model_type;
+        $modelName = Arr::get(Relation::morphMap(), $media->model_type, $media->model_type);
 
         /*
          * To prevent an sql query create a new model instead

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -229,4 +229,16 @@ class IntegrationTest extends TestCase
 
         $this->assertEquals('testName', $media->name);
     }
+
+    /**
+     * @test
+     */
+    public function it_can_add_file_to_model_with_morph_map()
+    {
+        $media = $this->testModelWithMorphMap
+            ->addMedia($this->getTestJpg())
+            ->toMediaLibrary();
+
+        $this->assertEquals($this->testModelWithMorphMap->getMorphClass(), $media->model_type);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Test;
 
 use File;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Schema\Blueprint;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -23,6 +24,11 @@ abstract class TestCase extends Orchestra
      */
     protected $testModelWithoutMediaConversions;
 
+    /**
+     * @var \Spatie\MediaLibrary\Test\TestModelWithMorphMap
+     */
+    protected $testModelWithMorphMap;
+
     public function setUp()
     {
         parent::setUp();
@@ -34,6 +40,7 @@ abstract class TestCase extends Orchestra
         $this->testModel = TestModel::first();
         $this->testModelWithConversion = TestModelWithConversion::first();
         $this->testModelWithoutMediaConversions = TestModelWithoutMediaConversions::first();
+        $this->testModelWithMorphMap = TestModelWithMorphMap::first();
     }
 
     /**
@@ -77,6 +84,8 @@ abstract class TestCase extends Orchestra
         });
 
         $app['config']->set('app.key', '6rE9Nz59bGRbeMATftriyQjrpF7DcOQm');
+
+        $this->setUpMorphMap();
     }
 
     /**
@@ -130,5 +139,12 @@ abstract class TestCase extends Orchestra
     public function getTestJpg()
     {
         return $this->getTestFilesDirectory('test.jpg');
+    }
+
+    private function setUpMorphMap()
+    {
+        Relation::morphMap([
+            'test-model-with-morph-map' => TestModelWithMorphMap::class,
+        ]);
     }
 }

--- a/tests/TestModelWithMorphMap.php
+++ b/tests/TestModelWithMorphMap.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test;
+
+class TestModelWithMorphMap extends TestModel
+{
+
+}


### PR DESCRIPTION
@freekmurze Sorry for resurrecting this question again, but I really want to solve an issue with `morphMap` described in PR #70 and stop forking and maintaining this package in my personal namespace.

Because `morphMap` was introduced only in Laravel 5.1.16 we should use some conditionals to keep  maintaining previous versions and don't limit usage of package for all newer Laravel versions too. Our luck PHP has `method_exists(Relation::class, 'morphMap')` that will do the job!