### PR TITLE
Update LocalUrlGenerator

### DIFF
--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -60,7 +60,7 @@ class LocalUrlGenerator extends BaseUrlGenerator
     {
         $diskRootPath = $this->config->get("filesystems.disks.{$this->media->disk}.root");
 
-        return realpath($diskRootPath);
+        return config('medialibrary.local_url_generator_realpath', true) ? realpath($diskRootPath) : $diskRootPath;
     }
 
     protected function makeCompatibleForNonUnixHosts(string $url): string


### PR DESCRIPTION
when config('medialibrary.local_url_generator_realpath') is set to false, just return $diskRootPath.
this way projects won't need to extend BaseUrlGenerator when using public symlink to files outside public folder.