### PR TITLE
Feature/rename to media library

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ simple API to work with. To learn all about it, head over to [the extensive docu
 Here are a few short examples of what you can do:
 ```php
 $newsItem = News::find(1);
-$newsItem->addMedia($pathToFile)->toMediaLibrary('images');
+$newsItem->addMedia($pathToFile)->toMediaLibraryCollection('images');
 ```
 It can handle your uploads directly:
 ```php
-$newsItem->addMedia($request->file('image'))->toMediaLibrary('images');
+$newsItem->addMedia($request->file('image'))->toMediaLibraryCollection('images');
 ```
 Want to store some large files on another filesystem? No problem:
 ```php
-$newsItem->addMedia($smallFile)->toMediaLibrary('downloads', 'local');
-$newsItem->addMedia($bigFile)->toMediaLibrary('downloads', 's3');
+$newsItem->addMedia($smallFile)->toMediaLibraryCollection('downloads', 'local');
+$newsItem->addMedia($bigFile)->toMediaLibraryCollection('downloads', 's3');
 ```
 The storage of the files is handled by [Laravel's Filesystem](https://laravel.com/docs/5.4/filesystem),
 so you can use any filesystem you like. Additionally the package can create image manipulations

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -233,7 +233,7 @@ class FileAdder
      */
     public function toMediaLibraryOnCloudDisk(string $collectionName = 'default')
     {
-        return $this->toMediaLibrary($collectionName, config('filesystems.cloud'));
+        return $this->toMediaLibraryCollection($collectionName, config('filesystems.cloud'));
     }
 
     /**
@@ -244,6 +244,58 @@ class FileAdder
      *
      * @throws FileCannotBeAdded
      * @throws \Spatie\MediaLibrary\Exceptions\FileCannotBeAdded
+     */
+    public function toMediaLibraryCollection(string $collectionName = 'default', string $diskName = '')
+    {
+        if (! $this->subject->exists) {
+            throw ModelDoesNotExist::create($this->subject);
+        }
+
+        if (! is_file($this->pathToFile)) {
+            throw FileDoesNotExist::create($this->pathToFile);
+        }
+
+        if (filesize($this->pathToFile) > config('medialibrary.max_file_size')) {
+            throw FileIsTooBig::create($this->pathToFile);
+        }
+
+        $mediaClass = config('medialibrary.media_model');
+        $media = new $mediaClass();
+
+        $media->name = $this->mediaName;
+        $media->file_name = $this->fileName;
+        $media->disk = $this->determineDiskName($diskName);
+
+        $media->collection_name = $collectionName;
+
+        $media->mime_type = File::getMimetype($this->pathToFile);
+        $media->size = filesize($this->pathToFile);
+        $media->custom_properties = $this->customProperties;
+        $media->manipulations = [];
+
+        $media->fill($this->properties);
+
+        $this->subject->media()->save($media);
+
+        $this->filesystem->add($this->pathToFile, $media, $this->fileName);
+
+        if (! $this->preserveOriginal) {
+            unlink($this->pathToFile);
+        }
+
+        return $media;
+    }
+
+    /**
+     * @param string $collectionName
+     * @param string $diskName
+     *
+     * @return \Spatie\MediaLibrary\Media
+     *
+     * @throws FileCannotBeAdded
+     * @throws \Spatie\MediaLibrary\Exceptions\FileCannotBeAdded
+     *
+     * @deprecated
      */
     public function toMediaLibrary(string $collectionName = 'default', string $diskName = '')
     {

--- a/tests/Commands/CleanCommandTest.php
+++ b/tests/Commands/CleanCommandTest.php
@@ -20,22 +20,22 @@ class CleanCommandTest extends TestCase
         $this->media['model1']['collection1'] = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('collection1');
+            ->toMediaLibraryCollection('collection1');
 
         $this->media['model1']['collection2'] = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('collection2');
+            ->toMediaLibraryCollection('collection2');
 
         $this->media['model2']['collection1'] = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('collection1');
+            ->toMediaLibraryCollection('collection1');
 
         $this->media['model2']['collection2'] = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('collection2');
+            ->toMediaLibraryCollection('collection2');
 
         mkdir($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/conversions"));
         mkdir($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/conversions"));

--- a/tests/Commands/ClearCommandTest.php
+++ b/tests/Commands/ClearCommandTest.php
@@ -18,22 +18,22 @@ class ClearCommandTest extends TestCase
         $this->media['model1']['collection1'] = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('collection1');
+            ->toMediaLibraryCollection('collection1');
 
         $this->media['model1']['collection2'] = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('collection2');
+            ->toMediaLibraryCollection('collection2');
 
         $this->media['model2']['collection1'] = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('collection1');
+            ->toMediaLibraryCollection('collection1');
 
         $this->media['model2']['collection2'] = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('collection2');
+            ->toMediaLibraryCollection('collection2');
 
         $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
         $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));

--- a/tests/Commands/RegenerateCommandTest.php
+++ b/tests/Commands/RegenerateCommandTest.php
@@ -10,7 +10,7 @@ class RegenerateCommandTest extends TestCase
     /** @test */
     public function it_can_regenerate_all_files()
     {
-        $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibrary('images');
+        $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibraryCollection('images');
 
         $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/thumb.jpg");
 
@@ -29,11 +29,11 @@ class RegenerateCommandTest extends TestCase
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestFilesDirectory('test.jpg'))
             ->preservingOriginal()
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $media2 = $this->testModelWithConversion
             ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/thumb.jpg");
         $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/thumb.jpg");
@@ -53,7 +53,7 @@ class RegenerateCommandTest extends TestCase
     /** @test */
     public function it_can_regenerate_files_even_if_there_are_files_missing()
     {
-        $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibrary('images');
+        $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibraryCollection('images');
 
         unlink($this->getMediaDirectory($media->id.'/test.jpg'));
 

--- a/tests/Conversion/ConversionCollectionTest.php
+++ b/tests/Conversion/ConversionCollectionTest.php
@@ -16,7 +16,7 @@ class ConversionCollectionTest extends TestCase
 
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $media->manipulations = ['thumb' => ['filter' => 'greyscale', 'height' => 10]];
         $media->save();

--- a/tests/Events/EventTest.php
+++ b/tests/Events/EventTest.php
@@ -25,7 +25,7 @@ class EventTest extends TestCase
     {
         $this->expectsEvent(MediaHasBeenAdded::class);
 
-        $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+        $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $this->addToAssertionCount(1);
     }
@@ -35,7 +35,7 @@ class EventTest extends TestCase
     {
         $this->expectsEvent(ConversionHasBeenCompleted::class);
 
-        $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibrary('images');
+        $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibraryCollection('images');
 
         $this->addToAssertionCount(1);
     }
@@ -46,7 +46,7 @@ class EventTest extends TestCase
         $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $this->expectsEvent(CollectionHasBeenCleared::class);
 

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -18,11 +18,21 @@ use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\RequestDoesNotHaveFile;
 class IntegrationTest extends TestCase
 {
     /** @test */
-    public function it_can_add_an_file_to_the_default_collection()
+    public function it_can_add_a_file_to_the_default_collection_with_to_media_library()
     {
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
             ->toMediaLibrary();
+
+        $this->assertEquals('default', $media->collection_name);
+    }
+
+    /** @test */
+    public function it_can_add_an_file_to_the_default_collection()
+    {
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('default', $media->collection_name);
     }
@@ -34,7 +44,7 @@ class IntegrationTest extends TestCase
 
         $this->testModel
             ->addMedia('this-file-does-not-exist.jpg')
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
     }
 
     /** @test */
@@ -44,7 +54,7 @@ class IntegrationTest extends TestCase
 
         (new TestModel())
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
     }
 
     /** @test */
@@ -52,7 +62,7 @@ class IntegrationTest extends TestCase
     {
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('test', $media->name);
     }
@@ -64,7 +74,7 @@ class IntegrationTest extends TestCase
 
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary($collectionName);
+            ->toMediaLibraryCollection($collectionName);
 
         $this->assertEquals($collectionName, $media->collection_name);
     }
@@ -76,7 +86,7 @@ class IntegrationTest extends TestCase
 
         $media = $this->testModel
             ->addMedia($testFile)
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertFileNotExists($testFile);
         $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
@@ -89,7 +99,7 @@ class IntegrationTest extends TestCase
 
         $media = $this->testModel
             ->copyMedia($testFile)
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $this->assertFileExists($testFile);
         $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
@@ -100,7 +110,7 @@ class IntegrationTest extends TestCase
     {
         $media = $this->testModel
             ->addMedia($this->getTestFilesDirectory('test'))
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('test', $media->name);
 
@@ -116,7 +126,7 @@ class IntegrationTest extends TestCase
     {
         $media = $this->testModel
             ->addMedia($this->getTestFilesDirectory('image'))
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('image', $media->type);
     }
@@ -126,7 +136,7 @@ class IntegrationTest extends TestCase
     {
         $media = $this->testModel
             ->addMedia($this->getTestFilesDirectory('test.txt'))
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('test', $media->name);
 
@@ -149,7 +159,7 @@ class IntegrationTest extends TestCase
 
         $media = $this->testModel
             ->addMedia($uploadedFile)
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('alternativename', $media->name);
         $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
@@ -161,7 +171,7 @@ class IntegrationTest extends TestCase
         $this->app['router']->get('/upload', function () {
             $media = $this->testModel
                 ->addMediaFromRequest('file')
-                ->toMediaLibrary();
+                ->toMediaLibraryCollection();
 
             $this->assertEquals('alternativename', $media->name);
             $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
@@ -189,7 +199,7 @@ class IntegrationTest extends TestCase
             );
 
             $fileAdders->each(function ($fileAdder) {
-                $media = $fileAdder->toMediaLibrary();
+                $media = $fileAdder->toMediaLibraryCollection();
 
                 $this->assertEquals('alternativename', $media->name);
                 $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
@@ -227,7 +237,7 @@ class IntegrationTest extends TestCase
             );
 
             $fileAdders->each(function ($fileAdder) {
-                $media = $fileAdder->toMediaLibrary();
+                $media = $fileAdder->toMediaLibraryCollection();
 
                 $this->assertEquals('alternativename', $media->name);
                 $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
@@ -265,7 +275,7 @@ class IntegrationTest extends TestCase
             try {
                 $this->testModel
                     ->addMediaFromRequest('non existing key')
-                    ->toMediaLibrary();
+                    ->toMediaLibraryCollection();
             } catch (RequestDoesNotHaveFile $exception) {
                 $exceptionWasThrown = true;
             }
@@ -283,7 +293,7 @@ class IntegrationTest extends TestCase
 
         $media = $this->testModel
             ->addMediaFromUrl($url)
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('header', $media->name);
         $this->assertFileExists($this->getMediaDirectory("{$media->id}/header.jpg"));
@@ -298,7 +308,7 @@ class IntegrationTest extends TestCase
 
         $this->testModel
             ->addMediaFromUrl($url)
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
     }
 
     /** @test */
@@ -307,7 +317,7 @@ class IntegrationTest extends TestCase
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
             ->usingName('othername')
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('othername', $media->name);
         $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
@@ -319,7 +329,7 @@ class IntegrationTest extends TestCase
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
             ->usingFileName('othertest.jpg')
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('test', $media->name);
         $this->assertFileExists($this->getMediaDirectory($media->id.'/othertest.jpg'));
@@ -331,7 +341,7 @@ class IntegrationTest extends TestCase
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
             ->usingFileName('other#test.jpg')
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('test', $media->name);
         $this->assertFileExists($this->getMediaDirectory($media->id.'/other-test.jpg'));
@@ -345,7 +355,7 @@ class IntegrationTest extends TestCase
             $media[] = $this->testModel
                 ->addMedia($this->getTestJpg())
                 ->preservingOriginal()
-                ->toMediaLibrary();
+                ->toMediaLibraryCollection();
 
             $this->assertEquals($index + 1, $media[$index]->order_column);
         }
@@ -358,7 +368,7 @@ class IntegrationTest extends TestCase
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
             ->withProperties(['name' => 'testName'])
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('testName', $media->name);
 
@@ -366,7 +376,7 @@ class IntegrationTest extends TestCase
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
             ->withAttributes(['name' => 'testName'])
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('testName', $media->name);
     }
@@ -376,7 +386,7 @@ class IntegrationTest extends TestCase
     {
         $media = $this->testModelWithMorphMap
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals($this->testModelWithMorphMap->getMorphClass(), $media->model_type);
     }
@@ -402,7 +412,7 @@ class IntegrationTest extends TestCase
 
         $this->testModel
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
     }
 
     /** @test */
@@ -412,7 +422,7 @@ class IntegrationTest extends TestCase
 
         $this->testModel
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary('images', 'non-existing-disk');
+            ->toMediaLibraryCollection('images', 'non-existing-disk');
     }
 
     /** @test */
@@ -423,7 +433,7 @@ class IntegrationTest extends TestCase
 
         $media = $this->testModel
             ->addMediaFromBase64($testBase64Data)
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
     }
@@ -436,7 +446,7 @@ class IntegrationTest extends TestCase
 
         $media = $this->testModel
             ->addMediaFromBase64($testBase64Data)
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
     }
@@ -451,6 +461,6 @@ class IntegrationTest extends TestCase
 
         $this->testModel
             ->addMediaFromBase64($invalidBase64Data)
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
     }
 }

--- a/tests/FileAdder/MultipleDiskTest.php
+++ b/tests/FileAdder/MultipleDiskTest.php
@@ -15,7 +15,7 @@ class MultipleDiskTest extends TestCase
 
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary($collectionName, $diskName);
+            ->toMediaLibraryCollection($collectionName, $diskName);
 
         $this->assertEquals($collectionName, $media->collection_name);
         $this->assertEquals($diskName, $media->disk);
@@ -29,7 +29,7 @@ class MultipleDiskTest extends TestCase
 
         $this->testModel
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary('images', 'diskdoesnotexist');
+            ->toMediaLibraryCollection('images', 'diskdoesnotexist');
     }
 
     /** @test */
@@ -40,7 +40,7 @@ class MultipleDiskTest extends TestCase
 
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary($collectionName, $diskName);
+            ->toMediaLibraryCollection($collectionName, $diskName);
 
         $this->assertEquals($collectionName, $media->collection_name);
         $this->assertEquals($diskName, $media->disk);
@@ -53,7 +53,7 @@ class MultipleDiskTest extends TestCase
     {
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary('', 'secondMediaDisk');
+            ->toMediaLibraryCollection('', 'secondMediaDisk');
 
         $this->assertEquals("/media2/{$media->id}/test.jpg", $media->getUrl());
         $this->assertEquals("/media2/{$media->id}/conversions/thumb.jpg", $media->getUrl('thumb'));

--- a/tests/HasMediaConversionsTrait/AddMediaTest.php
+++ b/tests/HasMediaConversionsTrait/AddMediaTest.php
@@ -16,7 +16,7 @@ class AddMediaTest extends TestCase
     {
         $media = $this->testModelWithoutMediaConversions
             ->copyMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertEquals('default', $media->collection_name);
     }
@@ -24,7 +24,7 @@ class AddMediaTest extends TestCase
     /** @test */
     public function it_can_create_a_derived_version_of_an_image()
     {
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibrary('images');
+        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibraryCollection('images');
 
         $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/thumb.jpg'));
     }
@@ -32,7 +32,7 @@ class AddMediaTest extends TestCase
     /** @test */
     public function it_will_not_create_a_derived_version_for_non_registered_collections()
     {
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaLibrary('downloads');
+        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaLibraryCollection('downloads');
 
         $this->assertFileNotExists($this->getMediaDirectory($media->id.'/conversions/thumb.jpg'));
     }
@@ -42,7 +42,7 @@ class AddMediaTest extends TestCase
     {
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestFilesDirectory('image'))
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/thumb.jpg'));
     }
@@ -66,7 +66,7 @@ class AddMediaTest extends TestCase
 
         $media = $model
             ->addMedia($this->getTestFilesDirectory('test.png'))
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/my-conversion.png'));
     }
@@ -76,7 +76,7 @@ class AddMediaTest extends TestCase
     {
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestFilesDirectory('test.pdf'))
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $thumbPath = $this->getMediaDirectory($media->id.'/conversions/thumb.jpg');
 
@@ -88,7 +88,7 @@ class AddMediaTest extends TestCase
     {
         Carbon::setTestNow();
 
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibrary('images');
+        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibraryCollection('images');
 
         $originalThumbCreatedAt = filemtime($this->getMediaDirectory($media->id.'/conversions/thumb.jpg'));
 
@@ -128,7 +128,7 @@ class AddMediaTest extends TestCase
 
         $media = $model
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $conversionCollection = ConversionCollection::createForMedia($media);
 

--- a/tests/HasMediaConversionsTrait/DeleteMediaTest.php
+++ b/tests/HasMediaConversionsTrait/DeleteMediaTest.php
@@ -16,12 +16,12 @@ class DeleteMediaTest extends TestCase
             $this->testModelWithoutMediaConversions
                 ->addMedia($this->getTestJpg())
                 ->preservingOriginal()
-                ->toMediaLibrary();
+                ->toMediaLibraryCollection();
 
             $this->testModelWithoutMediaConversions
                 ->addMedia($this->getTestJpg())
                 ->preservingOriginal()
-                ->toMediaLibrary('images');
+                ->toMediaLibraryCollection('images');
         }
     }
 

--- a/tests/HasMediaTrait/DeleteMediaTest.php
+++ b/tests/HasMediaTrait/DeleteMediaTest.php
@@ -15,12 +15,12 @@ class DeleteMediaTest extends TestCase
             $this->testModel
                 ->addMedia($this->getTestJpg())
                 ->preservingOriginal()
-                ->toMediaLibrary();
+                ->toMediaLibraryCollection();
 
             $this->testModel
                 ->addMedia($this->getTestJpg())
                 ->preservingOriginal()
-                ->toMediaLibrary('images');
+                ->toMediaLibraryCollection('images');
         }
     }
 

--- a/tests/HasMediaTrait/GetMediaTest.php
+++ b/tests/HasMediaTrait/GetMediaTest.php
@@ -23,9 +23,9 @@ class GetMediaTest extends TestCase
         $this->assertCount(0, $this->testModel->getMedia('downloads'));
         $this->assertCount(0, $this->testModel->getMedia());
 
-        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaLibrary('images');
-        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaLibrary('downloads');
-        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaLibrary();
+        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaLibraryCollection('images');
+        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaLibraryCollection('downloads');
+        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaLibraryCollection();
 
         $this->testModel = $this->testModel->fresh();
 
@@ -37,7 +37,7 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_returns_a_media_collection_as_a_laravel_collection()
     {
-        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibrary();
+        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibraryCollection();
 
         $this->assertInstanceOf(\Illuminate\Support\Collection::class, $this->testModel->getMedia());
     }
@@ -45,7 +45,7 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_returns_collections_filled_with_media_objects()
     {
-        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibrary();
+        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibraryCollection();
 
         $this->assertInstanceOf(\Spatie\MediaLibrary\Media::class, $this->testModel->getMedia()->first());
     }
@@ -53,8 +53,8 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_can_get_multiple_media_from_the_default_collection()
     {
-        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary();
-        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary();
+        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection();
+        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection();
 
         $this->assertCount(2, $this->testModel->getMedia());
     }
@@ -62,8 +62,8 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_can_get_files_from_a_named_collection()
     {
-        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary();
-        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary('images');
+        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection();
+        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection('images');
 
         $this->assertCount(1, $this->testModel->getMedia('images'));
         $this->assertEquals('images', $this->testModel->getMedia('images')[0]->collection_name);
@@ -76,25 +76,25 @@ class GetMediaTest extends TestCase
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
             ->withCustomProperties(['filter1' => 'value1'])
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $media2 = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
             ->withCustomProperties(['filter1' => 'value2'])
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $media3 = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
             ->withCustomProperties(['filter2' => 'value1'])
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $media4 = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
             ->withCustomProperties(['filter2' => 'value2'])
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $collection = $this->testModel->getMedia('images', ['filter2' => 'value1']);
         $this->assertCount(1, $collection);
@@ -108,25 +108,25 @@ class GetMediaTest extends TestCase
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
             ->withCustomProperties(['filter1' => 'value1'])
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $media2 = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
             ->withCustomProperties(['filter1' => 'value2'])
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $media3 = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
             ->withCustomProperties(['filter2' => 'value1'])
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $media4 = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
             ->withCustomProperties(['filter2' => 'value2'])
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
 
         $collection = $this->testModel->getMedia('images', function (Media $media) {
             return isset($media->custom_properties['filter1']);
@@ -139,11 +139,11 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_can_get_the_first_media_from_a_collection()
     {
-        $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary('images');
+        $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection('images');
         $media->name = 'first';
         $media->save();
 
-        $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary('images');
+        $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection('images');
         $media->name = 'second';
         $media->save();
 
@@ -157,14 +157,14 @@ class GetMediaTest extends TestCase
             ->addMedia($this->getTestJpg())
             ->withCustomProperties(['extra_property' => 'yes'])
             ->preservingOriginal()
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
         $media->name = 'first';
         $media->save();
 
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
         $media->name = 'second';
         $media->save();
 
@@ -179,10 +179,10 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_can_get_the_url_to_first_media_in_a_collection()
     {
-        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary('images');
+        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection('images');
         $firstMedia->save();
 
-        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary('images');
+        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection('images');
         $secondMedia->save();
 
         $this->assertEquals($firstMedia->getUrl(), $this->testModel->getFirstMediaUrl('images'));
@@ -191,10 +191,10 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_can_get_the_path_to_first_media_in_a_collection()
     {
-        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary('images');
+        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection('images');
         $firstMedia->save();
 
-        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary('images');
+        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection('images');
         $secondMedia->save();
 
         $this->assertEquals($firstMedia->getPath(), $this->testModel->getFirstMediaPath('images'));
@@ -203,8 +203,8 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_will_return_preloaded_media_sorting_on_order_column()
     {
-        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary('images');
-        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary('images');
+        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection('images');
+        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection('images');
 
         $preloadedTestModel = TestModel::with('media')
             ->where('id', $this->testModel->id)

--- a/tests/HasMediaTrait/HasMediaTest.php
+++ b/tests/HasMediaTrait/HasMediaTest.php
@@ -15,7 +15,7 @@ class HasMediaTest extends TestCase
     /** @test */
     public function it_returns_true_for_a_non_empty_collection()
     {
-        $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+        $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $this->assertTrue($this->testModel->hasMedia());
     }
@@ -23,7 +23,7 @@ class HasMediaTest extends TestCase
     /** @test */
     public function it_returns_true_for_if_any_collection_is_not_empty()
     {
-        $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary('images');
+        $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection('images');
 
         $this->assertTrue($this->testModel->hasMedia('images'));
     }
@@ -37,7 +37,7 @@ class HasMediaTest extends TestCase
     /** @test */
     public function it_returns_true_for_a_non_empty_named_collection()
     {
-        $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary('images');
+        $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection('images');
 
         $this->assertTrue($this->testModel->hasMedia('images'));
         $this->assertFalse($this->testModel->hasMedia('downloads'));

--- a/tests/HasMediaTrait/UpdateMediaTest.php
+++ b/tests/HasMediaTrait/UpdateMediaTest.php
@@ -10,8 +10,8 @@ class UpdateMediaTest extends TestCase
     {
         parent::setUp();
 
-        $this->testModel->addMedia($this->getTestJpg())->usingName('test1')->preservingOriginal()->toMediaLibrary();
-        $this->testModel->addMedia($this->getTestJpg())->usingName('test2')->preservingOriginal()->toMediaLibrary();
+        $this->testModel->addMedia($this->getTestJpg())->usingName('test1')->preservingOriginal()->toMediaLibraryCollection();
+        $this->testModel->addMedia($this->getTestJpg())->usingName('test2')->preservingOriginal()->toMediaLibraryCollection();
     }
 
     /** @test */

--- a/tests/ImageGenerators/ImageTest.php
+++ b/tests/ImageGenerators/ImageTest.php
@@ -12,7 +12,7 @@ class ImageTest extends TestCase
     {
         $imageGenerator = new Image();
 
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaLibrary();
+        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $this->assertTrue($imageGenerator->canConvert($media));
 

--- a/tests/ImageGenerators/PdfTest.php
+++ b/tests/ImageGenerators/PdfTest.php
@@ -16,7 +16,7 @@ class PdfTest extends TestCase
             $this->markTestSkipped('Skipping pdf test because requirements to run it are not met');
         }
 
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestPdf())->toMediaLibrary();
+        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestPdf())->toMediaLibraryCollection();
 
         $this->assertTrue($imageGenerator->canConvert($media));
 

--- a/tests/ImageGenerators/SvgTest.php
+++ b/tests/ImageGenerators/SvgTest.php
@@ -16,7 +16,7 @@ class SvgTest extends TestCase
             $this->markTestSkipped('Skipping svg test because requirements to run it are not met');
         }
 
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestSvg())->toMediaLibrary();
+        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestSvg())->toMediaLibraryCollection();
 
         $this->assertTrue($imageGenerator->canConvert($media));
 

--- a/tests/ImageGenerators/VideoTest.php
+++ b/tests/ImageGenerators/VideoTest.php
@@ -17,7 +17,7 @@ class VideoTest extends TestCase
             $this->markTestSkipped('Skipping video test because requirements to run it are not met');
         }
 
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestWebm())->toMediaLibrary();
+        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestWebm())->toMediaLibraryCollection();
 
         $this->assertTrue($imageGenerator->canConvert($media));
 

--- a/tests/Media/CustomPropertyTest.php
+++ b/tests/Media/CustomPropertyTest.php
@@ -25,7 +25,7 @@ class CustomPropertyTest extends TestCase
                     'customName' => 'nested customValue',
                 ],
             ])
-            ->toMediaLibrary('images');
+            ->toMediaLibraryCollection('images');
     }
 
     /** @test */

--- a/tests/Media/DeleteTest.php
+++ b/tests/Media/DeleteTest.php
@@ -12,7 +12,7 @@ class DeleteTest extends TestCase
     /** @test */
     public function it_will_remove_the_files_when_deleting_a_media_object()
     {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary('images');
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection('images');
 
         $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
 
@@ -35,7 +35,7 @@ class DeleteTest extends TestCase
 
         $testModel = $testModelClass::find($this->testModel->id);
 
-        $media = $testModel->addMedia($this->getTestJpg())->toMediaLibrary('images');
+        $media = $testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection('images');
 
         $testModel = $testModel->fresh();
 
@@ -58,7 +58,7 @@ class DeleteTest extends TestCase
 
         $testModel = $testModelClass::find($this->testModel->id);
 
-        $media = $testModel->addMedia($this->getTestJpg())->toMediaLibrary('images');
+        $media = $testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection('images');
 
         $testModel = $testModel->fresh();
 

--- a/tests/Media/GetMediaConversionsTest.php
+++ b/tests/Media/GetMediaConversionsTest.php
@@ -12,14 +12,14 @@ class GetMediaConversionsTest extends TestCase
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertSame([], $media->getMediaConversionNames());
 
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $this->assertSame(['thumb'], $media->getMediaConversionNames());
     }

--- a/tests/Media/GetPathTest.php
+++ b/tests/Media/GetPathTest.php
@@ -10,7 +10,7 @@ class GetPathTest extends TestCase
     /** @test */
     public function it_can_get_a_path_of_an_original_item()
     {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $this->assertEquals($media->getPath(), $this->getMediaDirectory()."/{$media->id}/test.jpg");
     }
@@ -18,7 +18,7 @@ class GetPathTest extends TestCase
     /** @test */
     public function it_can_get_a_path_of_a_derived_image()
     {
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibrary();
+        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $conversionName = 'thumb';
 
@@ -28,7 +28,7 @@ class GetPathTest extends TestCase
     /** @test */
     public function it_returns_an_exception_when_getting_a_path_for_an_unknown_conversion()
     {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $this->expectException(InvalidConversion::class);
 

--- a/tests/Media/GetTypeTest.php
+++ b/tests/Media/GetTypeTest.php
@@ -9,7 +9,7 @@ class GetTypeTest extends TestCase
     /** @test */
     public function it_can_return_the_file_mime()
     {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $this->assertEquals('image/jpeg', $media->mime_type);
     }

--- a/tests/Media/GetUrlTest.php
+++ b/tests/Media/GetUrlTest.php
@@ -10,7 +10,7 @@ class GetUrlTest extends TestCase
     /** @test */
     public function it_can_get_an_url_of_an_original_item()
     {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $this->assertEquals($media->getUrl(), "/media/{$media->id}/test.jpg");
     }
@@ -18,7 +18,7 @@ class GetUrlTest extends TestCase
     /** @test */
     public function it_can_get_an_url_of_a_derived_image()
     {
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibrary();
+        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $conversionName = 'thumb';
 
@@ -28,7 +28,7 @@ class GetUrlTest extends TestCase
     /** @test */
     public function it_returns_an_exception_when_getting_an_url_for_an_unknown_conversion()
     {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $this->expectException(InvalidConversion::class);
 
@@ -38,7 +38,7 @@ class GetUrlTest extends TestCase
     /** @test */
     public function it_wil_url_encode_the_file_name_when_generating_an_url()
     {
-        $this->testModel->addMedia($this->getTestFilesDirectory('test with space.jpg'))->toMediaLibrary();
+        $this->testModel->addMedia($this->getTestFilesDirectory('test with space.jpg'))->toMediaLibraryCollection();
 
         $this->assertEquals('/media/1/test%20with%20space.jpg', $this->testModel->getFirstMediaUrl());
     }
@@ -46,7 +46,7 @@ class GetUrlTest extends TestCase
     /** @test */
     public function it_can_get_the_full_url_of_an_original_item()
     {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibrary();
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $this->assertEquals($media->getFullUrl(), "http://localhost/media/{$media->id}/test.jpg");
     }
@@ -54,7 +54,7 @@ class GetUrlTest extends TestCase
     /** @test */
     public function it_can_get_the_full_url_of_a_derived_image()
     {
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibrary();
+        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaLibraryCollection();
 
         $conversionName = 'thumb';
 

--- a/tests/Media/MediaRepositoryTest.php
+++ b/tests/Media/MediaRepositoryTest.php
@@ -20,7 +20,7 @@ class MediaRepositoryTest extends TestCase
     {
         $this->testModel
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary();
+            ->toMediaLibraryCollection();
 
         $mediaRepository = app(MediaRepository::class);
 

--- a/tests/Media/RenameTest.php
+++ b/tests/Media/RenameTest.php
@@ -11,7 +11,7 @@ class RenameTest extends TestCase
     {
         $testFile = $this->getTestFilesDirectory('test.jpg');
 
-        $media = $this->testModel->addMedia($testFile)->toMediaLibrary();
+        $media = $this->testModel->addMedia($testFile)->toMediaLibraryCollection();
 
         $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
 

--- a/tests/PathGenerator/BasePathGeneratorTest.php
+++ b/tests/PathGenerator/BasePathGeneratorTest.php
@@ -47,7 +47,7 @@ class BasePathGeneratorTest extends TestCase
     /** @test */
     public function it_can_get_the_custom_path_for_media_without_conversions()
     {
-        $media = $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibrary();
+        $media = $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibraryCollection();
 
         $this->urlGenerator->setMedia($media);
 
@@ -59,7 +59,7 @@ class BasePathGeneratorTest extends TestCase
     /** @test */
     public function it_can_get_the_custom_path_for_media_with_conversions()
     {
-        $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibrary();
+        $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibraryCollection();
         $conversion = ConversionCollection::createForMedia($media)->getByName('thumb');
 
         $this->urlGenerator

--- a/tests/Performance/PerformanceTest.php
+++ b/tests/Performance/PerformanceTest.php
@@ -12,7 +12,7 @@ class PerformanceTest extends TestCase
     {
         foreach (range(1, 10) as $index) {
             $testModel = $this->testModelWithConversion->create(['name' => "test{$index}"]);
-            $testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibrary('images');
+            $testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaLibraryCollection('images');
         }
 
         DB::connection()->enableQueryLog();

--- a/tests/S3Integration/S3IntegrationTest.php
+++ b/tests/S3Integration/S3IntegrationTest.php
@@ -38,7 +38,7 @@ class S3IntegrationTest extends TestCase
     {
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary('default', 's3');
+            ->toMediaLibraryCollection('default', 's3');
 
         $this->assertTrue(Storage::disk('s3')->has("{$this->s3BaseDirectory}/{$media->id}/test.jpg"));
     }
@@ -48,7 +48,7 @@ class S3IntegrationTest extends TestCase
     {
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary('default', 's3');
+            ->toMediaLibraryCollection('default', 's3');
 
         $this->assertTrue(Storage::disk('s3')->has("{$this->s3BaseDirectory}/{$media->id}/test.jpg"));
         $this->assertTrue(Storage::disk('s3')->has("{$this->s3BaseDirectory}/{$media->id}/conversions/thumb.jpg"));
@@ -59,7 +59,7 @@ class S3IntegrationTest extends TestCase
     {
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary('default', 's3');
+            ->toMediaLibraryCollection('default', 's3');
 
         $this->assertTrue(Storage::disk('s3')->has("{$this->s3BaseDirectory}/{$media->id}/test.jpg"));
 
@@ -73,7 +73,7 @@ class S3IntegrationTest extends TestCase
     {
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary('default', 's3');
+            ->toMediaLibraryCollection('default', 's3');
 
         $this->assertTrue(Storage::disk('s3')->has("{$this->s3BaseDirectory}/{$media->id}/test.jpg"));
         $this->assertTrue(Storage::disk('s3')->has("{$this->s3BaseDirectory}/{$media->id}/conversions/thumb.jpg"));
@@ -90,7 +90,7 @@ class S3IntegrationTest extends TestCase
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaLibrary('default', 's3');
+            ->toMediaLibraryCollection('default', 's3');
 
         $this->assertEquals(
             $this->app['config']->get('medialibrary.s3.domain')."/{$this->s3BaseDirectory}/{$media->id}/test.jpg",
@@ -108,7 +108,7 @@ class S3IntegrationTest extends TestCase
     {
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
-            ->toMediaLibrary('default', 's3');
+            ->toMediaLibraryCollection('default', 's3');
 
         $this->assertEquals(
             $this->app['config']->get('medialibrary.s3.domain')."/{$this->s3BaseDirectory}/{$media->id}/conversions/thumb.jpg",

--- a/tests/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/UrlGenerator/BaseUrlGeneratorTest.php
@@ -37,7 +37,7 @@ class BaseUrlGeneratorTest extends TestCase
 
         $this->config = app('config');
 
-        $this->media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibrary();
+        $this->media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaLibraryCollection();
 
         $this->conversion = ConversionCollection::createForMedia($this->media)->getByName('thumb');
 


### PR DESCRIPTION
Rename `toMediaLibrary` to `toMediaLibraryCollection`.

Fixes #575 