### PR TITLE
Fix bug where `mediaIsPreloaded` always returned true

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -399,7 +399,7 @@ trait HasMediaTrait
 
     protected function mediaIsPreloaded(): bool
     {
-        return isset($this->media);
+        return $this->relationLoaded('media');
     }
 
     /**
@@ -411,27 +411,15 @@ trait HasMediaTrait
      */
     public function loadMedia(string $collectionName)
     {
-        if ($this->mediaIsPreloaded()) {
-            return $this->media
-                ->filter(function (Media $mediaItem) use ($collectionName) {
-                    if ($collectionName == '') {
-                        return true;
-                    }
+        return $this->media
+            ->filter(function (Media $mediaItem) use ($collectionName) {
+                if ($collectionName == '') {
+                    return true;
+                }
 
-                    return $mediaItem->collection_name === $collectionName;
-                })
-                ->sortBy('order_column')
-                ->values();
-        }
-
-        $query = $this->media();
-
-        if ($collectionName !== '') {
-            $query = $query->where('collection_name', $collectionName);
-        }
-
-        return $query
-            ->orderBy('order_column')
-            ->get();
+                return $mediaItem->collection_name === $collectionName;
+            })
+            ->sortBy('order_column')
+            ->values();
     }
 }

--- a/tests/HasMediaTrait/GetMediaTest.php
+++ b/tests/HasMediaTrait/GetMediaTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\Test\HasMediaTrait;
 
+use DB;
 use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\Test\TestCase;
 use Spatie\MediaLibrary\Test\TestModel;
@@ -226,5 +227,25 @@ class GetMediaTest extends TestCase
             2 => '2',
             1 => '3',
         ], $preloadedTestModel->getMedia('images')->pluck('order_column', 'id')->toArray());
+    }
+
+    /** @test */
+    public function it_will_cache_loaded_media()
+    {
+        DB::enableQueryLog();
+
+        $this->assertFalse($this->testModel->relationLoaded('media'));
+        $this->assertCount(0, DB::getQueryLog());
+
+        $this->testModel->getMedia('images');
+
+        $this->assertTrue($this->testModel->relationLoaded('media'));
+        $this->assertCount(1, DB::getQueryLog());
+
+        $this->testModel->getMedia('images');
+
+        $this->assertCount(1, DB::getQueryLog());
+
+        DB::DisableQueryLog();
     }
 }


### PR DESCRIPTION
Once the `media` relationship is lazy loaded it is cached on the model by default. This means that calling `loadMedia` a second time doesn't execute any DB queries (tested in `it_will_cache_loaded_media`).

Fixes the problem described in #598 