### PR TITLE
Fixing issue with multiple file uploads

### DIFF
--- a/src/FileAdder/FileAdderFactory.php
+++ b/src/FileAdder/FileAdderFactory.php
@@ -42,7 +42,7 @@ class FileAdderFactory
             return array_map(function ($file) use ($subject) {
                 return static::create($subject, $file);
             }, $files);
-        });
+        })->collapse();
     }
 
     public static function createAllFromRequest(Model $subject): Collection


### PR DESCRIPTION
If we have a file input which allows to upload multiple files, the PHP throws the following exception:

```
FatalThrowableError in FileAdderFactory.php line 26:
Type error: Return value of Spatie\MediaLibrary\FileAdder\FileAdderFactory::createFromRequest() must be an instance of Spatie\MediaLibrary\FileAdder\FileAdder, array returned
```
That's because the ``static::createMultipleFromRequest($subject, [$key])`` in case of multiple files returns the following

```
Collection {#294 ▼
  #items: array:1 [▼
    0 => array:2 [▼
      0 => FileAdder {#303 ▶}
      1 => FileAdder {#306 ▶}
    ]
  ]
}
```

Instead of

```
Collection {#295 ▼
  #items: array:2 [▼
    0 => FileAdder {#303 ▶}
    1 => FileAdder {#306 ▶}
  ]
}
```
Collapsing collection will resolve this.