### PR TITLE
Simplify the conversion path logic.

### DIFF
--- a/tests/PathGenerator/CustomPathGenerator.php
+++ b/tests/PathGenerator/CustomPathGenerator.php
@@ -22,6 +22,6 @@ class CustomPathGenerator implements PathGenerator
      */
     public function getPathForConversions(Media $media) : string
     {
-        return md5($media->id).'/c/';
+        return $this->getPath($media).'c/';
     }
 }


### PR DESCRIPTION
Since this test is being linked to from the docs as an example, it is nice to simplify the test class down. This way developers don't spend time duplicating logic if they don't realize they can call the other method first.