### PR TITLE
Add force option to commands

### DIFF
--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -12,6 +12,7 @@ use Spatie\MediaLibrary\FileManipulator;
 use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\MediaRepository;
 use Spatie\MediaLibrary\PathGenerator\BasePathGenerator;
+use Symfony\Component\Console\Input\InputOption;
 
 class CleanCommand extends Command
 {
@@ -22,7 +23,7 @@ class CleanCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'medialibrary:clean {modelType?} {collectionName?} {disk?} {--dry-run}';
+    protected $signature = 'medialibrary:clean {modelType?} {collectionName?} {disk?}';
 
     /**
      * The console command description.
@@ -160,5 +161,18 @@ class CleanCommand extends Command
 
                 $this->info("Orphaned media directory `{$directory}` ".($this->isDryRun ? 'found' : 'has been removed'));
             });
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['dry-run', null, InputOption::VALUE_NONE, 'List files that will be removed without removing them.'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the compiled class file to be written.'],
+        ];
     }
 }

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -24,7 +24,7 @@ class CleanCommand extends Command
      */
     protected $signature = 'medialibrary:clean {modelType?} {collectionName?} {disk?} 
     {--dry-run : List files that will be removed without removing them},
-    {-- force : Force the compiled class file to be written}';
+    {-- force : Force the operation to run when in production}';
 
     /**
      * The console command description.

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -12,7 +12,6 @@ use Spatie\MediaLibrary\FileManipulator;
 use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\MediaRepository;
 use Spatie\MediaLibrary\PathGenerator\BasePathGenerator;
-use Symfony\Component\Console\Input\InputOption;
 
 class CleanCommand extends Command
 {
@@ -23,7 +22,9 @@ class CleanCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'medialibrary:clean {modelType?} {collectionName?} {disk?}';
+    protected $signature = 'medialibrary:clean {modelType?} {collectionName?} {disk?} 
+    {--dry-run : List files that will be removed without removing them},
+    {-- force : Force the compiled class file to be written}';
 
     /**
      * The console command description.
@@ -161,18 +162,5 @@ class CleanCommand extends Command
 
                 $this->info("Orphaned media directory `{$directory}` ".($this->isDryRun ? 'found' : 'has been removed'));
             });
-    }
-
-    /**
-     * Get the console command options.
-     *
-     * @return array
-     */
-    protected function getOptions()
-    {
-        return [
-            ['dry-run', null, InputOption::VALUE_NONE, 'List files that will be removed without removing them.'],
-            ['force', null, InputOption::VALUE_NONE, 'Force the compiled class file to be written.'],
-        ];
     }
 }

--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -18,7 +18,7 @@ class ClearCommand extends Command
      * @var string
      */
     protected $signature = 'medialibrary:clear {modelType?} {collectionName?}
-    {-- force : Force the compiled class file to be written}';
+    {-- force : Force the operation to run when in production}';
 
     /**
      * The console command description.

--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -7,7 +7,6 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Eloquent\Collection;
 use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\MediaRepository;
-use Symfony\Component\Console\Input\InputOption;
 
 class ClearCommand extends Command
 {
@@ -18,7 +17,8 @@ class ClearCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'medialibrary:clear {modelType?} {collectionName?}';
+    protected $signature = 'medialibrary:clear {modelType?} {collectionName?}
+    {-- force : Force the compiled class file to be written}';
 
     /**
      * The console command description.
@@ -78,17 +78,5 @@ class ClearCommand extends Command
         }
 
         return $this->mediaRepository->all();
-    }
-
-    /**
-     * Get the console command options.
-     *
-     * @return array
-     */
-    protected function getOptions()
-    {
-        return [
-            ['force', null, InputOption::VALUE_NONE, 'Force the compiled class file to be written.'],
-        ];
     }
 }

--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Eloquent\Collection;
 use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\MediaRepository;
+use Symfony\Component\Console\Input\InputOption;
 
 class ClearCommand extends Command
 {
@@ -77,5 +78,17 @@ class ClearCommand extends Command
         }
 
         return $this->mediaRepository->all();
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'Force the compiled class file to be written.'],
+        ];
     }
 }

--- a/src/Commands/RegenerateCommand.php
+++ b/src/Commands/RegenerateCommand.php
@@ -10,6 +10,7 @@ use Spatie\{
     MediaLibrary\Media,
     MediaLibrary\MediaRepository
 };
+use Symfony\Component\Console\Input\InputOption;
 
 class RegenerateCommand extends Command
 {
@@ -66,7 +67,8 @@ class RegenerateCommand extends Command
                 $this->fileManipulator->createDerivedFiles($media);
                 $this->info("Media {$media->id} regenerated");
             } catch (Exception $exception) {
-                $this->error("Media {$media->id} could not be regenerated because `{$exception->getMessage()}`");          $this->erroredMediaIds[] = $media->id;
+                $this->error("Media {$media->id} could not be regenerated because `{$exception->getMessage()}`");
+                $this->erroredMediaIds[] = $media->id;
             }
         });
 
@@ -96,5 +98,17 @@ class RegenerateCommand extends Command
         }
 
         return $this->mediaRepository->getByModelType($modelType);
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'Force the compiled class file to be written.'],
+        ];
     }
 }

--- a/src/Commands/RegenerateCommand.php
+++ b/src/Commands/RegenerateCommand.php
@@ -4,22 +4,25 @@ namespace Spatie\MediaLibrary\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Support\Collection;
 use Spatie\{
     MediaLibrary\FileManipulator,
     MediaLibrary\Media,
     MediaLibrary\MediaRepository
 };
-use Symfony\Component\Console\Input\InputOption;
 
 class RegenerateCommand extends Command
 {
+    use ConfirmableTrait;
+
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $signature = 'medialibrary:regenerate {modelType?} {--ids=*}';
+    protected $signature = 'medialibrary:regenerate {modelType?} {--ids=*}
+    {-- force : Force the compiled class file to be written}';
 
     /**
      * The console command description.
@@ -62,6 +65,10 @@ class RegenerateCommand extends Command
      */
     public function handle()
     {
+        if (!$this->confirmToProceed()) {
+            return;
+        }
+
         $this->getMediaToBeRegenerated()->each(function (Media $media) {
             try {
                 $this->fileManipulator->createDerivedFiles($media);
@@ -98,17 +105,5 @@ class RegenerateCommand extends Command
         }
 
         return $this->mediaRepository->getByModelType($modelType);
-    }
-
-    /**
-     * Get the console command options.
-     *
-     * @return array
-     */
-    protected function getOptions()
-    {
-        return [
-            ['force', null, InputOption::VALUE_NONE, 'Force the compiled class file to be written.'],
-        ];
     }
 }

--- a/src/Commands/RegenerateCommand.php
+++ b/src/Commands/RegenerateCommand.php
@@ -22,7 +22,7 @@ class RegenerateCommand extends Command
      * @var string
      */
     protected $signature = 'medialibrary:regenerate {modelType?} {--ids=*}
-    {-- force : Force the compiled class file to be written}';
+    {-- force : Force the operation to run when in production}';
 
     /**
      * The console command description.


### PR DESCRIPTION
I've added the `--force` option to the three tmedialibrary commands so we can use them in production environment:

before:
![capture d ecran de 2016-07-29 18 56 27](https://cloud.githubusercontent.com/assets/2951704/17265621/9de56c5a-55f0-11e6-9bb7-15b7980292ad.png)

after:
![capture d ecran de 2016-07-29 19 05 16](https://cloud.githubusercontent.com/assets/2951704/17265627/a6c94fd0-55f0-11e6-895b-1d3d80dd43d2.png)

I've chosen to put optional args in the `getOptions` method instead of the command signature to keep them clean and easily readable.

+ I re indented [this line](https://github.com/spatie/laravel-medialibrary/blob/master/src/Commands/RegenerateCommand.php#L69)

Now that you now that I use the package in production I must send you a postcard :smile: 