### PR TITLE
Avoid creating / deleting temp dir if no conversions should be performed

### DIFF
--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -43,7 +43,7 @@ class FileManipulator
     {
         $imageGenerator = $this->determineImageGenerator($media);
 
-        if (! $imageGenerator) {
+        if (! $imageGenerator || $conversions->isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
Skip the creation of the temp dir, media copy to temp and temp dir delete if no conversions are found for a media.