### PR TITLE
Conversions are always regenerated

### DIFF
--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -22,7 +22,7 @@ class MediaObserver
             return;
         }
 
-        if ($media->manipulations !== $media->getOriginal('manipulations')) {
+        if ($media->manipulations !== json_decode($media->getOriginal('manipulations'))) {
             app(FileManipulator::class)->createDerivedFiles($media);
         }
     }


### PR DESCRIPTION
The check in the `MediaObserver` to see if the manipulations have changed always returns true, since `$media->manipulations` is casted to an array by eloquent but `getOriginal()` isn't.
This causes new derived-files to be generated even if just the filename or the order has changed.
Since there is no option method to let eloquent do the casting I used json_decode as this is exactly what eloquent does.

Unfortunately I could not figure out how to write a test for this without sleeping for 1 second and comparing timestamps. So I did not add it to the testsuite but here it is:

Spatie\MediaLibrary\Test\HasMediaConversionsTrait\AddMediaTest
```php
    /** @test */
    public function it_will_not_create_a_derived_version_if_manipulations_did_not_change()
    {
        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toCollection('images');

        $fileChangedTime = filemtime($this->getMediaDirectory($media->id.'/conversions/thumb.jpg'));

        sleep(1);
        $media->order_column = $media->order_column+1;
        $media->save();

        $this->assertEquals($fileChangedTime, filemtime($this->getMediaDirectory($media->id.'/conversions/thumb.jpg')));

    }
```