### PR TITLE
Change the default file system from media to local

### DIFF
--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -6,7 +6,7 @@ return [
      * The filesystems on which to store added files and derived images by default. Choose
      * one or more of the filesystems you configured in app/config/filesystems.php
      */
-    'defaultFilesystem' => 'media',
+    'defaultFilesystem' => 'local',
 
     /*
      * The maximum file size of an item in bytes. Adding a file


### PR DESCRIPTION
This is a fix for this error:
```php
DiskDoesNotExist in DiskDoesNotExist.php line 11:
There is no filesystem disk named `media`
```

This is because the default config come with `'defaultFilesystem' => 'media'` but there is no media Filesystem on Laravel, the default Filesystem in Laravel is `local`:
```php
'default' => env('FILESYSTEM_DRIVER', 'local'),
```