### PR TITLE
Add missing extensions to keep when converting

### DIFF
--- a/src/Conversion/Conversion.php
+++ b/src/Conversion/Conversion.php
@@ -156,9 +156,9 @@ class Conversion
         return array_reduce($this->getManipulations(), function ($carry, array $manipulation) {
 
             if (isset($manipulation['fm'])) {
-                $keepFormats = ['png', 'gif'];
+                $keepExtensions = ['jpg', 'jpeg', 'png', 'gif'];
 
-                return ($manipulation['fm'] === 'src' && in_array($carry, $keepFormats)) ? $carry : $manipulation['fm'];
+                return ($manipulation['fm'] === 'src' && in_array($carry, $keepExtensions)) ? $carry : $manipulation['fm'];
             }
 
             return $carry;

--- a/tests/Conversion/ConversionTest.php
+++ b/tests/Conversion/ConversionTest.php
@@ -115,8 +115,10 @@ class ConversionTest extends TestCase
     {
         $this->conversion->setManipulations(['w' => 100, 'fm' => 'src']);
 
-        $this->assertEquals('png', $this->conversion->getResultExtension('png'));
-        $this->assertEquals('gif', $this->conversion->getResultExtension('gif'));
+        $this->assertEquals('jpg',  $this->conversion->getResultExtension('jpg'));
+        $this->assertEquals('jpeg', $this->conversion->getResultExtension('jpeg'));
+        $this->assertEquals('png',  $this->conversion->getResultExtension('png'));
+        $this->assertEquals('gif',  $this->conversion->getResultExtension('gif'));
     }
 
     /** @test */


### PR DESCRIPTION
The .jpg and .jpeg extensions where set to .src when using 'fm': 'src' in the conversion. This should fix this. If you could merge this in as soon as possible it would be greatly appreciated since we have a project thats going live very soon ;)