### PR TITLE
Lumen support

### DIFF
--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\MediaLibrary;
 
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Support\Facades\File;
 use Spatie\Glide\GlideImage;
 use Spatie\MediaLibrary\Conversion\Conversion;
@@ -14,7 +13,6 @@ use Spatie\PdfToImage\Pdf;
 
 class FileManipulator
 {
-    use DispatchesJobs;
 
     /**
      * Create all derived files for the given media.
@@ -133,6 +131,6 @@ class FileManipulator
             $job->onQueue($customQueue);
         }
 
-        $this->dispatch($job);
+        app('Illuminate\Contracts\Bus\Dispatcher')->dispatch($job);
     }
 }

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Spatie\MediaLibrary;
 
 use Illuminate\Support\ServiceProvider;
+use Laravel\Lumen\Application as LumenApplication;
+use Illuminate\Foundation\Application as LaravelApplication;
 use Spatie\MediaLibrary\Commands\ClearCommand;
 use Spatie\MediaLibrary\Commands\RegenerateCommand;
 
@@ -20,22 +22,25 @@ class MediaLibraryServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->app instanceof LaravelApplication) {
+            $this->publishes([
+                __DIR__.'/../config/laravel-medialibrary.php' => config_path('laravel-medialibrary.php'),
+            ], 'config');
+
+            if (!class_exists('CreateMediaTable')) {
+                // Publish the migration
+                $timestamp = date('Y_m_d_His', time());
+
+                $this->publishes([
+                    __DIR__.'/../database/migrations/create_media_table.php.stub' => database_path('migrations/'.$timestamp.'_create_media_table.php'),
+                  ], 'migrations');
+            }
+        } elseif ($this->app instanceof LumenApplication) {
+            $this->app->configure('laravel-medialibrary');
+        }
+
         $mediaClass = config('laravel-medialibrary.media_model');
         $mediaClass::observe(new MediaObserver());
-
-        $this->publishes([
-            __DIR__.'/../config/laravel-medialibrary.php' => config_path('laravel-medialibrary.php'),
-        ], 'config');
-
-        if (!class_exists('CreateMediaTable')) {
-
-            // Publish the migration
-            $timestamp = date('Y_m_d_His', time());
-
-            $this->publishes([
-                __DIR__.'/../database/migrations/create_media_table.php.stub' => database_path('migrations/'.$timestamp.'_create_media_table.php'),
-            ], 'migrations');
-        }
     }
 
     /**


### PR DESCRIPTION
Hi there,

I've added support for Lumen 5.2. There wasn't too much requiring change, mainly figuring out how to get everything to load and configured correctly.

Key changes are removal of `Illuminate\Foundation\Bus\DispatchesJobs` trait from the FileManipulator class as this isn't present in Lumen. I have instead dispatched the job via the app helper, which is compatible with both Laravel and Lumen.

I have also updated the `MediaLibraryServiceProvider::boot()` method with a check to establish whether if it's running under Laravel or Lumen and configure accordingly.

Since there are very few functional changes to the package, I have not added any meaningful tests. However, it would be interesting to see how the test suite could be updated to run with `laravel/lumen-framework` as a dependency after running with `laravel/framework` mandated by the `orchestra\testbench` package.

Many thanks. :)