### PR TITLE
Allow the Filesystem class to be overridden

### DIFF
--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -3,9 +3,9 @@
 namespace Spatie\MediaLibrary\FileAdder;
 
 use Spatie\MediaLibrary\Media;
-use Spatie\MediaLibrary\Filesystem;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Cache\Repository;
+use Spatie\MediaLibrary\FilesystemInterface;
 use Symfony\Component\HttpFoundation\File\File;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -18,7 +18,7 @@ class FileAdder
     protected $subject;
 
     /**
-     * @var Filesystem
+     * @var FilesystemInterface
      */
     protected $filesystem;
 
@@ -68,10 +68,10 @@ class FileAdder
     protected $diskName = '';
 
     /**
-     * @param Filesystem $fileSystem
+     * @param FilesystemInterface $fileSystem
      * @param Repository $config
      */
-    public function __construct(Filesystem $fileSystem, Repository $config)
+    public function __construct(FilesystemInterface $fileSystem, Repository $config)
     {
         $this->filesystem = $fileSystem;
         $this->config = $config;

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -51,7 +51,7 @@ class FileManipulator
 
         $copiedOriginalFile = $tempDirectory.'/'.str_random(16).'.'.$media->extension;
 
-        app(Filesystem::class)->copyFromMediaLibrary($media, $copiedOriginalFile);
+        app(FilesystemInterface::class)->copyFromMediaLibrary($media, $copiedOriginalFile);
 
         foreach ($conversions as $conversion) {
             $copiedOriginalFile = $imageGenerator->convert($copiedOriginalFile, $conversion);
@@ -61,7 +61,7 @@ class FileManipulator
             $renamedFile = MediaLibraryFileHelper::renameInDirectory($conversionResult, $conversion->getName().'.'.
                 $conversion->getResultExtension(pathinfo($copiedOriginalFile, PATHINFO_EXTENSION)));
 
-            app(Filesystem::class)->copyToMediaLibrary($renamedFile, $media, true);
+            app(FilesystemInterface::class)->copyToMediaLibrary($renamedFile, $media, true);
 
             event(new ConversionHasBeenCompleted($media, $conversion));
         }

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -8,7 +8,7 @@ use Spatie\MediaLibrary\Events\MediaHasBeenAdded;
 use Spatie\MediaLibrary\PathGenerator\PathGeneratorFactory;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 
-class Filesystem
+class Filesystem implements FilesystemInterface
 {
     /**
      * @var \Illuminate\Contracts\Filesystem\Factory

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\MediaLibrary;
+
+interface FilesystemInterface
+{
+    public function add(string $file, Media $media, string $targetFileName = '');
+
+    public function copyToMediaLibrary(string $file, Media $media, bool $conversions = false, string $targetFileName = '');
+
+    public function addCustomRemoteHeaders(array $customRemoteHeaders);
+
+    public function getRemoteHeadersForFile(string $file) : array;
+
+    public function copyFromMediaLibrary(Media $media, string $targetFile);
+
+    public function removeFiles(Media $media);
+
+    public function renameFile(Media $media, string $oldName);
+
+    public function getMediaDirectory(Media $media, bool $conversion = false) : string;
+
+    public function getConversionDirectory(Media $media) : string;
+}

--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -4,8 +4,8 @@ namespace Spatie\MediaLibrary\HasMedia;
 
 use Spatie\MediaLibrary\Media;
 use Illuminate\Support\Collection;
-use Spatie\MediaLibrary\Filesystem;
 use Spatie\MediaLibrary\MediaRepository;
+use Spatie\MediaLibrary\FilesystemInterface;
 use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\FileAdder\FileAdderFactory;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded;
@@ -241,7 +241,7 @@ trait HasMediaTrait
     public function clearMediaCollection(string $collectionName = 'default')
     {
         $this->getMedia($collectionName)->map(function (Media $media) {
-            app(Filesystem::class)->removeFiles($media);
+            app(FilesystemInterface::class)->removeFiles($media);
             $media->delete();
         });
 

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -57,6 +57,8 @@ class MediaLibraryServiceProvider extends ServiceProvider
         $this->app->bind('command.medialibrary:clear', ClearCommand::class);
         $this->app->bind('command.medialibrary:clean', CleanCommand::class);
 
+        $this->app->bind(FilesystemInterface::class, Filesystem::class);
+
         $this->commands([
             'command.medialibrary:regenerate',
             'command.medialibrary:clear',

--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -12,7 +12,7 @@ class MediaObserver
     public function updating(Media $media)
     {
         if ($media->file_name !== $media->getOriginal('file_name')) {
-            app(Filesystem::class)->renameFile($media, $media->getOriginal('file_name'));
+            app(FilesystemInterface::class)->renameFile($media, $media->getOriginal('file_name'));
         }
     }
 
@@ -29,6 +29,6 @@ class MediaObserver
 
     public function deleted(Media $media)
     {
-        app(Filesystem::class)->removeFiles($media);
+        app(FilesystemInterface::class)->removeFiles($media);
     }
 }


### PR DESCRIPTION
Like some other folks mentioned in the issues, I would like to bypass the restriction of placing a single media object in a single directory. Although placing multiple objects in a single directory is no problem, deleting an object *is* since the whole directory is deleted.

My workaround is quite simple: define a FilesystemInterface and bind that to the service container. Now users can bind their own implementation of the interface to extend or alter the behavior of the default Filesystem class. As far as I can see this has no real downsides or compatibility problems while increasing flexibility.

The Filesystem implementation that should be used can also be configurable, like it is for the Media model already. I have not included this in my PR but I would happily add it.

I'm curious how you look at this @freekmurze. 

Cheers,

Barry