### PR TITLE
v3 - Laravel 5.3 + PHP 5

### DIFF
--- a/src/Conversion/ConversionCollection.php
+++ b/src/Conversion/ConversionCollection.php
@@ -38,7 +38,7 @@ class ConversionCollection extends Collection
      */
     public function getByName($name)
     {
-        $conversion = $this->first(function ($key, Conversion $conversion) use ($name) {
+        $conversion = $this->first(function (Conversion $conversion, $key) use ($name) {
             return $conversion->getName() == $name;
         });
 

--- a/src/Jobs/PerformConversions.php
+++ b/src/Jobs/PerformConversions.php
@@ -4,13 +4,12 @@ namespace Spatie\MediaLibrary\Jobs;
 
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Bus\SelfHandling;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Spatie\MediaLibrary\Conversion\ConversionCollection;
 use Spatie\MediaLibrary\FileManipulator;
 use Spatie\MediaLibrary\Media;
 
-class PerformConversions extends Job implements SelfHandling, ShouldQueue
+class PerformConversions extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
 


### PR DESCRIPTION
Very simple fixes to allow v3 branch to be used with Laravel 5.3 + PHP 5 (we cant quite move to php 7 yet).