### PR TITLE
Add custom remote headers on runtime logic

### DIFF
--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -235,15 +235,15 @@ class FileAdder
     }
 
     /**
-     * Set additional custom remote headers.
+     * Add additional custom remote headers.
      *
      * @param array $customRemoteHeaders
      *
      * @return $this
      */
-    public function setCustomRemoteHeaders(array $customRemoteHeaders)
+    public function addCustomRemoteHeaders(array $customRemoteHeaders)
     {
-        $this->filesystem->setCustomRemoteHeaders($customRemoteHeaders);
+        $this->filesystem->addCustomRemoteHeaders($customRemoteHeaders);
 
         return $this;
     }

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -235,6 +235,20 @@ class FileAdder
     }
 
     /**
+     * Set additional custom remote headers.
+     *
+     * @param array $customRemoteHeaders
+     *
+     * @return $this
+     */
+    public function setCustomRemoteHeaders(array $customRemoteHeaders)
+    {
+        $this->filesystem->setCustomRemoteHeaders($customRemoteHeaders);
+
+        return $this;
+    }
+
+    /**
      * Set the target media collection to default.
      * Will also start the import process.
      *

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -21,6 +21,11 @@ class Filesystem
     protected $config;
 
     /**
+     * @var array
+     */
+    protected $customRemoteHeaders = [];
+
+    /**
      * @param \Illuminate\Contracts\Filesystem\Factory $filesystems
      * @param \Illuminate\Contracts\Config\Repository  $config
      */
@@ -64,6 +69,16 @@ class Filesystem
             ->put($destination, fopen($file, 'r+'), $this->getRemoteHeadersForFile($file));
     }
 
+    /**
+     * Set custom remote headers on runtime.
+     *
+     * @param array $customRemoteHeaders
+     */
+    public function setCustomRemoteHeaders(array $customRemoteHeaders)
+    {
+        $this->customRemoteHeaders = $customRemoteHeaders;
+    }
+
     /*
      * Get the headers to be used when copying the
      * given file to a remote filesytem.
@@ -74,7 +89,7 @@ class Filesystem
 
         $extraHeaders = $this->config->get('laravel-medialibrary.remote.extra_headers');
 
-        return array_merge($mimeTypeHeader, $extraHeaders);
+        return array_merge($mimeTypeHeader, $extraHeaders, $this->customRemoteHeaders);
     }
 
     /*

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -70,11 +70,11 @@ class Filesystem
     }
 
     /**
-     * Set custom remote headers on runtime.
+     * Add custom remote headers on runtime.
      *
      * @param array $customRemoteHeaders
      */
-    public function setCustomRemoteHeaders(array $customRemoteHeaders)
+    public function addCustomRemoteHeaders(array $customRemoteHeaders)
     {
         $this->customRemoteHeaders = $customRemoteHeaders;
     }

--- a/tests/FileSystem/FileSystemTest.php
+++ b/tests/FileSystem/FileSystemTest.php
@@ -32,4 +32,41 @@ class FileSystemTest extends TestCase
             $this->filesystem->getRemoteHeadersForFile($this->getTestJpg())
         );
     }
+
+    /** @test */
+    public function it_can_add_custom_headers_for_file_that_will_be_copied_to_an_external_filesytem()
+    {
+        $this->filesystem->addCustomRemoteHeaders([
+            'ACL' => 'public-read',
+        ]);
+
+        $expectedHeaders = [
+            'ContentType' => 'image/jpeg',
+            'CacheControl' => 'max-age=604800',
+            'ACL' => 'public-read',
+        ];
+
+        $this->assertEquals(
+            $expectedHeaders,
+            $this->filesystem->getRemoteHeadersForFile($this->getTestJpg())
+        );
+    }
+
+    /** @test */
+    public function it_can_override_config_custom_headers_for_file_that_will_be_copied_to_an_external_filesytem()
+    {
+        $this->filesystem->addCustomRemoteHeaders([
+            'CacheControl' => 'max-age=302400',
+        ]);
+
+        $expectedHeaders = [
+            'ContentType' => 'image/jpeg',
+            'CacheControl' => 'max-age=302400',
+        ];
+
+        $this->assertEquals(
+            $expectedHeaders,
+            $this->filesystem->getRemoteHeadersForFile($this->getTestJpg())
+        );
+    }
 }


### PR DESCRIPTION
This is a quick hack that corresponds to #406.

I feel like `customRemoteHeaders` belongs to the `Filesystem` since it gets used there.
However, it should (optionally) get set on each file and the user never gets to set params on the `Filesystem`. Therefore the setter is located within the `FileAdder` which in turn sets the values in `$filesystem`

Example: 
```
$user->addMediaFromUrl('https://docs.spatie.be/images/medialibrary/header.jpg')
                ->setCustomRemoteHeaders([
                    'ACL' => 'public-read',
                ])
                ->toCollectionOnDisk('profile_images', 's3-media');
```

If this approach makes any sense, I'd also add some tests.  
Cheers