### PR TITLE
keepOriginalImageFormat manipulation

### DIFF
--- a/src/Conversion/Conversion.php
+++ b/src/Conversion/Conversion.php
@@ -23,6 +23,9 @@ class Conversion
     /** @var bool */
     protected $performOnQueue = true;
 
+    /** @var bool */
+    protected $keepOriginalImageFormat = false;
+
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -54,6 +57,18 @@ class Conversion
     public function getExtractVideoFrameAtSecond(): int
     {
         return $this->extractVideoFrameAtSecond;
+    }
+
+    public function keepOriginalImageFormat(): Conversion
+    {
+        $this->keepOriginalImageFormat = true;
+
+        return $this;
+    }
+
+    public function shouldKeepOriginalImageFormat(): Bool
+    {
+        return $this->keepOriginalImageFormat;
     }
 
     public function getManipulations(): Manipulations

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -90,6 +90,11 @@ class FileManipulator
 
         File::copy($imageFile, $conversionTempFile);
 
+        $supportedFormats = ['jpg', 'pjpg', 'png', 'gif'];
+        if ($conversion->shouldKeepOriginalImageFormat() && in_array($media->extension, $supportedFormats)) {
+            $conversion->format($media->extension);
+        }
+
         Image::load($conversionTempFile)
             ->useImageDriver(config('medialibrary.image_driver'))
             ->manipulate($conversion->getManipulations())

--- a/tests/HasMediaConversionsTrait/AddMediaTest.php
+++ b/tests/HasMediaConversionsTrait/AddMediaTest.php
@@ -48,6 +48,16 @@ class AddMediaTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_derived_version_for_an_image_keeping_the_original_format()
+    {
+        $media = $this->testModelWithConversion
+            ->addMedia($this->getTestPng())
+            ->toMediaCollection('images');
+
+        $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/keep_original_format.png'));
+    }
+
+    /** @test */
     public function it_will_use_the_name_of_the_conversion_for_naming_the_converted_file()
     {
         $modelClass = new class() extends TestModelWithConversion {

--- a/tests/Media/GetMediaConversionsTest.php
+++ b/tests/Media/GetMediaConversionsTest.php
@@ -21,6 +21,6 @@ class GetMediaConversionsTest extends TestCase
             ->preservingOriginal()
             ->toMediaCollection();
 
-        $this->assertSame(['thumb'], $media->getMediaConversionNames());
+        $this->assertSame(['thumb', 'keep_original_format'], $media->getMediaConversionNames());
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -133,6 +133,11 @@ abstract class TestCase extends Orchestra
         return $this->getTestFilesDirectory('test.jpg');
     }
 
+    public function getTestPng()
+    {
+        return $this->getTestFilesDirectory('test.png');
+    }
+
     public function getTestWebm()
     {
         return $this->getTestFilesDirectory('test.webm');

--- a/tests/TestModelWithConversion.php
+++ b/tests/TestModelWithConversion.php
@@ -14,5 +14,9 @@ class TestModelWithConversion extends TestModel
         $this->addMediaConversion('thumb')
             ->width(50)
             ->nonQueued();
+
+        $this->addMediaConversion('keep_original_format')
+            ->keepOriginalImageFormat()
+            ->nonQueued();
     }
 }


### PR DESCRIPTION
This PR adds a `keepOriginalImageFormat` manipulation which can be used on a `Conversion` to keep the original file type and image format.

For #225 