### PR TITLE
Convert multiple if/return to switch statement.

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -100,17 +100,19 @@ class Media extends Model
      */
     public function getTypeFromExtensionAttribute()
     {
-        $extension = strtolower($this->extension);
-
-        if (in_array($extension, ['png', 'jpg', 'jpeg', 'gif'])) {
-            return static::TYPE_IMAGE;
+        switch (strtolower($this->extension)) {
+            case 'png':
+            case 'jpg':
+            case 'jpeg':
+            case 'gif':
+                return static::TYPE_IMAGE;
+            break;
+            case 'pdf':
+                return static::TYPE_PDF;
+            break;
+            default:
+                return static::TYPE_OTHER;
         }
-
-        if ($extension == 'pdf') {
-            return static::TYPE_PDF;
-        }
-
-        return static::TYPE_OTHER;
     }
 
     /*
@@ -122,17 +124,19 @@ class Media extends Model
             return static::TYPE_OTHER;
         }
 
-        $mime = File::getMimetype($this->getPath());
 
-        if (in_array($mime, ['image/jpeg', 'image/gif', 'image/png'])) {
-            return static::TYPE_IMAGE;
+        switch (File::getMimetype($this->getPath())) {
+            case 'image/jpeg':
+            case 'image/gif':
+            case 'image/png':
+                return static::TYPE_IMAGE;
+            break;
+            case 'application/pdf':
+                return static::TYPE_PDF;
+            break;
+            default:
+                return static::TYPE_OTHER;
         }
-
-        if ($mime === 'application/pdf') {
-            return static::TYPE_PDF;
-        }
-
-        return static::TYPE_OTHER;
     }
 
     public function getExtensionAttribute() : string


### PR DESCRIPTION
This just keeps the code easier to maintain in case more things are added later. Instead of adding more if's it is just a new case/break clause. You also don't have an array for the image types that can get unruly  as more support is added.