### PR TITLE
Re-applied fix for #326 

### DIFF
--- a/src/UrlGenerator/BaseUrlGenerator.php
+++ b/src/UrlGenerator/BaseUrlGenerator.php
@@ -69,7 +69,7 @@ abstract class BaseUrlGenerator implements UrlGenerator
     public function getPathRelativeToRoot(): string
     {
         if (is_null($this->conversion)) {
-            return $this->pathGenerator->getPath($this->media).($this->media->file_name);
+            return $this->pathGenerator->getPath($this->media).rawurlencode($this->media->file_name);
         }
 
         return $this->pathGenerator->getPathForConversions($this->media)


### PR DESCRIPTION
Bug #326 (which was fixed in commit 1145a204165af499db39b226c8c2bdcbae068d84) is open again, because the `rawurlencode` function was later removed in commit 48ed0b4.

It looks like it was removed by mistake. This causes a problem with filenames that contain spaces.

This pull request puts the `rawurlencode` function back.