### PR TITLE
Revert #567

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -65,6 +65,7 @@ class Filesystem implements FilesystemInterface
 
         $this->filesystem
             ->disk($media->disk)
+            ->getDriver()
             ->put($destination, fopen($file, 'r'), $this->getRemoteHeadersForFile($file));
     }
 


### PR DESCRIPTION
The #567 PR introduced a bug with laravel 5.3:

https://github.com/laravel/framework/blob/5.3/src/Illuminate/Filesystem/FilesystemAdapter.php#L76

The third parameter of the `put` method should be a string, but `$this->getRemoteHeadersForFile($file)` return an array resulting in a `Array to string conversion` error