### PR TITLE
Cleaned up canConvert in BaseGenerator

### DIFF
--- a/src/Filesystem/DefaultFilesystem.php
+++ b/src/Filesystem/DefaultFilesystem.php
@@ -42,10 +42,14 @@ class DefaultFilesystem implements Filesystem
         $destination = $this->getMediaDirectory($media, $conversions).
             ($targetFileName == '' ? pathinfo($file, PATHINFO_BASENAME) : $targetFileName);
 
+        $filePointer = fopen($file, 'r');
+
         if ($media->getDiskDriverName() === 'local') {
             $this->filesystem
                 ->disk($media->disk)
-                ->put($destination, fopen($file, 'r'));
+                ->put($destination, $filePointer);
+
+            fclose($filePointer);
 
             return;
         }
@@ -53,7 +57,9 @@ class DefaultFilesystem implements Filesystem
         $this->filesystem
             ->disk($media->disk)
             ->getDriver()
-            ->put($destination, fopen($file, 'r'), $this->getRemoteHeadersForFile($file));
+            ->put($destination, $filePointer, $this->getRemoteHeadersForFile($file));
+        
+        fclose($filePointer);
     }
 
     /**

--- a/src/Filesystem/DefaultFilesystem.php
+++ b/src/Filesystem/DefaultFilesystem.php
@@ -58,7 +58,7 @@ class DefaultFilesystem implements Filesystem
             ->disk($media->disk)
             ->getDriver()
             ->put($destination, $filePointer, $this->getRemoteHeadersForFile($file));
-        
+
         fclose($filePointer);
     }
 

--- a/src/ImageGenerators/BaseGenerator.php
+++ b/src/ImageGenerators/BaseGenerator.php
@@ -4,8 +4,6 @@ namespace Spatie\MediaLibrary\ImageGenerators;
 
 use Spatie\MediaLibrary\Media;
 use Illuminate\Support\Collection;
-use Spatie\MediaLibrary\Helpers\File;
-use Spatie\MediaLibrary\UrlGenerator\UrlGeneratorFactory;
 
 abstract class BaseGenerator implements ImageGenerator
 {

--- a/src/ImageGenerators/BaseGenerator.php
+++ b/src/ImageGenerators/BaseGenerator.php
@@ -19,15 +19,7 @@ abstract class BaseGenerator implements ImageGenerator
             return true;
         }
 
-        $urlGenerator = UrlGeneratorFactory::createForMedia($media);
-
-        $mimeType = strtolower(File::getMimetype($media->getPath()));
-
-        if (
-            method_exists($urlGenerator, 'getPath') &&
-            file_exists($media->getPath()) &&
-            $this->supportedMimetypes()->contains($mimeType)
-        ) {
+        if ($this->supportedMimetypes()->contains(strtolower($media->mime_type))) {
             return true;
         }
 


### PR DESCRIPTION
Since the MIME type is stored on the `Media` model in the database we no longer have to get the MIME type from the file path when determining which `ImageGenerator` to use.

This solves issues with S3 storage since it doesn't have a `S3UrlGenerator::getPath`.

I've also added `fclose` to `DefaultFileSystem::copyToMediaLibrary` to avoid 'text file busy' errors when testing. (Same issue as https://github.com/spatie/laravel-backup/issues/373#issuecomment-281633489)