### PR TITLE
Fix s3 bug on 4.9.1

### DIFF
--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -129,10 +129,8 @@ class FileManipulator
      */
     public function determineImageGenerator(Media $media)
     {
-        $isLocal = $media->getDiskDriverName() === 'local';
-
         $imageGenerators = $media->getImageGenerators()
-            ->map(function (string $imageGeneratorClassName) use ($isLocal) {
+            ->map(function (string $imageGeneratorClassName) {
                 return app($imageGeneratorClassName);
             });
 

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -133,7 +133,7 @@ class FileManipulator
 
         $imageGenerators = $media->getImageGenerators()
             ->map(function (string $imageGeneratorClassName) use ($isLocal) {
-                return app($imageGeneratorClassName)->shouldCheckMime($isLocal);
+                return app($imageGeneratorClassName);
             });
 
         foreach ($imageGenerators as $imageGenerator) {

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -129,13 +129,15 @@ class FileManipulator
      */
     public function determineImageGenerator(Media $media)
     {
+        $isLocal = $media->getDiskDriverName() === 'local';
+
         $imageGenerators = $media->getImageGenerators()
-            ->map(function (string $imageGeneratorClassName) {
-                return app($imageGeneratorClassName);
+            ->map(function (string $imageGeneratorClassName) use ($isLocal) {
+                return app($imageGeneratorClassName)->shouldCheckMime($isLocal);
             });
 
         foreach ($imageGenerators as $imageGenerator) {
-            if ($imageGenerator->canConvert($media->getPath())) {
+            if ($imageGenerator->canConvert($media)) {
                 return $imageGenerator;
             }
         }

--- a/src/ImageGenerators/BaseGenerator.php
+++ b/src/ImageGenerators/BaseGenerator.php
@@ -20,7 +20,7 @@ abstract class BaseGenerator implements ImageGenerator
 
         if (method_exists($media, 'getPath') && file_exists($media->getPath())
             && $this->supportedMimetypes()->contains(File::getMimetype($media->getPath()))) {
-                return true;
+            return true;
         }
 
         return false;

--- a/src/ImageGenerators/BaseGenerator.php
+++ b/src/ImageGenerators/BaseGenerator.php
@@ -4,24 +4,24 @@ namespace Spatie\MediaLibrary\ImageGenerators;
 
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Helpers\File;
+use Spatie\MediaLibrary\Media;
 
 abstract class BaseGenerator implements ImageGenerator
 {
-    public function canConvert(string $path): bool
-    {
-        if (! file_exists($path)) {
-            return false;
-        }
+    protected $shouldCheckMime = true;
 
+    public function canConvert(Media $media): bool
+    {
         if (! $this->requirementsAreInstalled()) {
             return false;
         }
 
-        if ($this->supportedExtensions()->contains(pathinfo($path, PATHINFO_EXTENSION))) {
+        if ($this->supportedExtensions()->contains($media->getExtensionAttribute())) {
             return true;
         }
 
-        if ($this->supportedMimetypes()->contains(File::getMimetype($path))) {
+        if ($this->shouldCheckMime && file_exists($media->getPath())
+            && $this->supportedMimetypes()->contains(File::getMimetype($media->getPath()))) {
             return true;
         }
 
@@ -41,6 +41,13 @@ abstract class BaseGenerator implements ImageGenerator
     public function getType(): string
     {
         return strtolower(class_basename(static::class));
+    }
+
+    public function shouldCheckMime(bool $shouldCheckMime)
+    {
+        $this->shouldCheckMime = $shouldCheckMime;
+
+        return $this;
     }
 
     abstract public function requirementsAreInstalled(): bool;

--- a/src/ImageGenerators/BaseGenerator.php
+++ b/src/ImageGenerators/BaseGenerator.php
@@ -8,21 +8,19 @@ use Spatie\MediaLibrary\Media;
 
 abstract class BaseGenerator implements ImageGenerator
 {
-    protected $shouldCheckMime = true;
-
     public function canConvert(Media $media): bool
     {
         if (! $this->requirementsAreInstalled()) {
             return false;
         }
 
-        if ($this->supportedExtensions()->contains($media->getExtensionAttribute())) {
+        if ($this->supportedExtensions()->contains($media->extension)) {
             return true;
         }
 
-        if ($this->shouldCheckMime && file_exists($media->getPath())
+        if (method_exists($media, 'getPath') && file_exists($media->getPath())
             && $this->supportedMimetypes()->contains(File::getMimetype($media->getPath()))) {
-            return true;
+                return true;
         }
 
         return false;
@@ -41,13 +39,6 @@ abstract class BaseGenerator implements ImageGenerator
     public function getType(): string
     {
         return strtolower(class_basename(static::class));
-    }
-
-    public function shouldCheckMime(bool $shouldCheckMime)
-    {
-        $this->shouldCheckMime = $shouldCheckMime;
-
-        return $this;
     }
 
     abstract public function requirementsAreInstalled(): bool;

--- a/src/ImageGenerators/ImageGenerator.php
+++ b/src/ImageGenerators/ImageGenerator.php
@@ -3,10 +3,11 @@
 namespace Spatie\MediaLibrary\ImageGenerators;
 
 use Spatie\MediaLibrary\Conversion\Conversion;
+use Spatie\MediaLibrary\Media;
 
 interface ImageGenerator
 {
-    public function canConvert(string $path);
+    public function canConvert(Media $media);
 
     /**
      * Receive a file and return a thumbnail in jpg/png format.

--- a/tests/ImageGenerators/ImageTest.php
+++ b/tests/ImageGenerators/ImageTest.php
@@ -14,7 +14,7 @@ class ImageTest extends TestCase
 
         $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaLibrary();
 
-        $this->assertTrue($imageGenerator->canConvert($media->getPath()));
+        $this->assertTrue($imageGenerator->canConvert($media));
 
         $imageFile = $imageGenerator->convert($media->getPath());
 

--- a/tests/ImageGenerators/PdfTest.php
+++ b/tests/ImageGenerators/PdfTest.php
@@ -18,7 +18,7 @@ class PdfTest extends TestCase
 
         $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestPdf())->toMediaLibrary();
 
-        $this->assertTrue($imageGenerator->canConvert($media->getPath()));
+        $this->assertTrue($imageGenerator->canConvert($media));
 
         $imageFile = $imageGenerator->convert($media->getPath());
 

--- a/tests/ImageGenerators/SvgTest.php
+++ b/tests/ImageGenerators/SvgTest.php
@@ -18,7 +18,7 @@ class SvgTest extends TestCase
 
         $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestSvg())->toMediaLibrary();
 
-        $this->assertTrue($imageGenerator->canConvert($media->getPath()));
+        $this->assertTrue($imageGenerator->canConvert($media));
 
         $imageFile = $imageGenerator->convert($media->getPath());
 

--- a/tests/ImageGenerators/VideoTest.php
+++ b/tests/ImageGenerators/VideoTest.php
@@ -19,7 +19,7 @@ class VideoTest extends TestCase
 
         $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestWebm())->toMediaLibrary();
 
-        $this->assertTrue($imageGenerator->canConvert($media->getPath()));
+        $this->assertTrue($imageGenerator->canConvert($media));
 
         $imageFile = $imageGenerator->convert($media->getPath(), new Conversion('test'));
 


### PR DESCRIPTION
Should fix #359 

as @bakrpx mentioned in the issue the media->getPath()` method didn't existed for s3.

What I did to fix the bug is simply generating the original file copy on disk before checking if we can convert it, so we could always give a local path to `determineImageGenerator`.

It isn't the most efficient as a temp file will be created even if we can't convert the file, but it should work with all remote filesystem