### PR TITLE
Added optional allowed mime types, fixes #645

### DIFF
--- a/src/Exceptions/FileCannotBeAdded/MimeTypeNotAllowed.php
+++ b/src/Exceptions/FileCannotBeAdded/MimeTypeNotAllowed.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\MediaLibrary\Exceptions\FileCannotBeAdded;
+
+use Spatie\MediaLibrary\Helpers\File;
+use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded;
+
+class MimeTypeNotAllowed extends FileCannotBeAdded
+{
+    public static function create($mimeType, array $allowedMimeTypes)
+    {
+        $allowedMimeTypes = implode(', ', $allowedMimeTypes);
+
+        return new static("File has a mimetype of {$mimeType}, while only {$allowedMimeTypes} are allowed");
+    }
+}

--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\Media;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\MediaRepository;
+use Illuminate\Support\Facades\Validator;
 use Spatie\MediaLibrary\FileAdder\FileAdder;
 use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\FileAdder\FileAdderFactory;
@@ -113,7 +114,7 @@ trait HasMediaTrait
         $tmpFile = tempnam(sys_get_temp_dir(), 'media-library');
         file_put_contents($tmpFile, $stream);
 
-        if (! empty($allowedMimeTypes) && ! in_array(mime_content_type($tmpFile), $allowedMimeTypes)) {
+        if (! empty($allowedMimeTypes) && Validator::make(['file' => $tmpFile], ['file' => 'mimetypes:'.implode(',', $allowedMimeTypes)])->fails()) {
             throw MimeTypeNotAllowed::create(mime_content_type($tmpFile), $allowedMimeTypes);
         }
 
@@ -160,7 +161,7 @@ trait HasMediaTrait
         $tmpFile = tempnam(sys_get_temp_dir(), 'medialibrary');
         file_put_contents($tmpFile, $binaryData);
 
-        if (! empty($allowedMimeTypes) && ! in_array(mime_content_type($tmpFile), $allowedMimeTypes)) {
+        if (! empty($allowedMimeTypes) && Validator::make(['file' => $tmpFile], ['file' => 'mimetypes:'.implode(',', $allowedMimeTypes)])->fails()) {
             throw MimeTypeNotAllowed::create(mime_content_type($tmpFile), $allowedMimeTypes);
         }
 

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\Test\FileAdder;
 
+use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\MimeTypeNotAllowed;
 use Spatie\MediaLibrary\Test\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\UnknownType;
@@ -317,6 +318,18 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function it_wil_throw_an_exception_when_a_remote_file_has_an_invalid_mime_type()
+    {
+        $url = 'https://docs.spatie.be/images/medialibrary/header.jpg';
+
+        $this->expectException(MimeTypeNotAllowed::class);
+
+        $this->testModel
+            ->addMediaFromUrl($url, ['image/png'])
+            ->toMediaCollection();
+    }
+
+    /** @test */
     public function it_can_rename_the_media_before_it_gets_added()
     {
         $media = $this->testModel
@@ -466,6 +479,19 @@ class IntegrationTest extends TestCase
 
         $this->testModel
             ->addMediaFromBase64($invalidBase64Data)
+            ->toMediaCollection();
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_adding_invalid_base64_mime_type()
+    {
+        $testFile = $this->getTestJpg();
+        $testBase64Data = base64_encode(file_get_contents($testFile));
+
+        $this->expectException(MimeTypeNotAllowed::class);
+
+        $this->testModel
+            ->addMediaFromBase64($testBase64Data, ['image/png'])
             ->toMediaCollection();
     }
 

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\MediaLibrary\Test\FileAdder;
 
-use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\MimeTypeNotAllowed;
 use Spatie\MediaLibrary\Test\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\UnknownType;
@@ -11,6 +10,7 @@ use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\UnreachableUrl;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\DiskDoesNotExist;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\FileDoesNotExist;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\InvalidBase64Data;
+use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\MimeTypeNotAllowed;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\RequestDoesNotHaveFile;
 
 class IntegrationTest extends TestCase


### PR DESCRIPTION
Added optional allowed mime types for addMediaFromUrl and addMediaFromBase64, to prevent adding other type of files than intended. Fixes #645.