### PR TITLE
Fix: getFirstMediaUrl() only returns first conversion

### DIFF
--- a/src/Conversion/ConversionCollection.php
+++ b/src/Conversion/ConversionCollection.php
@@ -49,8 +49,8 @@ class ConversionCollection extends Collection
      */
     public function getByName(string $name)
     {
-        $conversion = $this->first(function (Conversion $conversion) {
-            return $conversion->getName();
+        $conversion = $this->first(function (Conversion $conversion) use ($name) {
+            return $conversion->getName() === $name;
         });
 
         if (! $conversion) {


### PR DESCRIPTION
This fixes ```getFirstMediaUrl()``` from always returning the first defined media conversion.

Here is what was happening:
```
<img src="{{ $item->getFirstMediaUrl('product', 'sm') }}">
// conversions/sm.jpg

<img src="{{ $item->getFirstMediaUrl('product', 'md') }}">
// conversions/sm.jpg

<img src="{{ $item->getFirstMediaUrl('product', 'lg') }}">
// conversions/sm.jpg
```

Also, my first ever pull request. Hope I did okay!