### PR TITLE
Support upload array of medias, fixes #629

### DIFF
--- a/src/FileAdder/FileAdderFactory.php
+++ b/src/FileAdder/FileAdderFactory.php
@@ -33,7 +33,15 @@ class FileAdderFactory
                 throw RequestDoesNotHaveFile::create($key);
             }
 
-            return static::create($subject, request()->file($key));
+            $files = request()->file($key);
+
+            if (! is_array($files)) {
+                return static::create($subject, $files);
+            }
+
+            return array_map(function ($file) use ($subject) {
+                return static::create($subject, $file);
+            }, $files);
         });
     }
 

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\MediaLibrary\Test\FileAdder;
 
-use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\Test\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\UnknownType;
@@ -225,13 +224,17 @@ class IntegrationTest extends TestCase
             );
 
             $fileAdders->each(function ($fileAdder) {
-                $media = $fileAdder->toMediaCollection();
+                $fileAdder = is_array($fileAdder) ? $fileAdder : [$fileAdder];
 
-                $this->assertEquals('alternativename', $media->name);
-                $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
+                foreach ($fileAdder as $item) {
+                    $media = $item->toMediaCollection();
+
+                    $this->assertEquals('alternativename', $media->name);
+                    $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
+                }
             });
 
-            $this->assertCount(2, $fileAdders);
+            $this->assertCount(3, $fileAdders);
         });
 
         $uploadedFiles = [
@@ -247,6 +250,20 @@ class IntegrationTest extends TestCase
                 'image/svg',
                 filesize($this->getTestSvg())
             ),
+            'medias' => [
+                new UploadedFile(
+                    $this->getTestPng(),
+                    'alternativename.png',
+                    'image/png',
+                    filesize($this->getTestPng())
+                ),
+                new UploadedFile(
+                    $this->getTestWebm(),
+                    'alternativename.webm',
+                    'video/webm',
+                    filesize($this->getTestWebm())
+                ),
+            ],
         ];
 
         $result = $this->call('get', 'upload', [], [], $uploadedFiles);


### PR DESCRIPTION
This pr allows user to upload array of medias.

However, user should still pass keys as arguments instead of UploadFile array.

--
See from [twitter](https://twitter.com/freekmurze/status/861851718769934336).