### PR TITLE
Fix for conversions not being generated on S3 filesystem

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -7,6 +7,7 @@ use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\Conversion\ConversionCollection;
 use Spatie\MediaLibrary\Helpers\File;
 use Spatie\MediaLibrary\UrlGenerator\UrlGeneratorFactory;
+use Storage;
 
 class Media extends Model
 {
@@ -128,11 +129,7 @@ class Media extends Model
      */
     public function getTypeFromMimeAttribute() : string
     {
-        if ($this->getDiskDriverName() !== 'local') {
-            return static::TYPE_OTHER;
-        }
-
-        $mime = $this->getMimeAttribute();
+        $mime = Storage::disk($this->disk)->getMimetype($this->getPath());
 
         if (in_array($mime, ['image/jpeg', 'image/gif', 'image/png'])) {
             return static::TYPE_IMAGE;

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -13,7 +13,7 @@ class S3UrlGenerator extends BaseUrlGenerator
     {
         return config('laravel-medialibrary.s3.domain').'/'.$this->getPathRelativeToRoot();
     }
-    
+
     /**
      * Get the relative path for the profile of a media item.
      *
@@ -24,5 +24,5 @@ class S3UrlGenerator extends BaseUrlGenerator
     public function getPath()
     {
         return $this->getPathRelativeToRoot();
-    }  
+    }
 }

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -13,4 +13,16 @@ class S3UrlGenerator extends BaseUrlGenerator
     {
         return config('laravel-medialibrary.s3.domain').'/'.$this->getPathRelativeToRoot();
     }
+    
+    /**
+     * Get the relative path for the profile of a media item.
+     *
+     * @return string
+     *
+     * @throws \Spatie\MediaLibrary\Exceptions\UrlCouldNotBeDeterminedException
+     */
+    public function getPath()
+    {
+        return $this->getPathRelativeToRoot();
+    }  
 }


### PR DESCRIPTION
This is a proposed fix for issue #325 . Basically, the Spatie\MediaLibrary\FileManipulator::createDerivedFiles() method was returning early without creating any conversions because the package could not determine the mime type for a file located on S3.