### PR TITLE
Fix svg and pdf file path when performing conversion

### DIFF
--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -123,7 +123,7 @@ class FileManipulator
 
     protected function extractVideoThumbnail(string $videoFile, Conversion $conversion) : string
     {
-        $imageFile = pathinfo($videoFile, PATHINFO_FILENAME).'.jpg';
+        $imageFile = pathinfo($videoFile, PATHINFO_DIRNAME).'/'.pathinfo($videoFile, PATHINFO_FILENAME).'.jpg';
 
         $ffmpeg = \FFMpeg\FFMpeg::create([
             'ffmpeg.binaries' => config('laravel-medialibrary.ffmpeg_binaries'),
@@ -139,7 +139,7 @@ class FileManipulator
 
     protected function convertPdfToImage(string $pdfFile) : string
     {
-        $imageFile = pathinfo($pdfFile, PATHINFO_FILENAME).'.jpg';
+        $imageFile = pathinfo($pdfFile, PATHINFO_DIRNAME).'/'.pathinfo($pdfFile, PATHINFO_FILENAME).'.jpg';
 
         (new Pdf($pdfFile))->saveImage($imageFile);
 
@@ -148,7 +148,7 @@ class FileManipulator
 
     protected function convertSvgToImage(string $svgFile) : string
     {
-        $imageFile = pathinfo($svgFile, PATHINFO_FILENAME).'.png';
+        $imageFile = pathinfo($svgFile, PATHINFO_DIRNAME).'/'.pathinfo($svgFile, PATHINFO_FILENAME).'.png';
 
         $image = new \Imagick();
         $image->readImage($svgFile);


### PR DESCRIPTION
This should fix #301, 

the bug has been introduced [here](https://github.com/spatie/laravel-medialibrary/pull/276/files#diff-0d11c445b5c28ccade90cf390e511012R142).

PDF / svg / video when converted to image before manipulation were stored directly in the root of the project instead of `storage/medialibrary/temp/`


