### PR TITLE
Use URL property of disk as baseUrl when available

### DIFF
--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -15,11 +15,7 @@ class LocalUrlGenerator extends BaseUrlGenerator
      */
     public function getUrl(): string
     {
-        if (! starts_with($this->getStoragePath(), public_path())) {
-            throw UrlCannotBeDetermined::mediaNotPubliclyAvailable($this->getStoragePath(), public_path());
-        }
-
-        $url = $this->getBaseMediaDirectory().'/'.$this->getPathRelativeToRoot();
+        $url = $this->getBaseMediaDirectoryUrl().'/'.$this->getPathRelativeToRoot();
 
         $url = $this->makeCompatibleForNonUnixHosts($url);
 
@@ -34,6 +30,25 @@ class LocalUrlGenerator extends BaseUrlGenerator
     public function getPath(): string
     {
         return $this->getStoragePath().'/'.$this->getPathRelativeToRoot();
+    }
+
+    /**
+     * Get the relative URL to the root of the public medialibrary directory
+     *
+     * @throws UrlCannotBeDetermined
+     */
+    protected function getBaseMediaDirectoryUrl(): string
+    {
+        $diskUrl = $this->config->get("filesystems.disks.{$this->media->disk}.url");
+        if ($diskUrl) {
+            return str_replace(url('/'), '', $diskUrl);
+        }
+
+        if (! starts_with($this->getStoragePath(), public_path())) {
+            throw UrlCannotBeDetermined::mediaNotPubliclyAvailable($this->getStoragePath(), public_path());
+        }
+
+        return $this->getBaseMediaDirectory();
     }
 
     /*

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -33,7 +33,7 @@ class LocalUrlGenerator extends BaseUrlGenerator
     }
 
     /**
-     * Get the relative URL to the root of the public medialibrary directory
+     * Get the relative URL to the root of the public medialibrary directory.
      *
      * @throws UrlCannotBeDetermined
      */


### PR DESCRIPTION
Use the `url` property of the selected media disk as a base url when available. 

This way symlinked public disks use the correct url instead of the non-public `root` path.