### PR TITLE
Conversions return src format extensions #225

### DIFF
--- a/src/Conversion/Conversion.php
+++ b/src/Conversion/Conversion.php
@@ -155,7 +155,14 @@ class Conversion
     {
         return array_reduce($this->getManipulations(), function ($carry, array $manipulation) {
 
-            return isset($manipulation['fm']) ? $manipulation['fm'] : $carry;
+            if (isset($manipulation['fm'])) {
+                $keep_formats = ['png', 'gif'];
+
+                return ($manipulation['fm'] === 'src' && in_array($carry, $keep_formats)) ?
+                    $carry : $manipulation['fm'];
+            }
+
+            return $carry;
 
         }, $originalFileExtension);
     }


### PR DESCRIPTION
getResultExtension checks if `'fm' => 'src'` has been defined, and if the image formats are png or gif to return the source's extension.