### PR TITLE
Media is being returned in the wrong order

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -17,6 +17,8 @@ use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\InvalidBase64Data;
 
 trait HasMediaTrait
 {
+    public $mediaData;
+    
     /** @var array */
     public $mediaConversions = [];
 
@@ -305,7 +307,7 @@ trait HasMediaTrait
         event(new CollectionHasBeenCleared($this, $collectionName));
 
         if ($this->mediaIsPreloaded()) {
-            unset($this->media);
+            unset($this->mediaData);
         }
 
         return $this;
@@ -334,7 +336,7 @@ trait HasMediaTrait
             ->each->delete();
 
         if ($this->mediaIsPreloaded()) {
-            unset($this->media);
+            unset($this->mediaData);
         }
 
         return $this;
@@ -399,7 +401,7 @@ trait HasMediaTrait
 
     protected function mediaIsPreloaded(): bool
     {
-        return isset($this->media);
+        return isset($this->mediaData);
     }
 
     /**
@@ -412,7 +414,7 @@ trait HasMediaTrait
     public function loadMedia(string $collectionName)
     {
         if ($this->mediaIsPreloaded()) {
-            return $this->media
+            return $this->mediaData
                 ->filter(function (Media $mediaItem) use ($collectionName) {
                     if ($collectionName == '') {
                         return true;


### PR DESCRIPTION
the function `mediaIsPreloaded` checks if the media is set, but at the same time retrieves it. This results in the parts of `loadMedia`not being used and the data never being sorted.

This is an attempt to correct this, but probably needs a better solution. 
I just want to show the problem. I detected the problem because the retrieved data did not follow the media's order.