### PR TITLE
add getLastMedia* methods into HasMediaTrait

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -172,6 +172,53 @@ trait HasMediaTrait
 
         return $media->getPath($conversionName);
     }
+    
+    /**
+     * Get the last media item of a media collection.
+     *
+     * @param string $collectionName
+     * @param array  $filters
+     *
+     * @return Media|null
+     */
+    public function getLastMedia(string $collectionName = 'default', array $filters = [])
+    {
+        $media = $this->getMedia($collectionName, $filters);
+
+        return $media->last();
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for last media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getLastMediaUrl(string $collectionName = 'default', string $conversionName = '') : string
+    {
+        $media = $this->getLastMedia($collectionName);
+
+        if (! $media) {
+            return false;
+        }
+
+        return $media->getUrl($conversionName);
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for last media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getLastMediaPath(string $collectionName = 'default', string $conversionName = '') : string
+    {
+        $media = $this->getLastMedia($collectionName);
+
+        if (! $media) {
+            return false;
+        }
+
+        return $media->getPath($conversionName);
+    }
 
     /**
      * Update a media collection by deleting and inserting again with new values.


### PR DESCRIPTION
It is just a small adding. I need a shortcut to get the latest image from a collection in many cases such as getting the latest uploaded profile picture of a user, while preserving the old ones for reuse.

I don't know about the performance consideration, but I think it is complementing for the _getFirst*_ pair. I am using this additional snippet now, hopefully it could be official :)