### PR TITLE
Use put method on FileSystemAdapter (v4)

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -65,7 +65,6 @@ class Filesystem implements FilesystemInterface
 
         $this->filesystem
             ->disk($media->disk)
-            ->getDriver()
             ->put($destination, fopen($file, 'r'), $this->getRemoteHeadersForFile($file));
     }
 


### PR DESCRIPTION
The `put` method on the `FileSystemAdapter` determines whether to use `putStream` or a regular `put` on the FileSystem driver. This way we don't have to worry about it.

This should fix #453 