### PR TITLE
Feature/remove individual media event

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary\HasMedia;
 use Illuminate\Contracts\Events\Dispatcher;
 use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\Events\CollectionHasBeenCleared;
+use Spatie\MediaLibrary\Events\IndividualMediaRemoved;
 use Spatie\MediaLibrary\Exceptions\MediaDoesNotBelongToModel;
 use Spatie\MediaLibrary\Exceptions\MediaIsNotPartOfCollection;
 use Spatie\MediaLibrary\Exceptions\UrlCouldNotBeOpened;
@@ -250,7 +251,10 @@ trait HasMediaTrait
     {
         $this->getMedia($collectionName)->map(function ($media) {
             app(Filesystem::class)->removeFiles($media);
+
             $media->delete();
+
+            app(Dispatcher::class)->fire(new IndividualMediaRemoved($media));
         });
 
         app(Dispatcher::class)->fire(new CollectionHasBeenCleared($this, $collectionName));

--- a/tests/Events/EventTest.php
+++ b/tests/Events/EventTest.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary\Test\Events;
 use Event;
 use Spatie\MediaLibrary\Events\CollectionHasBeenCleared;
 use Spatie\MediaLibrary\Events\ConversionHasBeenCompleted;
+use Spatie\MediaLibrary\Events\IndividualMediaRemoved;
 use Spatie\MediaLibrary\Events\MediaHasBeenAdded;
 use Spatie\MediaLibrary\Test\TestCase;
 
@@ -50,6 +51,21 @@ class EventTest extends TestCase
             ->toMediaLibrary('images');
 
         $this->expectsEvent(CollectionHasBeenCleared::class);
+
+        $this->testModel->clearMediaCollection('images');
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_fire_the_individual_media_cleared_event()
+    {
+        $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaLibrary('images');
+
+        $this->expectsEvent(IndividualMediaRemoved::class);
 
         $this->testModel->clearMediaCollection('images');
     }


### PR DESCRIPTION
This pull request enables developers to hook into an extra event, when an individual (single) media is deleted. For example, if you use an third party system that has something to do with the Media model, developers can now hook in to is.

Basically, it's a new `IndividualMediaRemoved` event. 

@freekmurze If this could be merged (and if it's a good idea), I will convert this to use at master branch.