### PR TITLE
Resolves type hinting issue in Media.php

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -63,7 +63,7 @@ trait HasMediaTrait
      *
      * @return \Spatie\MediaLibrary\FileAdder\FileAdder
      */
-    public function addMediaFromRequest(string $key)
+    public function addMediaFromRequest($key)
     {
         return app(FileAdderFactory::class)->createFromRequest($this, $key);
     }
@@ -77,7 +77,7 @@ trait HasMediaTrait
      *
      * @throws \Spatie\MediaLibrary\Exceptions\FileCannotBeAdded
      */
-    public function addMediaFromUrl(string $url)
+    public function addMediaFromUrl($url)
     {
         if (!$stream = @fopen($url, 'r')) {
             throw FileCannotBeAdded::unreachableUrl($url);
@@ -109,7 +109,7 @@ trait HasMediaTrait
     /*
      * Determine if there is media in the given collection.
      */
-    public function hasMedia(string $collectionName = '') : bool
+    public function hasMedia($collectionName = '') : bool
     {
         return count($this->getMedia($collectionName)) ? true : false;
     }
@@ -122,7 +122,7 @@ trait HasMediaTrait
      *
      * @return \Illuminate\Support\Collection
      */
-    public function getMedia(string $collectionName = '', $filters = []) : Collection
+    public function getMedia($collectionName = '', $filters = []) : Collection
     {
         return app(MediaRepository::class)->getCollection($this, $collectionName, $filters);
     }
@@ -135,7 +135,7 @@ trait HasMediaTrait
      *
      * @return Media|null
      */
-    public function getFirstMedia(string $collectionName = 'default', array $filters = [])
+    public function getFirstMedia($collectionName = 'default', array $filters = [])
     {
         $media = $this->getMedia($collectionName, $filters);
 
@@ -147,7 +147,7 @@ trait HasMediaTrait
      * for first media for the given collectionName.
      * If no profile is given, return the source's url.
      */
-    public function getFirstMediaUrl(string $collectionName = 'default', string $conversionName = '') : string
+    public function getFirstMediaUrl($collectionName = 'default', $conversionName = '') : string
     {
         $media = $this->getFirstMedia($collectionName);
 
@@ -163,7 +163,7 @@ trait HasMediaTrait
      * for first media for the given collectionName.
      * If no profile is given, return the source's url.
      */
-    public function getFirstMediaPath(string $collectionName = 'default', string $conversionName = '') : string
+    public function getFirstMediaPath($collectionName = 'default', $conversionName = '') : string
     {
         $media = $this->getFirstMedia($collectionName);
 
@@ -184,7 +184,7 @@ trait HasMediaTrait
      *
      * @throws \Spatie\Medialibrary\Exceptions\MediaCannotBeUpdated
      */
-    public function updateMedia(array $newMediaArray, string $collectionName = 'default') : array
+    public function updateMedia(array $newMediaArray, $collectionName = 'default') : array
     {
         $this->removeMediaItemsNotPresentInArray($newMediaArray, $collectionName);
 
@@ -221,7 +221,7 @@ trait HasMediaTrait
      * @param array  $newMediaArray
      * @param string $collectionName
      */
-    protected function removeMediaItemsNotPresentInArray(array $newMediaArray, string $collectionName = 'default')
+    protected function removeMediaItemsNotPresentInArray(array $newMediaArray, $collectionName = 'default')
     {
         $this->getMedia($collectionName, [])
             ->filter(function (Media $currentMediaItem) use ($newMediaArray) {
@@ -239,7 +239,7 @@ trait HasMediaTrait
      *
      * @return $this
      */
-    public function clearMediaCollection(string $collectionName = 'default')
+    public function clearMediaCollection($collectionName = 'default')
     {
         $this->getMedia($collectionName)->map(function (Media $media) {
             app(Filesystem::class)->removeFiles($media);
@@ -277,7 +277,7 @@ trait HasMediaTrait
     /*
      * Add a conversion.
      */
-    public function addMediaConversion(string $name) : Conversion
+    public function addMediaConversion($name) : Conversion
     {
         $conversion = Conversion::create($name);
 

--- a/src/HasMedia/Interfaces/HasMedia.php
+++ b/src/HasMedia/Interfaces/HasMedia.php
@@ -36,7 +36,7 @@ interface HasMedia
      *
      * @return bool
      */
-    public function hasMedia(string $collectionMedia = '') : bool;
+    public function hasMedia($collectionMedia = '') : bool;
 
     /**
      * Get media collection by its collectionName.
@@ -46,14 +46,14 @@ interface HasMedia
      *
      * @return \Spatie\MediaLibrary\Media
      */
-    public function getMedia(string $collectionName = 'default', $filters = []);
+    public function getMedia($collectionName = 'default', $filters = []);
 
     /**
      * Remove all media in the given collection.
      *
      * @param string $collectionName
      */
-    public function clearMediaCollection(string $collectionName = 'default');
+    public function clearMediaCollection($collectionName = 'default');
 
     /**
      * Determines if the media files should be preserved when the media object gets deleted.

--- a/src/Media.php
+++ b/src/Media.php
@@ -47,7 +47,7 @@ class Media extends Model
      *
      * @throws \Spatie\MediaLibrary\Exceptions\InvalidConversion
      */
-    public function getUrl(string $conversionName = '') : string
+    public function getUrl($conversionName = '') : string
     {
         $urlGenerator = UrlGeneratorFactory::createForMedia($this);
 
@@ -67,7 +67,7 @@ class Media extends Model
      *
      * @throws \Spatie\MediaLibrary\Exceptions\InvalidConversion
      */
-    public function getPath(string $conversionName = '') : string
+    public function getPath($conversionName = '') : string
     {
         $urlGenerator = UrlGeneratorFactory::createForMedia($this);
 


### PR DESCRIPTION
Previously generating the following errors:
Fatal error: Default value for parameter conversionName with a class type hint can only be NULL in [project root]/vendor/spatie/laravel-medialibrary/src/Media.php on line 50
Fatal error: Default value for parameter conversionName with a class type hint can only be NULL in [project root]/vendor/spatie/laravel-medialibrary/src/Media.php on line 70

Removed the old 'string' type hinting from each method definition