### PR TITLE
Use `putStream` instead of `put` for cloud drivers

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -61,7 +61,7 @@ class Filesystem
         $this->filesystem
             ->disk($media->disk)
             ->getDriver()
-            ->put($destination, fopen($file, 'r+'), $this->getRemoteHeadersForFile($file));
+            ->putStream($destination, fopen($file, 'r+'), $this->getRemoteHeadersForFile($file));
     }
 
     /*


### PR DESCRIPTION
I'm using this adapter for Google Cloud Storage https://github.com/Superbalist/flysystem-google-storage, but i'm getting this error.

```
ErrorException in MediaFileUpload.php line 88: strlen() expects parameter 1 to be string, resource given
```