### PR TITLE
Fixes #631

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get install -y ghostscript
   - travis_retry composer self-update
 
 install:
@@ -20,6 +19,7 @@ install:
   - travis_retry composer require php-ffmpeg/php-ffmpeg
   - travis_retry composer require league/flysystem-aws-s3-v3
   - printf "\n" | pecl install imagick
+  - sudo apt-get install -y ghostscript
 
 script:
   - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 
 before_install:
   - sudo apt-get update
+  - sudo apt-get install -y ghostscript
   - travis_retry composer self-update
 
 install:


### PR DESCRIPTION
Travis have recently upgraded their build (https://blog.travis-ci.com/2017-05-04-precise-image-updates) although it appears that this does not include the Ghostscript library. I have added in this install to the build process to fix #631 relating to PDF tests not working correctly.