### PR TITLE
Added Media access to registerMediaConversions

### DIFF
--- a/src/Conversion/ConversionCollection.php
+++ b/src/Conversion/ConversionCollection.php
@@ -88,7 +88,7 @@ class ConversionCollection extends Collection
         }
 
         if ($model instanceof HasMediaConversions) {
-            $model->registerMediaConversions();
+            $model->registerMediaConversions($media);
         }
 
         $this->items = $model->mediaConversions;

--- a/src/HasMedia/Interfaces/HasMediaConversions.php
+++ b/src/HasMedia/Interfaces/HasMediaConversions.php
@@ -4,10 +4,13 @@ namespace Spatie\MediaLibrary\HasMedia\Interfaces;
 
 interface HasMediaConversions extends HasMedia
 {
+    
     /**
      * Register the conversions that should be performed.
      *
+     * @param $media    The Media Model, base for the conversions
+     *
      * @return array
      */
-    public function registerMediaConversions();
+    public function registerMediaConversions($media);
 }


### PR DESCRIPTION
This update allows access to the Media Model in the `registerMediaConversions` method. This way the Media's `custom_properties` can be used when registering its conversions.