### PR TITLE
Fix bug where `getResultExtension` would ignore `keepOriginalImageFormat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 5.8.1 - 2017-03-30
+
+- fix bug where the wrong extension would be returned by `getResultExtension` for `keepOriginalImageFormat`
+
 ## 5.8.0 - 2017-03-24
 
 - add `clearMediaCollectionExcept` method

--- a/src/Conversion/Conversion.php
+++ b/src/Conversion/Conversion.php
@@ -201,6 +201,10 @@ class Conversion
      */
     public function getResultExtension(string $originalFileExtension = ''): string
     {
+        if ($this->shouldKeepOriginalImageFormat()) {
+            return $originalFileExtension;
+        }
+
         if ($manipulationArgument = $this->manipulations->getManipulationArgument('format')) {
             return $manipulationArgument;
         }

--- a/tests/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/UrlGenerator/BaseUrlGeneratorTest.php
@@ -22,6 +22,11 @@ class BaseUrlGeneratorTest extends TestCase
     protected $conversion;
 
     /**
+     * @var \Spatie\MediaLibrary\Conversion\Conversion
+     */
+    protected $conversionKeepingOriginalImageFormat;
+
+    /**
      * @var LocalUrlGenerator
      */
     protected $urlGenerator;
@@ -37,9 +42,11 @@ class BaseUrlGeneratorTest extends TestCase
 
         $this->config = app('config');
 
-        $this->media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection();
+        $this->media = $this->testModelWithConversion->addMedia($this->getTestPng())->toMediaCollection();
 
         $this->conversion = ConversionCollection::createForMedia($this->media)->getByName('thumb');
+
+        $this->conversionKeepingOriginalImageFormat = ConversionCollection::createForMedia($this->media)->getByName('keep_original_format');
 
         // because BaseUrlGenerator is abstract we'll use LocalUrlGenerator to test the methods of base
         $this->urlGenerator = new LocalUrlGenerator($this->config);
@@ -54,7 +61,17 @@ class BaseUrlGeneratorTest extends TestCase
     /** @test */
     public function it_can_get_the_path_relative_to_the_root_of_media_folder()
     {
-        $pathRelativeToRoot = $this->media->id.'/conversions/'.$this->conversion->getName().'.'.$this->conversion->getResultExtension($this->media->extension);
+        $pathRelativeToRoot = $this->media->id.'/conversions/'.$this->conversion->getName().'.jpg';
+
+        $this->assertEquals($pathRelativeToRoot, $this->urlGenerator->getPathRelativeToRoot());
+    }
+
+    /** @test */
+    public function it_can_get_the_path_relative_to_the_root_of_media_folder_when_keeping_the_original_image_format()
+    {
+        $this->urlGenerator->setConversion($this->conversionKeepingOriginalImageFormat);
+
+        $pathRelativeToRoot = $this->media->id.'/conversions/'.$this->conversionKeepingOriginalImageFormat->getName().'.png';
 
         $this->assertEquals($pathRelativeToRoot, $this->urlGenerator->getPathRelativeToRoot());
     }


### PR DESCRIPTION
Fixes #591