### PR TITLE
Easily allow pseudo softdelete configuration from the model

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -28,7 +28,7 @@ trait HasMediaTrait
     public static function bootHasMediaTrait()
     {
         static::deleted(function ($entity) {
-            if (!$entity->deletePreservingMedia) {
+            if (!$entity->getDeletePreservingMedia()) {
                 $entity->media()->get()->map(function (Media $media) {
                     $media->delete();
                 });
@@ -298,13 +298,33 @@ trait HasMediaTrait
     }
 
     /**
+     * Return the value of deletePreservingAttribute.
+     *
+     * @return bool
+     */
+    public function getDeletePreservingMedia()
+    {
+        return $this->deletePreservingMedia;
+    }
+
+    /**
+     * Set the value of deletePreservingAttribute.
+     *
+     * @param bool $value
+     */
+    public function setDeletePreservingMedia($value)
+    {
+        $this->deletePreservingMedia = $value;
+    }
+
+    /**
      * Delete the model, but preserve all the associated media.
      *
      * @return bool
      */
     public function deletePreservingMedia()
     {
-        $this->deletePreservingMedia = true;
+        $this->setDeletePreservingMedia(true);
 
         return $this->delete();
     }


### PR DESCRIPTION
Actually, because you can't override a trait attribute, you need to specify that you want to delete the model without deleting the associated media using the `deletePreservingMedia()` method.

The solution I offer allows you specify it directly in your model, by overriding the `getDeletePreservingMedia()` method. This way, you can use the basic `delete()` method on your model, and still preserve your media.