### PR TITLE
Added an ability to get full url of media file

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -52,13 +52,25 @@ class Media extends Model
      */
     public function getUrl($conversionName = '')
     {
-        $urlGenerator = UrlGeneratorFactory::createForMedia($this);
-
-        if ($conversionName != '') {
-            $urlGenerator->setConversion(ConversionCollectionFactory::createForMedia($this)->getByName($conversionName));
-        }
+        $urlGenerator = $this->getUrlGenerator($conversionName);
 
         return $urlGenerator->getUrl();
+    }
+
+    /**
+     * Get the original full Url to a media-file.
+     *
+     * @param string $conversionName
+     *
+     * @return string
+     *
+     * @throws \Spatie\MediaLibrary\Exceptions\UnknownConversion
+     */
+    public function getFullUrl($conversionName = '')
+    {
+        $urlGenerator = $this->getUrlGenerator($conversionName);
+
+        return $urlGenerator->getFullUrl();
     }
 
     /**
@@ -72,11 +84,7 @@ class Media extends Model
      */
     public function getPath($conversionName = '')
     {
-        $urlGenerator = UrlGeneratorFactory::createForMedia($this);
-
-        if ($conversionName != '') {
-            $urlGenerator->setConversion(ConversionCollectionFactory::createForMedia($this)->getByName($conversionName));
-        }
+        $urlGenerator = $this->getUrlGenerator($conversionName);
 
         return $urlGenerator->getPath();
     }
@@ -192,5 +200,25 @@ class Media extends Model
     public function setCustomProperty($name, $value)
     {
         $this->custom_properties = array_merge($this->custom_properties, [$name => $value]);
+    }
+
+    /**
+     * Get the UrlGenerator instance.
+     *
+     * @param $conversionName
+     *
+     * @return \Spatie\MediaLibrary\UrlGenerator\UrlGenerator
+     *
+     * @throws \Spatie\MediaLibrary\Exceptions\UnknownConversion
+     */
+    protected function getUrlGenerator($conversionName)
+    {
+        $urlGenerator = UrlGeneratorFactory::createForMedia($this);
+
+        if ($conversionName != '') {
+            $urlGenerator->setConversion(ConversionCollectionFactory::createForMedia($this)->getByName($conversionName));
+        }
+
+        return $urlGenerator;
     }
 }

--- a/src/UrlGenerator/BaseUrlGenerator.php
+++ b/src/UrlGenerator/BaseUrlGenerator.php
@@ -73,6 +73,18 @@ abstract class BaseUrlGenerator
     }
 
     /**
+     * Get the full url for the profile of a media item.
+     *
+     * @return string
+     *
+     * @throws \Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDetermined
+     */
+    public function getFullUrl()
+    {
+        return $this->getUrl();
+    }
+
+    /**
      * Get the path to the requested file relative to the root of the media directory.
      *
      * @return string

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -25,6 +25,18 @@ class LocalUrlGenerator extends BaseUrlGenerator implements UrlGenerator
     }
 
     /**
+     * Get the full url for the profile of a media item.
+     *
+     * @return string
+     *
+     * @throws \Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDetermined
+     */
+    public function getFullUrl()
+    {
+        return url($this->getUrl());
+    }
+
+    /**
      * Get the path for the profile of a media item.
      *
      * @return string

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -9,7 +9,7 @@ class S3UrlGenerator extends BaseUrlGenerator implements UrlGenerator
      *
      * @return string
      *
-     * @throws \Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDeterminedException
+     * @throws \Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDetermined
      */
     public function getUrl()
     {

--- a/src/UrlGenerator/UrlGenerator.php
+++ b/src/UrlGenerator/UrlGenerator.php
@@ -11,9 +11,18 @@ interface UrlGenerator
      *
      * @return string
      *
-     * @throws UrlCouldNotBeDeterminedException
+     * @throws \Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDetermined
      */
     public function getUrl();
+
+    /**
+     * Get the full url for the profile of a media item.
+     *
+     * @return string
+     *
+     * @throws \Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDetermined
+     */
+    public function getFullUrl();
 
     /**
      * Set the path generator class.

--- a/tests/Media/GetUrlTest.php
+++ b/tests/Media/GetUrlTest.php
@@ -31,6 +31,16 @@ class GetUrlTest extends TestCase
     /**
      * @test
      */
+    public function it_cat_get_a_full_url_of_an_original_item()
+    {
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+
+        $this->assertEquals($media->getFullUrl(), "{$this->baseUrl}/media/{$media->id}/test.jpg");
+    }
+    
+    /**
+     * @test
+     */
     public function it_returns_an_exception_when_getting_an_url_for_an_unknown_conversion()
     {
         $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();


### PR DESCRIPTION
Today I were needed to get fully qualified urls to media files, but haven't found such method in your library. So I've added it and made couple of optimizations in code.

* Added an ability to get full url of media file.
* Unit test for this case is written.
* Extracted `getUrlGenerator` method in Media model to keep code DRY.
* Fixed docblocks with `\Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDetermined` exception.