### PR TITLE
Fixes running multiple workers processing image manipulations

### DIFF
--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -9,6 +9,12 @@ return [
     'defaultFilesystem' => 'media',
 
     /*
+     * The path where to store temporary files while performing image conversions.
+     * If set to null, storage_path('medialibrary/temp') will be used.
+     */
+    'temp_file_path' => null,
+
+    /*
      * The maximum file size of an item in bytes. Adding a file
      * that is larger will result in an exception.
      */

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -55,7 +55,7 @@ class FileManipulator
             return;
         }
 
-        $temporaryDirectory = new TemporaryDirectory(storage_path('medialibrary/temp'));
+        $temporaryDirectory = new TemporaryDirectory($this->getTemporaryDirectoryPath());
 
         $copiedOriginalFile = app(Filesystem::class)->copyFromMediaLibrary(
             $media,
@@ -76,9 +76,11 @@ class FileManipulator
             app(Filesystem::class)->copyToMediaLibrary($renamedFile, $media, true);
 
             event(new ConversionHasBeenCompleted($media, $conversion));
+
+            unlink($renamedFile);
         }
 
-        $temporaryDirectory->delete();
+        unlink($copiedOriginalFile);
     }
 
     public function performConversion(Media $media, Conversion $conversion, string $imageFile): string
@@ -107,6 +109,20 @@ class FileManipulator
         }
 
         app(Dispatcher::class)->dispatch($job);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getTemporaryDirectoryPath(): string
+    {
+        $path = config('medialibrary.temp_file_path');
+
+        if ($path !== null) {
+            return $path;
+        }
+
+        return storage_path('medialibrary/temp');
     }
 
     /**


### PR DESCRIPTION
We are testing this (pretty awesome) library in an environment where we have multiple queue workers running to process tasks, and also to process image manipulations.

In the current situation, the whole temporary directory used by FileManipulator is being trashed after all manipulations on one file are processed. This causes trouble (files not found, directories not found, etc.) when the same temporary directory is currently in use by one or more other workers.

This pull request covers two problems:

1. Allow the temporary image conversion directory to be configurable. Our workers are low-spaced boxes and we would like to make sure there is enough space in the temporary directory to work with; so we would like to point the temporary directory to one of our storage boxes.
2. Do not trash the temporary directory completely, as this causes problem when one is running multiple queue workers that process image manipulations. Instead, nicely clean the generated files.

If there are any tests required, I will look into them later.