### PR TITLE
Driver system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - sudo apt-get install -y ffmpeg libavcodec-extra-53
   - travis_retry composer update --prefer-source $PREFER_LOWEST
   - travis_retry composer require php-ffmpeg/php-ffmpeg
+  - travis_retry composer require spatie/pdf-to-image
   - printf "\n" | pecl install imagick
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     "illuminate/database": "~5.1.16|~5.2.0|~5.3.0",
     "illuminate/support": "~5.1.16|~5.2.0|~5.3.0",
     "spatie/laravel-glide": "^3.0.0",
-    "spatie/pdf-to-image": "^1.0.1",
-    "spatie/string": "^2.0.0"
+    "spatie/string": "^2.0.0",
   },
   "require-dev": {
     "phpunit/phpunit" : "^5.0.0",
@@ -37,10 +36,12 @@
     "doctrine/dbal": "^2.5.2"
   },
   "conflict": {
-    "php-ffmpeg/php-ffmpeg": "<0.6.1"
+    "php-ffmpeg/php-ffmpeg": "<0.6.1",
+    "spatie/pdf-to-image": "<1.0.0"
   },
   "suggest": {
-    "php-ffmpeg/php-ffmpeg": "Required for generating video thumbnails"
+    "php-ffmpeg/php-ffmpeg": "Required for generating video thumbnails",
+    "spatie/pdf-to-image": "Required for generating Pdf thumbnails"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "illuminate/database": "~5.1.16|~5.2.0|~5.3.0",
     "illuminate/support": "~5.1.16|~5.2.0|~5.3.0",
     "spatie/laravel-glide": "^3.0.0",
-    "spatie/string": "^2.0.0",
+    "spatie/string": "^2.0.0"
   },
   "require-dev": {
     "phpunit/phpunit" : "^5.0.0",

--- a/src/BeforeConversion/BeforeConversionDriver.php
+++ b/src/BeforeConversion/BeforeConversionDriver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\MediaLibrary\BeforeConversion;
+
+use Spatie\MediaLibrary\Conversion\Conversion;
+
+interface BeforeConversionDriver
+{
+    /**
+     * Return the name of the media type handled by the driver.
+     */
+    public function getMediaType() : string;
+
+    /**
+     * Verify that a file is this driver media type using it's extension.
+     */
+    public function fileExtensionIsType(string $extension) : bool;
+
+    /**
+     * Verify that a file is this driver media type using it's mime.
+     */
+    public function fileMimeIsType(string $mime) : bool;
+
+    /**
+     * Return true if the project as all the requirements to use the thumbnail driver.
+     */
+    public function hasRequirements() : bool;
+
+    /**
+     * Receive a file of type X and return a thumbnail in jpg/png format.
+     */
+    public function convertToImage(string $file, Conversion $conversion) : string;
+}

--- a/src/BeforeConversion/BeforeConversionDriverHandler.php
+++ b/src/BeforeConversion/BeforeConversionDriverHandler.php
@@ -10,7 +10,7 @@ class BeforeConversionDriverHandler
     protected $model;
 
     /**
-     * BeforeConversionDriver[]|Collection
+     * BeforeConversionDriver[]|Collection.
      */
     protected $drivers;
 
@@ -27,6 +27,7 @@ class BeforeConversionDriverHandler
     {
         return $this->model->getBeforeConversionDrivers()->map(function ($driver) {
             app()->singleton($driver);
+
             return app($driver);
         })->keyBy(function ($driver) {
             return $driver->getMediaType();
@@ -36,27 +37,23 @@ class BeforeConversionDriverHandler
     public function getTypeFromExtension(string $extension)
     {
         foreach ($this->drivers as $driver) {
-            if (!$driver->fileExtensionIsType($extension)) {
+            if (! $driver->fileExtensionIsType($extension)) {
                 continue;
             }
 
             return $driver->getMediaType();
         }
-
-        return ($this->model)::TYPE_OTHER;
     }
 
     public function getTypeFromMime(string $mime)
     {
         foreach ($this->drivers as $driver) {
-            if (!$driver->fileMimeIsType($mime)) {
+            if (! $driver->fileMimeIsType($mime)) {
                 continue;
             }
 
             return $driver->getMediaType();
         }
-
-        return null;
     }
 
     public function getDrivers()

--- a/src/BeforeConversion/BeforeConversionDriverHandler.php
+++ b/src/BeforeConversion/BeforeConversionDriverHandler.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Spatie\MediaLibrary\BeforeConversion;
+
+use Illuminate\Support\Collection;
+use Spatie\MediaLibrary\Media;
+
+class BeforeConversionDriverHandler
+{
+    protected $model;
+
+    /**
+     * BeforeConversionDriver[]|Collection
+     */
+    protected $drivers;
+
+    public function __construct(Media $model)
+    {
+        $this->model = $model;
+        $this->drivers = $this->bindDrivers();
+    }
+
+    /**
+     * Register each drivers in the service container as a singleton.
+     */
+    private function bindDrivers() : Collection
+    {
+        return $this->model->getBeforeConversionDrivers()->map(function ($driver) {
+            app()->singleton($driver);
+            return app($driver);
+        })->keyBy(function ($driver) {
+            return $driver->getMediaType();
+        });
+    }
+
+    public function getTypeFromExtension(string $extension)
+    {
+        foreach ($this->drivers as $driver) {
+            if (!$driver->fileExtensionIsType($extension)) {
+                continue;
+            }
+
+            return $driver->getMediaType();
+        }
+
+        return ($this->model)::TYPE_OTHER;
+    }
+
+    public function getTypeFromMime(string $mime)
+    {
+        foreach ($this->drivers as $driver) {
+            if (!$driver->fileMimeIsType($mime)) {
+                continue;
+            }
+
+            return $driver->getMediaType();
+        }
+
+        return null;
+    }
+
+    public function getDrivers()
+    {
+        return $this->drivers;
+    }
+
+    public function mediaHasDriver(Media $media) : bool
+    {
+        return $this->drivers->has($media->type) && $this->drivers->get($media->type)->hasRequirements();
+    }
+
+    public function getDriverForMedia(Media $media)
+    {
+        return $this->drivers->get($media->type);
+    }
+}

--- a/src/BeforeConversion/Drivers/ImageDriver.php
+++ b/src/BeforeConversion/Drivers/ImageDriver.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Spatie\MediaLibrary\BeforeConversion\Drivers;
+
+use Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriver;
+use Spatie\MediaLibrary\Conversion\Conversion;
+
+class ImageDriver implements BeforeConversionDriver
+{
+    /**
+     * Return the name of the media type handled by the driver.
+     */
+    public function getMediaType() : string
+    {
+        return 'image';
+    }
+
+    /**
+     * Verify that a file is this driver media type using it's extension.
+     */
+    public function fileExtensionIsType(string $extension) : bool
+    {
+        return in_array($extension, ['png', 'jpg', 'jpeg', 'gif']);
+    }
+
+    /**
+     * Verify that a file is this driver media type using it's mime.
+     */
+    public function fileMimeIsType(string $mime) : bool
+    {
+        return in_array($mime, ['image/jpeg', 'image/gif', 'image/png']);
+    }
+
+    public function hasRequirements() : bool
+    {
+        return true;
+    }
+
+    /**
+     * Image do not need any before conversion processing.
+     */
+    public function convertToImage(string $file, Conversion $conversion) : string
+    {
+        return $file;
+    }
+}

--- a/src/BeforeConversion/Drivers/PdfDriver.php
+++ b/src/BeforeConversion/Drivers/PdfDriver.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Spatie\MediaLibrary\BeforeConversion\Drivers;
+
+use Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriver;
+use Spatie\MediaLibrary\Conversion\Conversion;
+use Spatie\PdfToImage\Pdf;
+
+class PdfDriver implements BeforeConversionDriver
+{
+    /**
+     * Return the name of the media type handled by the driver.
+     */
+    public function getMediaType() : string
+    {
+        return 'pdf';
+    }
+
+    /**
+     * Verify that a file is this driver media type using it's extension.
+     */
+    public function fileExtensionIsType(string $extension) : bool
+    {
+        return $extension === 'pdf';
+    }
+
+    /**
+     * Verify that a file is this driver media type using it's mime.
+     */
+    public function fileMimeIsType(string $mime) : bool
+    {
+        return $mime === 'application/pdf';
+    }
+
+    public function hasRequirements() : bool
+    {
+        return class_exists('Imagick');
+    }
+
+    /**
+     * Receive a file of type pdf and return a thumbnail in jpg.
+     */
+    public function convertToImage(string $file, Conversion $conversion) : string
+    {
+        $imageFile = pathinfo($file, PATHINFO_DIRNAME) . '/' . pathinfo($file, PATHINFO_FILENAME) . '.jpg';
+
+        (new Pdf($file))->saveImage($imageFile);
+
+        return $imageFile;
+    }
+}

--- a/src/BeforeConversion/Drivers/PdfDriver.php
+++ b/src/BeforeConversion/Drivers/PdfDriver.php
@@ -42,7 +42,7 @@ class PdfDriver implements BeforeConversionDriver
      */
     public function convertToImage(string $file, Conversion $conversion) : string
     {
-        $imageFile = pathinfo($file, PATHINFO_DIRNAME) . '/' . pathinfo($file, PATHINFO_FILENAME) . '.jpg';
+        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
 
         (new Pdf($file))->saveImage($imageFile);
 

--- a/src/BeforeConversion/Drivers/PdfDriver.php
+++ b/src/BeforeConversion/Drivers/PdfDriver.php
@@ -4,7 +4,6 @@ namespace Spatie\MediaLibrary\BeforeConversion\Drivers;
 
 use Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriver;
 use Spatie\MediaLibrary\Conversion\Conversion;
-use Spatie\PdfToImage\Pdf;
 
 class PdfDriver implements BeforeConversionDriver
 {
@@ -34,7 +33,7 @@ class PdfDriver implements BeforeConversionDriver
 
     public function hasRequirements() : bool
     {
-        return class_exists('Imagick');
+        return class_exists('Imagick') && class_exists('\\Spatie\\PdfToImage\\Pdf');
     }
 
     /**
@@ -44,7 +43,7 @@ class PdfDriver implements BeforeConversionDriver
     {
         $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
 
-        (new Pdf($file))->saveImage($imageFile);
+        (new \Spatie\PdfToImage\Pdf($file))->saveImage($imageFile);
 
         return $imageFile;
     }

--- a/src/BeforeConversion/Drivers/SvgDriver.php
+++ b/src/BeforeConversion/Drivers/SvgDriver.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Spatie\MediaLibrary\BeforeConversion\Drivers;
+
+use ImagickPixel;
+use Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriver;
+use Spatie\MediaLibrary\Conversion\Conversion;
+
+class SvgDriver implements BeforeConversionDriver
+{
+    /**
+     * Return the name of the media type handled by the driver.
+     */
+    public function getMediaType() : string
+    {
+        return 'svg';
+    }
+
+    /**
+     * Verify that a file is this driver media type using it's extension.
+     */
+    public function fileExtensionIsType(string $extension) : bool
+    {
+        return $extension === 'svg';
+    }
+
+    /**
+     * Verify that a file is this driver media type using it's mime.
+     */
+    public function fileMimeIsType(string $mime) : bool
+    {
+        return $mime === 'image/svg+xml';
+    }
+
+    public function hasRequirements() : bool
+    {
+        return class_exists('Imagick');
+    }
+
+    /**
+     * Receive a file of type svg and return a thumbnail in png.
+     */
+    public function convertToImage(string $file, Conversion $conversion) : string
+    {
+        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.png';
+
+        $image = new \Imagick();
+        $image->readImage($file);
+        $image->setBackgroundColor(new ImagickPixel('none'));
+        $image->setImageFormat('png32');
+
+        file_put_contents($imageFile, $image);
+
+        return $imageFile;
+    }
+}

--- a/src/BeforeConversion/Drivers/VideoDriver.php
+++ b/src/BeforeConversion/Drivers/VideoDriver.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Spatie\MediaLibrary\BeforeConversion\Drivers;
+
+use Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriver;
+use Spatie\MediaLibrary\Conversion\Conversion;
+
+class VideoDriver implements BeforeConversionDriver
+{
+    /**
+     * Return the name of the media type handled by the driver.
+     */
+    public function getMediaType() : string
+    {
+        return 'video';
+    }
+
+    /**
+     * Verify that a file is this driver media type using it's extension.
+     */
+    public function fileExtensionIsType(string $extension) : bool
+    {
+        return in_array($extension, ['webm', 'mov', 'mp4']);
+    }
+
+    /**
+     * Verify that a file is this driver media type using it's mime.
+     */
+    public function fileMimeIsType(string $mime) : bool
+    {
+        return in_array($mime, ['video/webm', 'video/mpeg', 'video/mp4', 'video/quicktime']);
+    }
+
+    public function hasRequirements() : bool
+    {
+        return class_exists('\\FFMpeg\\FFMpeg');
+    }
+
+    /**
+     * Receive a file of any video type and return a thumbnail in jpg.
+     */
+    public function convertToImage(string $file, Conversion $conversion) : string
+    {
+        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
+
+        $ffmpeg = \FFMpeg\FFMpeg::create([
+            'ffmpeg.binaries' => config('laravel-medialibrary.ffmpeg_binaries'),
+            'ffprobe.binaries' => config('laravel-medialibrary.ffprobe_binaries'),
+        ]);
+        $video = $ffmpeg->open($file);
+
+        $frame = $video->frame(\FFMpeg\Coordinate\TimeCode::fromSeconds($conversion->getExtractVideoFrameAtSecond()));
+        $frame->save($imageFile);
+
+        return $imageFile;
+    }
+}

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -27,7 +27,7 @@ class FileManipulator
         $conversionDriverHandler = app(BeforeConversionDriverHandler::class);
 
         // If the media doesn't have any driver
-        if (!$conversionDriverHandler->mediaHasDriver($media)) {
+        if (! $conversionDriverHandler->mediaHasDriver($media)) {
             return;
         }
 

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -3,14 +3,13 @@
 namespace Spatie\MediaLibrary;
 
 use Illuminate\Support\Facades\File;
-use ImagickPixel;
 use Spatie\Glide\GlideImage;
+use Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriverHandler;
 use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\Conversion\ConversionCollection;
 use Spatie\MediaLibrary\Events\ConversionHasBeenCompleted;
 use Spatie\MediaLibrary\Helpers\File as MediaLibraryFileHelper;
 use Spatie\MediaLibrary\Jobs\PerformConversions;
-use Spatie\PdfToImage\Pdf;
 
 class FileManipulator
 {
@@ -25,17 +24,20 @@ class FileManipulator
             return;
         }
 
-        if ($media->type === Media::TYPE_VIDEO && ! class_exists('\\FFMpeg\\FFMpeg')) {
-            return;
-        }
+        $conversionDriverHandler = app(BeforeConversionDriverHandler::class);
 
-        if (in_array($media->type, [Media::TYPE_PDF, Media::TYPE_SVG]) && ! class_exists('Imagick')) {
+        // If the media doesn't have any driver
+        if (!$conversionDriverHandler->mediaHasDriver($media)) {
             return;
         }
 
         $profileCollection = ConversionCollection::createForMedia($media);
 
-        $this->performConversions($profileCollection->getNonQueuedConversions($media->collection_name), $media);
+        $this->performConversions(
+            $profileCollection->getNonQueuedConversions($media->collection_name),
+            $media,
+            $conversionDriverHandler->getDriverForMedia($media)
+        );
 
         $queuedConversions = $profileCollection->getQueuedConversions($media->collection_name);
 
@@ -47,10 +49,11 @@ class FileManipulator
     /**
      * Perform the given conversions for the given media.
      *
-     * @param \Spatie\MediaLibrary\Conversion\ConversionCollection $conversions
-     * @param \Spatie\MediaLibrary\Media                           $media
+     * @param \Spatie\MediaLibrary\Conversion\ConversionCollection         $conversions
+     * @param \Spatie\MediaLibrary\Media                                   $media
+     * @param \Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriver $driver
      */
-    public function performConversions(ConversionCollection $conversions, Media $media)
+    public function performConversions(ConversionCollection $conversions, Media $media, $driver)
     {
         $tempDirectory = $this->createTempDirectory();
 
@@ -58,18 +61,8 @@ class FileManipulator
 
         app(Filesystem::class)->copyFromMediaLibrary($media, $copiedOriginalFile);
 
-        if ($media->type == Media::TYPE_PDF) {
-            $copiedOriginalFile = $this->convertPdfToImage($copiedOriginalFile);
-        }
-
-        if ($media->type == Media::TYPE_SVG) {
-            $copiedOriginalFile = $this->convertSvgToImage($copiedOriginalFile);
-        }
-
         foreach ($conversions as $conversion) {
-            if ($media->type == Media::TYPE_VIDEO) {
-                $copiedOriginalFile = $this->extractVideoThumbnail($copiedOriginalFile, $conversion);
-            }
+            $copiedOriginalFile = $driver->convertToImage($copiedOriginalFile, $conversion);
 
             $conversionResult = $this->performConversion($media, $conversion, $copiedOriginalFile);
 
@@ -119,45 +112,6 @@ class FileManipulator
         File::makeDirectory($tempDirectory, 493, true);
 
         return $tempDirectory;
-    }
-
-    public function extractVideoThumbnail(string $videoFile, Conversion $conversion) : string
-    {
-        $imageFile = pathinfo($videoFile, PATHINFO_DIRNAME).'/'.pathinfo($videoFile, PATHINFO_FILENAME).'.jpg';
-
-        $ffmpeg = \FFMpeg\FFMpeg::create([
-            'ffmpeg.binaries' => config('laravel-medialibrary.ffmpeg_binaries'),
-            'ffprobe.binaries' => config('laravel-medialibrary.ffprobe_binaries'),
-        ]);
-        $video = $ffmpeg->open($videoFile);
-
-        $frame = $video->frame(\FFMpeg\Coordinate\TimeCode::fromSeconds($conversion->getExtractVideoFrameAtSecond()));
-        $frame->save($imageFile);
-
-        return $imageFile;
-    }
-
-    public function convertPdfToImage(string $pdfFile) : string
-    {
-        $imageFile = pathinfo($pdfFile, PATHINFO_DIRNAME).'/'.pathinfo($pdfFile, PATHINFO_FILENAME).'.jpg';
-
-        (new Pdf($pdfFile))->saveImage($imageFile);
-
-        return $imageFile;
-    }
-
-    public function convertSvgToImage(string $svgFile) : string
-    {
-        $imageFile = pathinfo($svgFile, PATHINFO_DIRNAME).'/'.pathinfo($svgFile, PATHINFO_FILENAME).'.png';
-
-        $image = new \Imagick();
-        $image->readImage($svgFile);
-        $image->setBackgroundColor(new ImagickPixel('none'));
-        $image->setImageFormat('png32');
-
-        file_put_contents($imageFile, $image);
-
-        return $imageFile;
     }
 
     /*

--- a/src/Media.php
+++ b/src/Media.php
@@ -79,7 +79,7 @@ class Media extends Model
     }
 
     /**
-     * Collection of all BeforeConversion drivers
+     * Collection of all BeforeConversion drivers.
      */
     public function getBeforeConversionDrivers() : Collection
     {

--- a/src/Media.php
+++ b/src/Media.php
@@ -3,6 +3,8 @@
 namespace Spatie\MediaLibrary;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriverHandler;
 use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\Conversion\ConversionCollection;
 use Spatie\MediaLibrary\Helpers\File;
@@ -13,10 +15,6 @@ class Media extends Model
     use SortableTrait;
 
     const TYPE_OTHER = 'other';
-    const TYPE_IMAGE = 'image';
-    const TYPE_VIDEO = 'video';
-    const TYPE_SVG = 'svg';
-    const TYPE_PDF = 'pdf';
 
     protected $guarded = ['id', 'disk', 'file_name', 'size', 'model_type', 'model_id'];
 
@@ -81,6 +79,19 @@ class Media extends Model
     }
 
     /**
+     * Collection of all BeforeConversion drivers
+     */
+    public function getBeforeConversionDrivers() : Collection
+    {
+        return collect([
+            \Spatie\MediaLibrary\BeforeConversion\Drivers\ImageDriver::class,
+            \Spatie\MediaLibrary\BeforeConversion\Drivers\PdfDriver::class,
+            \Spatie\MediaLibrary\BeforeConversion\Drivers\SvgDriver::class,
+            \Spatie\MediaLibrary\BeforeConversion\Drivers\VideoDriver::class,
+        ]);
+    }
+
+    /**
      * Determine the type of a file.
      *
      * @return string
@@ -104,23 +115,7 @@ class Media extends Model
     {
         $extension = strtolower($this->extension);
 
-        if (in_array($extension, ['png', 'jpg', 'jpeg', 'gif'])) {
-            return static::TYPE_IMAGE;
-        }
-
-        if (in_array($extension, ['webm', 'mov', 'mp4'])) {
-            return static::TYPE_VIDEO;
-        }
-
-        if ($extension == 'pdf') {
-            return static::TYPE_PDF;
-        }
-
-        if ($extension == 'svg') {
-            return static::TYPE_SVG;
-        }
-
-        return static::TYPE_OTHER;
+        return app(BeforeConversionDriverHandler::class)->getTypeFromExtension($extension) ?? static::TYPE_OTHER;
     }
 
     /*
@@ -134,23 +129,7 @@ class Media extends Model
 
         $mime = $this->getMimeAttribute();
 
-        if (in_array($mime, ['image/jpeg', 'image/gif', 'image/png'])) {
-            return static::TYPE_IMAGE;
-        }
-
-        if (in_array($mime, ['video/webm', 'video/mpeg', 'video/mp4', 'video/quicktime'])) {
-            return static::TYPE_VIDEO;
-        }
-
-        if ($mime === 'application/pdf') {
-            return static::TYPE_PDF;
-        }
-
-        if ($mime === 'image/svg+xml') {
-            return static::TYPE_SVG;
-        }
-
-        return static::TYPE_OTHER;
+        return app(BeforeConversionDriverHandler::class)->getTypeFromMime($mime) ?? static::TYPE_OTHER;
     }
 
     public function getMimeAttribute() : string

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
 use Illuminate\Foundation\Application as LaravelApplication;
+use Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriverHandler;
 use Spatie\MediaLibrary\Commands\CleanCommand;
 use Spatie\MediaLibrary\Commands\ClearCommand;
 use Spatie\MediaLibrary\Commands\RegenerateCommand;
@@ -42,6 +43,10 @@ class MediaLibraryServiceProvider extends ServiceProvider
 
         $mediaClass = config('laravel-medialibrary.media_model');
         $mediaClass::observe(new MediaObserver());
+
+        $this->app->singleton(BeforeConversionDriverHandler::class, function ($app) use ($mediaClass) {
+            return new BeforeConversionDriverHandler(new $mediaClass);
+        });
     }
 
     /**

--- a/tests/Conversion/BeforeConversionTest.php
+++ b/tests/Conversion/BeforeConversionTest.php
@@ -140,7 +140,7 @@ class BeforeConversionTest extends TestCase
     {
         $driver = new VideoDriver();
 
-        if (!$driver->hasRequirements()) {
+        if (! $driver->hasRequirements()) {
             return;
         }
 
@@ -155,7 +155,7 @@ class BeforeConversionTest extends TestCase
     {
         $driver = new PdfDriver();
 
-        if (!$driver->hasRequirements()) {
+        if (! $driver->hasRequirements()) {
             return;
         }
 
@@ -170,7 +170,7 @@ class BeforeConversionTest extends TestCase
     {
         $driver = new SvgDriver();
 
-        if (!$driver->hasRequirements()) {
+        if (! $driver->hasRequirements()) {
             return;
         }
 

--- a/tests/Conversion/BeforeConversionTest.php
+++ b/tests/Conversion/BeforeConversionTest.php
@@ -70,7 +70,7 @@ class BeforeConversionTest extends TestCase
     public function it_can_detect_media_type_from_extension_with_drivers($extension, $type)
     {
         $media = new Media();
-        $media->file_name = 'test.' . $extension;
+        $media->file_name = 'test.'.$extension;
         $this->assertEquals($type, $media->type_from_extension);
     }
 

--- a/tests/Conversion/BeforeConversionTest.php
+++ b/tests/Conversion/BeforeConversionTest.php
@@ -138,11 +138,13 @@ class BeforeConversionTest extends TestCase
     /** @test */
     public function it_has_a_working_video_driver()
     {
-        if (! class_exists('\\FFMpeg\\FFMpeg')) {
+        $driver = new VideoDriver();
+
+        if (!$driver->hasRequirements()) {
             return;
         }
 
-        $imageFile = (new VideoDriver())->convertToImage($this->getTestWebm(), $this->conversion);
+        $imageFile = $driver->convertToImage($this->getTestWebm(), $this->conversion);
 
         $this->assertEquals(str_replace('.webm', '.jpg', $this->getTestWebm()), $imageFile);
         $this->assertEquals('image/jpeg', mime_content_type($imageFile));
@@ -151,7 +153,13 @@ class BeforeConversionTest extends TestCase
     /** @test */
     public function it_has_a_working_pdf_driver()
     {
-        $imageFile = (new PdfDriver())->convertToImage($this->getTestPdf(), $this->conversion);
+        $driver = new PdfDriver();
+
+        if (!$driver->hasRequirements()) {
+            return;
+        }
+
+        $imageFile = $driver->convertToImage($this->getTestPdf(), $this->conversion);
 
         $this->assertEquals(str_replace('.pdf', '.jpg', $this->getTestPdf()), $imageFile);
         $this->assertEquals('image/jpeg', mime_content_type($imageFile));
@@ -160,7 +168,13 @@ class BeforeConversionTest extends TestCase
     /** @test */
     public function it_has_a_working_svg_driver()
     {
-        $imageFile = (new SvgDriver())->convertToImage($this->getTestSvg(), $this->conversion);
+        $driver = new SvgDriver();
+
+        if (!$driver->hasRequirements()) {
+            return;
+        }
+
+        $imageFile = $driver->convertToImage($this->getTestSvg(), $this->conversion);
 
         $this->assertEquals(str_replace('.svg', '.png', $this->getTestSvg()), $imageFile);
         $this->assertEquals('image/png', mime_content_type($imageFile));

--- a/tests/Conversion/BeforeConversionTest.php
+++ b/tests/Conversion/BeforeConversionTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test\Conversion;
+
+use Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriver;
+use Spatie\MediaLibrary\BeforeConversion\BeforeConversionDriverHandler;
+use Spatie\MediaLibrary\BeforeConversion\Drivers\ImageDriver;
+use Spatie\MediaLibrary\BeforeConversion\Drivers\PdfDriver;
+use Spatie\MediaLibrary\BeforeConversion\Drivers\SvgDriver;
+use Spatie\MediaLibrary\BeforeConversion\Drivers\VideoDriver;
+use Spatie\MediaLibrary\Conversion\Conversion;
+use Spatie\MediaLibrary\Media;
+use Spatie\MediaLibrary\Test\TestCase;
+
+class BeforeConversionTest extends TestCase
+{
+    protected $conversionName = 'test';
+
+    /**
+     * @var \Spatie\MediaLibrary\Conversion\Conversion
+     */
+    protected $conversion;
+
+    public function setUp()
+    {
+        $this->conversion = new Conversion($this->conversionName);
+
+        parent::setUp();
+    }
+
+    /** @test */
+    public function it_has_the_required_drivers()
+    {
+        $mediaModelDrivers = (new Media())->getBeforeConversionDrivers();
+
+        $this->assertContains(ImageDriver::class, $mediaModelDrivers);
+        $this->assertContains(PdfDriver::class, $mediaModelDrivers);
+        $this->assertContains(SvgDriver::class, $mediaModelDrivers);
+        $this->assertContains(VideoDriver::class, $mediaModelDrivers);
+    }
+
+    /** @test */
+    public function it_instantiate_the_required_drivers()
+    {
+        $mediaModelDrivers = (new Media())->getBeforeConversionDrivers();
+        $instanciatedDrivers = app(BeforeConversionDriverHandler::class)->getDrivers();
+
+        $this->assertEquals($mediaModelDrivers->count(), $instanciatedDrivers->count());
+
+        foreach ($instanciatedDrivers as $key => $driver) {
+            $this->assertTrue($mediaModelDrivers->contains(get_class($driver)));
+            $this->assertEquals($driver->getMediaType(), $key);
+        }
+    }
+
+    /** @test */
+    public function it_implements_the_before_conversion_driver_interface()
+    {
+        $instanciatedDrivers = app(BeforeConversionDriverHandler::class)->getDrivers();
+
+        foreach ($instanciatedDrivers as $driver) {
+            $this->assertContains(BeforeConversionDriver::class, class_implements($driver));
+        }
+    }
+
+    /**
+     * @test
+     * @dataProvider extensionProvider
+     */
+    public function it_can_detect_media_type_from_extension_with_drivers($extension, $type)
+    {
+        $media = new Media();
+        $media->file_name = 'test.' . $extension;
+        $this->assertEquals($type, $media->type_from_extension);
+    }
+
+    public static function extensionProvider()
+    {
+        $extensions =
+            [
+                ['jpg', (new ImageDriver())->getMediaType()],
+                ['jpeg', (new ImageDriver())->getMediaType()],
+                ['png', (new ImageDriver())->getMediaType()],
+                ['gif', (new ImageDriver())->getMediaType()],
+                ['webm', (new VideoDriver())->getMediaType()],
+                ['mov', (new VideoDriver())->getMediaType()],
+                ['mp4', (new VideoDriver())->getMediaType()],
+                ['pdf', (new PdfDriver())->getMediaType()],
+                ['svg', (new SvgDriver())->getMediaType()],
+                ['bla', Media::TYPE_OTHER],
+            ];
+
+        $capitalizedExtensions = array_map(function ($extension) {
+            $extension[0] = strtoupper($extension[0]);
+
+            return $extension;
+        }, $extensions);
+
+        return array_merge($extensions, $capitalizedExtensions);
+    }
+
+    /**
+     * @test
+     * @dataProvider mimeProvider
+     *
+     * @param string $file
+     * @param string $type
+     */
+    public function it_can_determine_the_type_from_the_mime($file, $type)
+    {
+        $media = $this->testModel->addMedia($this->getTestFilesDirectory($file))->toMediaLibrary();
+        $this->assertEquals($type, $media->type_from_mime);
+    }
+
+    public static function mimeProvider()
+    {
+        return [
+            ['image', (new ImageDriver())->getMediaType()],
+            ['test.jpg', (new ImageDriver())->getMediaType()],
+            ['test.webm', (new VideoDriver())->getMediaType()],
+            ['test.mp4', (new VideoDriver())->getMediaType()],
+            ['test.pdf', (new PdfDriver())->getMediaType()],
+            ['test.svg', (new SvgDriver())->getMediaType()],
+            ['test', Media::TYPE_OTHER],
+            ['test.txt', Media::TYPE_OTHER],
+        ];
+    }
+
+    /** @test */
+    public function image_driver_can_convert_image()
+    {
+        $imageFile = (new ImageDriver())->convertToImage($this->getTestJpg(), $this->conversion);
+
+        $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+        $this->assertEquals($this->getTestJpg(), $imageFile);
+    }
+
+    /** @test */
+    public function it_has_a_working_video_driver()
+    {
+        if (! class_exists('\\FFMpeg\\FFMpeg')) {
+            return;
+        }
+
+        $imageFile = (new VideoDriver())->convertToImage($this->getTestWebm(), $this->conversion);
+
+        $this->assertEquals(str_replace('.webm', '.jpg', $this->getTestWebm()), $imageFile);
+        $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+    }
+
+    /** @test */
+    public function it_has_a_working_pdf_driver()
+    {
+        $imageFile = (new PdfDriver())->convertToImage($this->getTestPdf(), $this->conversion);
+
+        $this->assertEquals(str_replace('.pdf', '.jpg', $this->getTestPdf()), $imageFile);
+        $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+    }
+
+    /** @test */
+    public function it_has_a_working_svg_driver()
+    {
+        $imageFile = (new SvgDriver())->convertToImage($this->getTestSvg(), $this->conversion);
+
+        $this->assertEquals(str_replace('.svg', '.png', $this->getTestSvg()), $imageFile);
+        $this->assertEquals('image/png', mime_content_type($imageFile));
+    }
+}

--- a/tests/Conversion/ConversionTest.php
+++ b/tests/Conversion/ConversionTest.php
@@ -3,7 +3,6 @@
 namespace Spatie\MediaLibrary\Test\Conversion;
 
 use Spatie\MediaLibrary\Conversion\Conversion;
-use Spatie\MediaLibrary\FileManipulator;
 use Spatie\MediaLibrary\Test\TestCase;
 
 class ConversionTest extends TestCase
@@ -223,36 +222,5 @@ class ConversionTest extends TestCase
         $this->conversion->setExtractVideoFrameAtSecond(10);
 
         $this->assertEquals(10, $this->conversion->getExtractVideoFrameAtSecond());
-    }
-
-    /** @test */
-    public function it_will_extract_a_video_thumbnail()
-    {
-        if (! class_exists('\\FFMpeg\\FFMpeg')) {
-            return;
-        }
-
-        $imageFile = (new FileManipulator())->extractVideoThumbnail($this->getTestWebm(), $this->conversion);
-
-        $this->assertEquals(str_replace('.webm', '.jpg', $this->getTestWebm()), $imageFile);
-        $this->assertEquals('image/jpeg', mime_content_type($imageFile));
-    }
-
-    /** @test */
-    public function it_will_convert_pdf_to_image()
-    {
-        $imageFile = (new FileManipulator())->convertPdfToImage($this->getTestPdf());
-
-        $this->assertEquals(str_replace('.pdf', '.jpg', $this->getTestPdf()), $imageFile);
-        $this->assertEquals('image/jpeg', mime_content_type($imageFile));
-    }
-
-    /** @test */
-    public function it_will_convert_svg_to_image()
-    {
-        $imageFile = (new FileManipulator())->convertSvgToImage($this->getTestSvg());
-
-        $this->assertEquals(str_replace('.svg', '.png', $this->getTestSvg()), $imageFile);
-        $this->assertEquals('image/png', mime_content_type($imageFile));
     }
 }

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\Test\FileAdder;
 
+use Spatie\MediaLibrary\BeforeConversion\Drivers\ImageDriver;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded;
 use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\Test\TestCase;
@@ -103,7 +104,7 @@ class IntegrationTest extends TestCase
     {
         $media = $this->testModel->addMedia($this->getTestFilesDirectory('image'))->toMediaLibrary();
 
-        $this->assertEquals(Media::TYPE_IMAGE, $media->type);
+        $this->assertEquals((new ImageDriver)->getMediaType(), $media->type);
     }
 
     /** @test */

--- a/tests/Media/GetTypeTest.php
+++ b/tests/Media/GetTypeTest.php
@@ -2,77 +2,10 @@
 
 namespace Spatie\MediaLibrary\Test\Media;
 
-use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\Test\TestCase;
 
 class GetTypeTest extends TestCase
 {
-    /**
-     * @test
-     * @dataProvider extensionProvider
-     *
-     * @param string $extension
-     * @param string $type
-     */
-    public function it_can_determine_the_type_from_the_extension($extension, $type)
-    {
-        $media = new Media();
-        $media->file_name = 'test.'.$extension;
-        $this->assertEquals($type, $media->type_from_extension);
-    }
-
-    public static function extensionProvider()
-    {
-        $extensions =
-            [
-                ['jpg', Media::TYPE_IMAGE],
-                ['jpeg', Media::TYPE_IMAGE],
-                ['png', Media::TYPE_IMAGE],
-                ['gif', Media::TYPE_IMAGE],
-                ['webm', Media::TYPE_VIDEO],
-                ['mov', Media::TYPE_VIDEO],
-                ['mp4', Media::TYPE_VIDEO],
-                ['pdf', Media::TYPE_PDF],
-                ['svg', Media::TYPE_SVG],
-                ['bla', Media::TYPE_OTHER],
-            ];
-
-        $capitalizedExtensions = array_map(function ($extension) {
-            $extension[0] = strtoupper($extension[0]);
-
-            return $extension;
-        }, $extensions);
-
-        return array_merge($extensions, $capitalizedExtensions);
-    }
-
-    /**
-     * @test
-     * @dataProvider mimeProvider
-     *
-     * @param string $file
-     * @param string $type
-     */
-    public function it_can_determine_the_type_from_the_mime($file, $type)
-    {
-        $media = $this->testModel->addMedia($this->getTestFilesDirectory($file))->toMediaLibrary();
-        $this->assertEquals($type, $media->type_from_mime);
-    }
-
-    public static function mimeProvider()
-    {
-        return [
-            ['image', Media::TYPE_IMAGE],
-            ['test', Media::TYPE_OTHER],
-            ['test.jpg', Media::TYPE_IMAGE],
-            ['test.webm', Media::TYPE_VIDEO],
-            ['test.mp4', Media::TYPE_VIDEO],
-            ['test.pdf', Media::TYPE_PDF],
-            ['test.svg', Media::TYPE_SVG],
-            ['test.txt', Media::TYPE_OTHER],
-        ];
-    }
-
     /** @test */
     public function it_can_return_the_file_mime()
     {


### PR DESCRIPTION
This PR add a driver system to simplify the extensibility of laravel-medialibrary.

#### How does it work ?

A drivers list is defined in the base `Media` model so it's easy to extend the list to add / replace any driver without extensive knowledge.

Each driver defines the following methods (has requested in the `BeforeConversionDriver` trait):

- `getMediaType`: return the media type handled by the driver (replace the current use of Media::TYPE_IMAGE...)
- `fileExtensionIsType`: verify if a file should be processed by this driver by checking its extension.
- `fileMimeIsType`: same but by checking the mime type.
- `hasRequirements`: return a bool, useful for a driver that require specific pecl / package.
- `convertToImage`: where the magic is coded.

#### Does it break things ?

The only thing that I can see is if one use the following constants that I removed `Media::TYPE_IMAGE`, `Media::TYPE_SVG`, `Media::TYPE_PDF` or `Media::TYPE_VIDEO` in its project.

#### How to add a new driver:

Create an `AudioDriver` class that implement the `BeforeConversionDriver` trait and override the `Media->getBeforeConversionDrivers` method by creating a custom Media model or directly from an Eloquent model.

