### PR TITLE
Use filepath instead of pointer for getting remote headers

### DIFF
--- a/src/Filesystem/DefaultFilesystem.php
+++ b/src/Filesystem/DefaultFilesystem.php
@@ -57,7 +57,7 @@ class DefaultFilesystem implements Filesystem
         $this->filesystem
             ->disk($media->disk)
             ->getDriver()
-            ->put($destination, $file, $this->getRemoteHeadersForFile($file));
+            ->put($destination, $file, $this->getRemoteHeadersForFile($pathToFile));
 
         fclose($file);
     }


### PR DESCRIPTION
Fixes some errors with S3 integration (due to refactor in 2f08d88d294c91df1958d1b12ebc10f978e351e1).

This also fixes #546 