### PR TITLE
Add getFullUrl method

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -38,6 +38,20 @@ class Media extends Model
     }
 
     /**
+     * Get the full url to a original media file.
+     *
+     * @param string $conversionName
+     *
+     * @return string
+     *
+     * @throws \Spatie\MediaLibrary\Exceptions\InvalidConversion
+     */
+    public function getFullUrl(string $conversionName = ''): string
+    {
+        return url($this->getUrl($conversionName));
+    }
+    
+    /**
      * Get the url to a original media file.
      *
      * @param string $conversionName

--- a/tests/Media/GetFullUrlTest.php
+++ b/tests/Media/GetFullUrlTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test\Media;
+
+use Spatie\MediaLibrary\Test\TestCase;
+use Spatie\MediaLibrary\Exceptions\InvalidConversion;
+
+class GetFullUrlTest extends TestCase
+{
+    /** @test */
+    public function it_can_get_an_url_of_an_original_item()
+    {
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+
+        $this->assertEquals($media->getFullUrl(), "http://localhost/media/{$media->id}/test.jpg");
+    }
+
+    /** @test */
+    public function it_can_get_an_url_of_a_derived_image()
+    {
+        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibrary();
+
+        $conversionName = 'thumb';
+
+        $this->assertEquals("http://localhost/media/{$media->id}/conversions/{$conversionName}.jpg", $media->getFullUrl($conversionName));
+    }
+
+    /** @test */
+    public function it_returns_an_exception_when_getting_an_url_for_an_unknown_conversion()
+    {
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+
+        $this->expectException(InvalidConversion::class);
+
+        $media->getFullUrl('unknownConversionName');
+    }
+
+    /** @test */
+    public function it_wil_url_encode_the_file_name_when_generating_an_url()
+    {
+        $this->testModel->addMedia($this->getTestFilesDirectory('test with space.jpg'))->toMediaLibrary();
+
+        $this->assertEquals('http://localhost/media/1/test%20with%20space.jpg', $this->testModel->getFirstMediaUrl());
+    }
+}


### PR DESCRIPTION
Just a small helper method which could be used instead of having to do `{{ url($post->images[0]->getUrl()) }}` you could do `{{ $post->images[0]->getFullUrl() }}`.

I am currently building an API which returns full urls to media objects and see myself constantly doing `url($image->getUrl())` in Transformers and Services. Think it would be more consistent to have a `getUrl` and `getFullUrl` method to handle both cases where you want the relative or full url.