### PR TITLE
Fix HasMediaTrait inconsistency on hasMedia and getMedia

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -108,7 +108,7 @@ trait HasMediaTrait
     /*
      * Determine if there is media in the given collection.
      */
-    public function hasMedia(string $collectionName = '') : bool
+    public function hasMedia(string $collectionName = 'default') : bool
     {
         return count($this->getMedia($collectionName)) ? true : false;
     }
@@ -121,7 +121,7 @@ trait HasMediaTrait
      *
      * @return \Illuminate\Support\Collection
      */
-    public function getMedia(string $collectionName = '', $filters = []) : Collection
+    public function getMedia(string $collectionName = 'default', $filters = []) : Collection
     {
         return app(MediaRepository::class)->getCollection($this, $collectionName, $filters);
     }


### PR DESCRIPTION
Hi guys!

I'm using your awesome library but there's some inconsistencies.

Consider this basic scenario:
```php
$model->addMedia($request->file('picture'))->toCollection();
```

By default, `toCollection` appends the file to the collection named `default`.

If I want to check if the file was added I do:
```php
$model->hasMedia();
```

But, methods `hasMedia` and `getMedia` are checking by default a collection named ` ` and return false.

My pull request fix that for more consistency.