### PR TITLE
Add get mime method

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -127,7 +127,7 @@ class Media extends Model
             return static::TYPE_OTHER;
         }
 
-        $mime = File::getMimetype($this->getPath());
+        $mime = $this->getMimeAttribute();
 
         if (in_array($mime, ['image/jpeg', 'image/gif', 'image/png'])) {
             return static::TYPE_IMAGE;
@@ -142,6 +142,11 @@ class Media extends Model
         }
 
         return static::TYPE_OTHER;
+    }
+
+    public function getMimeAttribute() : string
+    {
+        return File::getMimetype($this->getPath());
     }
 
     public function getExtensionAttribute() : string

--- a/tests/Media/GetTypeTest.php
+++ b/tests/Media/GetTypeTest.php
@@ -67,4 +67,12 @@ class GetTypeTest extends TestCase
             ['test.txt', Media::TYPE_OTHER],
         ];
     }
+
+    /** @test */
+    public function it_can_return_the_file_mime()
+    {
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+
+        $this->assertEquals('image/jpeg', $media->mime);
+    }
 }


### PR DESCRIPTION
Add a `getMimeAttribute` method to the Media model.

It can be useful to access the raw mime type easily from a media instance, like:
```html
<video controls>
  <source src="{{ $media->getUrl() }}" type="{{ $media->mime }}" />
</video>
```