### PR TITLE
set configured model class explicitly

### DIFF
--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -36,7 +36,12 @@ class MediaLibraryServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/medialibrary.php', 'medialibrary');
 
-        $this->app->singleton(MediaRepository::class);
+        $this->app->singleton(MediaRepository::class, function () {
+            // set class explicitly, otherwise in case of a custom class with custom table name commands will fail
+            $mediaClass = $this->app['config']['medialibrary']['media_model'];
+
+            return new MediaRepository(new $mediaClass);
+        });
 
         $this->app->bind('command.medialibrary:regenerate', RegenerateCommand::class);
         $this->app->bind('command.medialibrary:clear', ClearCommand::class);


### PR DESCRIPTION
Hello Freek,

thanks for your awesome libraries, i'm having not only this in use. Yes, my postcard is on the way.

With laravel-medialibrary i got a problem with a custom class and the regenerate command. Because it uses always Media instead of configured model class. I didn't find any about in the documentation. Also i want to avoid to override MediaRepository in my own AppServiceProvider.

I derived from tag 4.13.0 because i'm using laravel 5.3...