### PR TITLE
Remove unused supportedTypes method from image generators

### DIFF
--- a/src/ImageGenerators/FileTypes/Image.php
+++ b/src/ImageGenerators/FileTypes/Image.php
@@ -27,9 +27,4 @@ class Image extends BaseGenerator
     {
         return collect(['image/jpeg', 'image/gif', 'image/png']);
     }
-
-    public function supportedTypes() : Collection
-    {
-        return collect('image');
-    }
 }

--- a/src/ImageGenerators/FileTypes/Pdf.php
+++ b/src/ImageGenerators/FileTypes/Pdf.php
@@ -39,9 +39,4 @@ class Pdf extends BaseGenerator
     {
         return collect(['application/pdf']);
     }
-
-    public function supportedTypes() : Collection
-    {
-        return collect('pdf');
-    }
 }

--- a/src/ImageGenerators/FileTypes/Svg.php
+++ b/src/ImageGenerators/FileTypes/Svg.php
@@ -37,9 +37,4 @@ class Svg extends BaseGenerator
     {
         return collect('image/svg+xml');
     }
-
-    public function supportedTypes() : Collection
-    {
-        return collect('svg');
-    }
 }

--- a/src/ImageGenerators/FileTypes/Video.php
+++ b/src/ImageGenerators/FileTypes/Video.php
@@ -42,9 +42,4 @@ class Video extends BaseGenerator
     {
         return collect(['video/webm', 'video/mpeg', 'video/mp4', 'video/quicktime']);
     }
-
-    public function supportedTypes() : Collection
-    {
-        return collect('video');
-    }
 }


### PR DESCRIPTION
I was writing the doc for creating custom generators and noticed the `supportedTypes` isn't used anywhere on the project.