### PR TITLE
Allow custom job classes.

### DIFF
--- a/config/laravel-medialibrary.php
+++ b/config/laravel-medialibrary.php
@@ -21,6 +21,11 @@ return [
     'queue_name' => '',
 
     /*
+     * The class to use for the queue job to convert media.
+     */
+    'queue_job_class' => \Spatie\MediaLibrary\Jobs\PerformConversions::class,
+
+    /*
      * The class name of the media model to be used.
      */
     'media_model' => Spatie\MediaLibrary\Media::class,

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -111,7 +111,8 @@ class FileManipulator
      */
     protected function dispatchQueuedConversions(Media $media, ConversionCollection $queuedConversions)
     {
-        $job = new PerformConversions($queuedConversions, $media);
+        $jobClass = config('laravel-medialibrary.queue_job_class', PerformConversions::class);
+        $job = new $jobClass($queuedConversions, $media);
 
         $customQueue = config('laravel-medialibrary.queue_name');
 


### PR DESCRIPTION
If someone is using an alternate bus package that allows non-selfhandling jobs, the current job will fail in these situations. This modification allows developers to override the job class itself to support alternate busses by extending the internal job.

The change is non-breaking since it defaults to the internal job even if the config key is not defined respecting existing rollouts.