### PR TITLE
Add clean command to delete files created for removed conversions

### DIFF
--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Spatie\MediaLibrary\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Contracts\Filesystem\Factory;
+use Illuminate\Database\Eloquent\Collection;
+use Spatie\MediaLibrary\Conversion\ConversionCollection;
+use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded;
+use Spatie\MediaLibrary\FileManipulator;
+use Spatie\MediaLibrary\Media;
+use Spatie\MediaLibrary\MediaRepository;
+use Spatie\MediaLibrary\PathGenerator\BasePathGenerator;
+
+class CleanCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'medialibrary:clean {modelType?} {collectionName?} {disk?} {--dry-run}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clean deprecated conversions and files without related model.';
+
+    /**
+     * @var \Spatie\MediaLibrary\MediaRepository
+     */
+    protected $mediaRepository;
+
+    /**
+     * @var \Spatie\MediaLibrary\FileManipulator
+     */
+    protected $fileManipulator;
+
+    /**
+     * @var Factory
+     */
+    private $fileSystem;
+
+    /**
+     * @var BasePathGenerator
+     */
+    private $basePathGenerator;
+
+    /**
+     * @var bool
+     */
+    protected $dry = false;
+
+    /**
+     * @param MediaRepository   $mediaRepository
+     * @param FileManipulator   $fileManipulator
+     * @param Factory           $fileSystem
+     * @param BasePathGenerator $basePathGenerator
+     */
+    public function __construct(
+        MediaRepository $mediaRepository,
+        FileManipulator $fileManipulator,
+        Factory $fileSystem,
+        BasePathGenerator $basePathGenerator
+    ) {
+        parent::__construct();
+        $this->mediaRepository = $mediaRepository;
+        $this->fileManipulator = $fileManipulator;
+        $this->fileSystem = $fileSystem;
+        $this->basePathGenerator = $basePathGenerator;
+    }
+
+    /**
+     * Handle command.
+     */
+    public function handle()
+    {
+        if (!$this->confirmToProceed()) {
+            return;
+        }
+
+        $this->dry = $this->option('dry-run');
+
+        // Clean deprecated conversions
+        $this->getMediaItems()->each(function (Media $media) {
+            $this->cleanDeprecatedConversions($media);
+        });
+
+        // Clean files without related models
+        $this->cleanOrphanFiles();
+
+        $this->info('All done!');
+    }
+
+    public function getMediaItems() : Collection
+    {
+        $modelType = $this->argument('modelType');
+        $collectionName = $this->argument('collectionName');
+
+        if (!is_null($modelType) && !is_null($collectionName)) {
+            return $this->mediaRepository->getByModelTypeAndCollectionName(
+                $modelType,
+                $collectionName
+            );
+        }
+
+        if (!is_null($modelType)) {
+            return $this->mediaRepository->getByModelType($modelType);
+        }
+
+        if (!is_null($collectionName)) {
+            return $this->mediaRepository->getByCollectionName($collectionName);
+        }
+
+        return $this->mediaRepository->all();
+    }
+
+    /**
+     * @param Media $media
+     */
+    private function cleanDeprecatedConversions(Media $media)
+    {
+        // Get conversion directory
+        $path = $this->basePathGenerator->getPathForConversions($media);
+        $files = $this->fileSystem->disk($media->disk)->files($path);
+
+        // Get the list of currently defined conversions
+        $conversions = ConversionCollection::createForMedia($media)->getConversionsFiles($media->collection_name);
+
+        // Verify that each file on disk is defined in a conversion, else we delete the file
+        foreach ($files as $file) {
+            if (!$conversions->contains(basename($file))) {
+                if (!$this->dry) {
+                    $this->fileSystem->disk($media->disk)->delete($file);
+                }
+
+                $this->info("Deprecated conversion file $file " . ($this->dry ? '' : 'has been removed'));
+            }
+        }
+    }
+
+    private function cleanOrphanFiles()
+    {
+        $diskName = $this->argument('disk') ?: config('laravel-medialibrary.defaultFilesystem');
+
+        if (is_null(config("filesystems.disks.{$diskName}"))) {
+            throw FileCannotBeAdded::diskDoesNotExist($diskName);
+        }
+
+        $medias = $this->mediaRepository->all()->pluck('id');
+        $directories = new Collection($this->fileSystem->disk($diskName)->directories());
+
+        // Ignore all directories related to a media row and non numeric directories name
+        $directories = $directories->filter(function ($directory) use ($medias) {
+            return is_numeric($directory) ? !$medias->contains((int)$directory) : false;
+        });
+
+        // Delete all directories with bo media row
+        foreach ($directories as $directory) {
+            if (!$this->dry) {
+                $this->fileSystem->disk($diskName)->deleteDirectory($directory);
+            }
+
+            $this->info("Orphan media file $directory " . ($this->dry ? '' : 'has been removed'));
+        }
+    }
+}

--- a/src/Conversion/ConversionCollection.php
+++ b/src/Conversion/ConversionCollection.php
@@ -145,4 +145,14 @@ class ConversionCollection extends Collection
             return !$conversion->shouldBeQueued();
         });
     }
+
+    /**
+     * Return the list of conversion files.
+     */
+    public function getConversionsFiles(string $collectionName = '') : ConversionCollection
+    {
+        return $this->getConversions($collectionName)->map(function (Conversion $conversion) {
+            return $conversion->getName() . '.' . $conversion->getResultExtension();
+        });
+    }
 }

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
 use Illuminate\Foundation\Application as LaravelApplication;
+use Spatie\MediaLibrary\Commands\CleanCommand;
 use Spatie\MediaLibrary\Commands\ClearCommand;
 use Spatie\MediaLibrary\Commands\RegenerateCommand;
 
@@ -54,10 +55,12 @@ class MediaLibraryServiceProvider extends ServiceProvider
 
         $this->app->bind('command.medialibrary:regenerate', RegenerateCommand::class);
         $this->app->bind('command.medialibrary:clear', ClearCommand::class);
+        $this->app->bind('command.medialibrary:clean', CleanCommand::class);
 
         $this->commands([
             'command.medialibrary:regenerate',
             'command.medialibrary:clear',
+            'command.medialibrary:clean',
         ]);
     }
 }

--- a/tests/Commands/CleanCommandTest.php
+++ b/tests/Commands/CleanCommandTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test\Conversion;
+
+use Illuminate\Support\Facades\Artisan;
+use Spatie\MediaLibrary\Test\TestCase;
+use Spatie\MediaLibrary\Test\TestModel;
+use Spatie\MediaLibrary\Test\TestModelWithConversion;
+
+class CleanCommandTest extends TestCase
+{
+    /** @var array */
+    protected $media;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->media['model1']['collection1'] = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toCollection('collection1');
+
+        $this->media['model1']['collection2'] = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toCollection('collection2');
+
+        $this->media['model2']['collection1'] = $this->testModelWithConversion
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toCollection('collection1');
+
+        $this->media['model2']['collection2'] = $this->testModelWithConversion
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toCollection('collection2');
+
+        mkdir($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/conversions"));
+        mkdir($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/conversions"));
+
+        $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
+        $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
+        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
+        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+    }
+
+    /** @test */
+    public function it_can_clean_deprecated_conversion_files()
+    {
+        $media = $this->media['model2']['collection1'];
+        $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/deprecated.jpg");
+
+        touch($deprecatedImage);
+        $this->assertFileExists($deprecatedImage);
+
+        Artisan::call('medialibrary:clean');
+
+        $this->assertFileNotExists($deprecatedImage);
+        $this->assertFileExists($this->getMediaDirectory("{$media->id}/conversions/thumb.jpg"));
+    }
+
+    /** @test */
+    public function it_can_clean_deprecated_conversion_files_from_a_specific_model_type()
+    {
+        $media1 = $this->media['model1']['collection1'];
+        $media2 = $this->media['model2']['collection1'];
+
+        $deprecatedImage1 = $this->getMediaDirectory("{$media1->id}/conversions/deprecated.jpg");
+        $deprecatedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/deprecated.jpg");
+        touch($deprecatedImage1);
+        touch($deprecatedImage2);
+
+        Artisan::call('medialibrary:clean', [
+            'modelType' => TestModelWithConversion::class,
+        ]);
+
+        $this->assertFileExists($deprecatedImage1);
+        $this->assertFileNotExists($deprecatedImage2);
+    }
+
+    /** @test */
+    public function it_can_clean_deprecated_conversion_files_from_a_specific_collection()
+    {
+        $media1 = $this->media['model1']['collection1'];
+        $media2 = $this->media['model1']['collection2'];
+
+        $deprecatedImage1 = $this->getMediaDirectory("{$media1->id}/conversions/deprecated.jpg");
+        $deprecatedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/deprecated.jpg");
+        touch($deprecatedImage1);
+        touch($deprecatedImage2);
+
+        Artisan::call('medialibrary:clean', [
+            'collectionName' => 'collection2',
+        ]);
+
+        $this->assertFileExists($deprecatedImage1);
+        $this->assertFileNotExists($deprecatedImage2);
+    }
+
+    /** @test */
+    public function it_can_clean_deprecated_conversion_files_from_a_specific_model_type_and_collection()
+    {
+        $media1 = $this->media['model1']['collection1'];
+        $media2 = $this->media['model1']['collection2'];
+        $media3 = $this->media['model2']['collection1'];
+
+        $deprecatedImage1 = $this->getMediaDirectory("{$media1->id}/conversions/deprecated.jpg");
+        $deprecatedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/deprecated.jpg");
+        $deprecatedImage3 = $this->getMediaDirectory("{$media3->id}/conversions/deprecated.jpg");
+
+        touch($deprecatedImage1);
+        touch($deprecatedImage2);
+        touch($deprecatedImage3);
+
+        Artisan::call('medialibrary:clean', [
+            'modelType' => TestModel::class,
+            'collectionName' => 'collection1',
+        ]);
+
+        $this->assertFileNotExists($deprecatedImage1);
+        $this->assertFileExists($deprecatedImage2);
+        $this->assertFileExists($deprecatedImage3);
+    }
+
+    /** @test */
+    public function it_can_clean_orphan_files_in_the_media_disk()
+    {
+        // Dirty delete
+        \DB::table('media')->delete($this->media['model1']['collection1']->id);
+
+        Artisan::call('medialibrary:clean');
+
+        $this->assertFileNotExists($this->getMediaDirectory($this->media['model1']['collection1']->id));
+        $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
+    }
+}


### PR DESCRIPTION
Add a `--purge` option to the `medialibrary:regenerate` command.

Using the options will check all current conversions on disk and check if they are still defined in the current Model conversions.

if not the conversions is deleted.

Requested in #245