### PR TITLE
Feature/reduce s3 http calls

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -128,7 +128,9 @@ class Filesystem
             $pathGenerator->getPathForConversions($media) :
             $pathGenerator->getPath($media);
 
-        $this->filesystem->disk($media->disk)->makeDirectory($directory);
+        if(! in_array($media->getDiskDriverName(), ['s3'], true)) {
+            $this->filesystem->disk($media->disk)->makeDirectory($directory);
+        }
 
         return $directory;
     }

--- a/src/Media.php
+++ b/src/Media.php
@@ -170,7 +170,7 @@ class Media extends Model
 
     public function getDiskDriverName() : string
     {
-        return config("filesystems.disks.{$this->disk}.driver");
+        return strtolower(config("filesystems.disks.{$this->disk}.driver"));
     }
 
     /*


### PR DESCRIPTION
For #405 

After I dug a little bit more, I ended up putting this in the `getMediaDirectory` method after all.

Quick wrap-up:

On various occasions the method `getMediaDirectory` gets called.
In my opinion its main task is to determine the directory path name.
However, it also calls `$this->filesystem->disk($media->disk)->makeDirectory($directory);`. Therefor it guarantees that the directory name returned will physically be a folder on the disk.
This makes sense for the `local` filesystem, but is redundant/non-essential for `s3` disks.
Media/files can get pushed to non-existing "folders" (_i assume they aren't real folders on s3_) on s3 - AWS takes care of everything.

## Pros:

1. Skipping `$this->filesystem->disk($media->disk)->makeDirectory($directory);` for s3 disks reduces up-to 50% HTTP calls to S3 for a file association and thus improves performance.

2. Allegedly making empty directories in S3 or treating object storages as POSIX is bad practice.  (I've heard - cannot prove)

3. I couldn't come up with a scenario where this might be a breaking change. 

## Cons:

1. If the file upload is corrupt, but the preceding `makeDirectory` succeeds, there won't be any empty folders on S3 (I don't even know if this is a con. I was just looking for something 😄)

### Extra Info:

As I mentioned in the issue, I think that this performance improvement also works for `rackspace`. This is the reason why I'm using `in_array`. But I didn't add `rackspace` to the array because I don't have an account an therefore cannot test it.

I've tested it personally and everything worked fine for me.
Each test works on his own, but fail when running in series:

```
1) Spatie\MediaLibrary\Test\FileAdder\S3IntegrationTest::it_store_a_file_on_s3
 ErrorException: unlink(/var/www/html/tests/temp/testfiles/test.jpg): Text file busy

 /var/www/html/src/FileAdder/FileAdder.php:347
 /var/www/html/src/FileAdder/FileAdder.php:265
 /var/www/html/tests/S3Integration/S3IntegrationTest.php:36

 2) Spatie\MediaLibrary\Test\FileAdder\S3IntegrationTest::it_store_a_file_and_its_conversion_on_s3
 ErrorException: mkdir(): File exists

 /var/www/html/vendor/laravel/framework/src/Illuminate/Filesystem/Filesystem.php:337
 /var/www/html/vendor/illuminate/support/Facades/Facade.php:215
 /var/www/html/tests/TestCase.php:120
 /var/www/html/tests/TestCase.php:63
 /var/www/html/vendor/orchestra/testbench/src/Traits/ApplicationTrait.php:101
 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Testing/ApplicationTrait.php:34
 /var/www/html/vendor/orchestra/testbench/src/TestCase.php:43
 /var/www/html/tests/TestCase.php:34
 /var/www/html/tests/S3Integration/S3IntegrationTest.php:13
```

Cheers