### PR TITLE
Remove realpath() from getStoragePath

### DIFF
--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -54,7 +54,7 @@ class LocalUrlGenerator extends BaseUrlGenerator
     {
         $diskRootPath = $this->config->get('filesystems.disks.'.$this->media->disk.'.root');
 
-        return realpath($diskRootPath);
+        return $diskRootPath;
     }
 
     protected function makeCompatibleForNonUnixHosts(string $url) : string


### PR DESCRIPTION
Remove realpath() from the return in LocalUrlGenerator::getStoragePath() to avoid creating custom URL's for linked storages