### PR TITLE
Fix s3 conversion (undefined getPath method)

### DIFF
--- a/src/ImageGenerators/BaseGenerator.php
+++ b/src/ImageGenerators/BaseGenerator.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary\ImageGenerators;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Helpers\File;
 use Spatie\MediaLibrary\Media;
+use Spatie\MediaLibrary\UrlGenerator\UrlGeneratorFactory;
 
 abstract class BaseGenerator implements ImageGenerator
 {
@@ -18,7 +19,9 @@ abstract class BaseGenerator implements ImageGenerator
             return true;
         }
 
-        if (method_exists($media, 'getPath') && file_exists($media->getPath())
+        $urlGenerator = UrlGeneratorFactory::createForMedia($media);
+
+        if (method_exists($urlGenerator, 'getPath') && file_exists($media->getPath())
             && $this->supportedMimetypes()->contains(strtolower(File::getMimetype($media->getPath())))) {
             return true;
         }

--- a/src/Media.php
+++ b/src/Media.php
@@ -4,14 +4,14 @@ namespace Spatie\MediaLibrary;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use Spatie\MediaLibrary\Conversion\Conversion;
+use Spatie\MediaLibrary\Conversion\ConversionCollection;
+use Spatie\MediaLibrary\Helpers\File;
 use Spatie\MediaLibrary\ImageGenerators\FileTypes\Image;
 use Spatie\MediaLibrary\ImageGenerators\FileTypes\Pdf;
 use Spatie\MediaLibrary\ImageGenerators\FileTypes\Svg;
 use Spatie\MediaLibrary\ImageGenerators\FileTypes\Video;
-use Spatie\MediaLibrary\ImageGenerators\ImageGenerator;
-use Spatie\MediaLibrary\Conversion\Conversion;
-use Spatie\MediaLibrary\Conversion\ConversionCollection;
-use Spatie\MediaLibrary\Helpers\File;
 use Spatie\MediaLibrary\UrlGenerator\UrlGeneratorFactory;
 
 class Media extends Model
@@ -140,10 +140,6 @@ class Media extends Model
      */
     public function getTypeFromMimeAttribute() : string
     {
-        if ($this->getDiskDriverName() !== 'local') {
-            return static::TYPE_OTHER;
-        }
-
         $imageGenerators = $this->getImageGenerators()
             ->map(function (string $className) {
                 return app($className);

--- a/src/Media.php
+++ b/src/Media.php
@@ -4,7 +4,6 @@ namespace Spatie\MediaLibrary;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Storage;
 use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\Conversion\ConversionCollection;
 use Spatie\MediaLibrary\Helpers\File;

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\MediaLibrary\Test\FileAdder;
 
-use Spatie\MediaLibrary\ImageGenerators\FileTypes\Image;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded;
 use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\Test\TestCase;


### PR DESCRIPTION
I reworked #329, I tested it on a new project against a real s3 bucket.

Is there a way to perform some basic unit test with files on s3 (at least upload, conversion & url generation) ? I know that we should not test "s3" itself but part of the medialibrary code is different for local and remote files, which caused some major bug on the lasts versions.

What is your thought on this ?


 