### PR TITLE
Fixed medialibrary:clean command for custom path generators

### DIFF
--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -9,9 +9,10 @@ use Spatie\MediaLibrary\FileManipulator;
 use Spatie\MediaLibrary\MediaRepository;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Database\Eloquent\Collection;
+use Spatie\MediaLibrary\Filesystem\Filesystem;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded;
 use Spatie\MediaLibrary\Conversion\ConversionCollection;
-use Spatie\MediaLibrary\PathGenerator\BasePathGenerator;
+use Spatie\MediaLibrary\PathGenerator\PathGeneratorFactory;
 
 class CleanCommand extends Command
 {
@@ -32,30 +33,34 @@ class CleanCommand extends Command
     /** @var \Illuminate\Contracts\Filesystem\Factory */
     protected $fileSystem;
 
-    /** @var \Spatie\MediaLibrary\PathGenerator\BasePathGenerator */
-    protected $basePathGenerator;
+    /** @var \Spatie\MediaLibrary\Filesystem\Filesystem */
+    protected $mediaFileSystem;
+
+    /** @var \Spatie\MediaLibrary\PathGenerator\PathGenerator */
+    protected $pathGenerator;
 
     /** @var bool */
     protected $isDryRun = false;
 
     /**
-     * @param \Spatie\MediaLibrary\MediaRepository                 $mediaRepository
-     * @param \Spatie\MediaLibrary\FileManipulator                 $fileManipulator
-     * @param \Illuminate\Contracts\Filesystem\Factory             $fileSystem
-     * @param \Spatie\MediaLibrary\PathGenerator\BasePathGenerator $basePathGenerator
+     * @param \Spatie\MediaLibrary\MediaRepository $mediaRepository
+     * @param \Spatie\MediaLibrary\FileManipulator $fileManipulator
+     * @param \Spatie\MediaLibrary\Filesystem\Filesystem $mediaFileSystem
+     * @param \Illuminate\Contracts\Filesystem\Factory $fileSystem
      */
     public function __construct(
         MediaRepository $mediaRepository,
         FileManipulator $fileManipulator,
-        Factory $fileSystem,
-        BasePathGenerator $basePathGenerator
+        Filesystem $mediaFileSystem,
+        Factory $fileSystem
     ) {
         parent::__construct();
 
         $this->mediaRepository = $mediaRepository;
         $this->fileManipulator = $fileManipulator;
+        $this->mediaFileSystem = $mediaFileSystem;
         $this->fileSystem = $fileSystem;
-        $this->basePathGenerator = $basePathGenerator;
+        $this->pathGenerator = PathGeneratorFactory::create();
     }
 
     public function handle()
@@ -101,12 +106,12 @@ class CleanCommand extends Command
         $this->getMediaItems()->each(function (Media $media) {
             $conversionFilePaths = ConversionCollection::createForMedia($media)->getConversionsFiles($media->collection_name);
 
-            $path = $this->basePathGenerator->getPathForConversions($media);
+            $path = $this->pathGenerator->getPathForConversions($media);
             $currentFilePaths = $this->fileSystem->disk($media->disk)->files($path);
 
             collect($currentFilePaths)
                 ->reject(function (string $currentFilePath) use ($conversionFilePaths) {
-                    return  $conversionFilePaths->contains(basename($currentFilePath));
+                    return $conversionFilePaths->contains(basename($currentFilePath));
                 })
                 ->each(function (string $currentFilePath) use ($media) {
                     if (! $this->isDryRun) {
@@ -126,20 +131,26 @@ class CleanCommand extends Command
             throw FileCannotBeAdded::diskDoesNotExist($diskName);
         }
 
-        $mediaIds = collect($this->mediaRepository->all()->pluck('id')->toArray());
+        $medias = $this->mediaRepository->all();
 
-        collect($this->fileSystem->disk($diskName)->directories())
-            ->filter(function (string $directory) {
-                return is_numeric($directory);
-            })
-            ->reject(function (string $directory) use ($mediaIds) {
-                return $mediaIds->contains((int) $directory);
-            })->each(function (string $directory) use ($diskName) {
-                if (! $this->isDryRun) {
-                    $this->fileSystem->disk($diskName)->deleteDirectory($directory);
-                }
+        $mediaPaths = $medias->map(function ($media) {
+            return rtrim($this->pathGenerator->getPath($media), '/');
+        });
 
-                $this->info("Orphaned media directory `{$directory}` ".($this->isDryRun ? 'found' : 'has been removed'));
-            });
+        $mediaPaths = $mediaPaths->merge($medias->map(function ($media) {
+            return rtrim($this->pathGenerator->getPathForConversions($media), '/');
+        }));
+
+        $diff = collect($this->fileSystem->disk($diskName)->allDirectories())->diff($mediaPaths);
+
+        $diff->reject(function (string $directory) use ($diskName) {
+            return empty($this->fileSystem->disk($diskName)->files($directory));
+        })->each(function (string $directory) use ($diskName) {
+            if (! $this->isDryRun) {
+                $this->mediaFileSystem->removeDirectory($directory, $diskName);
+            }
+
+            $this->info("Orphaned media directory `{$directory}` ".($this->isDryRun ? 'found' : 'has been removed'));
+        });
     }
 }

--- a/src/Filesystem/DefaultFilesystem.php
+++ b/src/Filesystem/DefaultFilesystem.php
@@ -111,8 +111,33 @@ class DefaultFilesystem implements Filesystem
 
         collect([$mediaDirectory, $conversionsDirectory])
             ->each(function ($directory) use ($media) {
-                $this->filesystem->disk($media->disk)->deleteDirectory($directory);
+                $this->removeDirectory($directory, $media->disk);
             });
+    }
+
+    /*
+     * Remove target directory with empty parents recursively
+     */
+    public function removeDirectory(string $directory, string $diskName)
+    {
+        $this->filesystem->disk($diskName)->deleteDirectory($directory);
+        $this->cleanDirectoryRecursive(dirname($directory), $diskName);
+    }
+
+    /*
+     * Remove parent directories if it's empty
+     */
+    protected function cleanDirectoryRecursive(string $directory, string $diskName)
+    {
+        if ('.' === $directory) {
+            return;
+        }
+
+        if (empty($this->filesystem->disk($diskName)->directories($directory)) &&
+            empty($this->filesystem->disk($diskName)->files($directory))) {
+            $this->filesystem->disk($diskName)->deleteDirectory($directory);
+            $this->cleanDirectoryRecursive(dirname($directory), $diskName);
+        }
     }
 
     /*

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -23,4 +23,6 @@ interface Filesystem
     public function getMediaDirectory(Media $media, bool $conversion = false) : string;
 
     public function getConversionDirectory(Media $media) : string;
+
+    public function removeDirectory(string $directory, string $diskName);
 }


### PR DESCRIPTION
Related to issue #665 
Custom paths can be with any nesting level. After deleting the directory, we should check for parent directories on empty recursively, and if it's empty - remove them too.
This is also justified for remove a single media model.
I'm tested it with several path generators. For example implementation of **partitioned id** structure:
```php
use Exception;
use Spatie\MediaLibrary\Media;
use Spatie\MediaLibrary\PathGenerator\PathGenerator;

class MediaPathGenerator implements PathGenerator
{
    /**
     * @param Media $media
     * @return string
     * @throws Exception
     */
    public function getPath(Media $media) : string
    {
        $id = $this->ensurePrintable($media->getKey());
        if (is_numeric($id)) {
            return implode('/', str_split(sprintf('%09d', $id), 3)) . '/';
        } elseif (is_string($id)) {
            return implode('/', array_slice(str_split($id, 3), 0, 3)) . '/';
        }

        throw new Exception('Unsupported type for generating correct file path storage');
    }

    /**
     * @param Media $media
     * @return string
     */
    public function getPathForConversions(Media $media) : string
    {
        return $this->getPath($media) . 'conversions/';
    }

    /**
     * Utility method to ensure the input data only contains
     * printable characters. This is especially important when
     * handling non-printable ID's such as binary UUID's.
     *
     * @param mixed $input
     *
     * @return mixed
     */
    protected function ensurePrintable($input)
    {
        if (! is_numeric($input) && ! ctype_print($input)) {
            // Hash the input data with SHA-256 to represent
            // as printable characters, with minimum chances
            // of the uniqueness being lost.
            return hash('sha256', $input);
        }

        return $input;
    }
}
```