### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/bus": "~5.4.0|~5.5.x-dev",
-        "illuminate/console": "~5.4.0|~5.5.x-dev",
-        "illuminate/database": "~5.4.0|~5.5.x-dev",
-        "illuminate/support": "~5.4.0|~5.5.x-dev",
-        "illuminate/pipeline": "~5.4.0|~5.5.x-dev",
+        "illuminate/bus": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/console": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/database": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/pipeline": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
         "spatie/pdf-to-image": "^1.2",
         "spatie/image": "^1.0.0",
         "spatie/temporary-directory": "^1.1"
@@ -36,7 +36,7 @@
         "league/flysystem-aws-s3-v3": "^1.0.13",
         "phpunit/phpunit": "^6.2",
         "mockery/mockery": "^0.9.4",
-        "orchestra/testbench": "~3.4.0|~3.5.x-dev",
+        "orchestra/testbench": "~3.4.0|~3.5.x-dev|~3.5.x-dev",
         "doctrine/dbal": "^2.5.2"
     },
     "conflict": {
@@ -64,3 +64,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -1,66 +1,66 @@
 {
-  "name": "spatie/laravel-medialibrary",
-  "description": "Associate files with Eloquent models",
-  "keywords": [
-    "spatie",
-    "laravel-medialibrary",
-    "media",
-    "conversion",
-    "images",
-    "downloads",
-    "cms",
-    "laravel"
-  ],
-  "homepage": "https://github.com/spatie/laravel-medialibrary",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Freek Van der Herten",
-      "email": "freek@spatie.be",
-      "homepage": "https://murze.be",
-      "role": "Developer"
+    "name": "spatie/laravel-medialibrary",
+    "description": "Associate files with Eloquent models",
+    "keywords": [
+        "spatie",
+        "laravel-medialibrary",
+        "media",
+        "conversion",
+        "images",
+        "downloads",
+        "cms",
+        "laravel"
+    ],
+    "homepage": "https://github.com/spatie/laravel-medialibrary",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Freek Van der Herten",
+            "email": "freek@spatie.be",
+            "homepage": "https://murze.be",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": "^7.0",
+        "illuminate/bus": "~5.4.0|~5.5.x-dev",
+        "illuminate/console": "~5.4.0|~5.5.x-dev",
+        "illuminate/database": "~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.4.0|~5.5.x-dev",
+        "illuminate/pipeline": "~5.4.0|~5.5.x-dev",
+        "spatie/pdf-to-image": "^1.2",
+        "spatie/image": "^1.0.0",
+        "spatie/temporary-directory": "^1.1"
+    },
+    "require-dev": {
+        "league/flysystem-aws-s3-v3": "^1.0.13",
+        "phpunit/phpunit": "^6.2",
+        "mockery/mockery": "^0.9.4",
+        "orchestra/testbench": "~3.4.0|~3.5.x-dev",
+        "doctrine/dbal": "^2.5.2"
+    },
+    "conflict": {
+        "php-ffmpeg/php-ffmpeg": "<0.6.1"
+    },
+    "suggest": {
+        "php-ffmpeg/php-ffmpeg": "Required for generating video thumbnails",
+        "league/flysystem-aws-s3-v3": "Required to use AWS S3 file storage"
+    },
+    "autoload": {
+        "psr-4": {
+            "Spatie\\MediaLibrary\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Spatie\\MediaLibrary\\Test\\": "tests"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Spatie\\MediaLibrary\\MediaLibraryServiceProvider"
+            ]
+        }
     }
-  ],
-  "require": {
-    "php" : "^7.0",
-    "illuminate/bus": "~5.4.0",
-    "illuminate/console": "~5.4.0",
-    "illuminate/database": "~5.4.0",
-    "illuminate/support": "~5.4.0",
-    "illuminate/pipeline": "~5.4.0",
-    "spatie/pdf-to-image": "^1.2",
-    "spatie/image": "^1.0.0",
-    "spatie/temporary-directory": "^1.1"
-  },
-  "require-dev": {
-    "league/flysystem-aws-s3-v3": "^1.0.13",
-    "phpunit/phpunit" : "^6.0",
-    "mockery/mockery": "^0.9.4",
-    "orchestra/testbench": "~3.4.0",
-    "doctrine/dbal": "^2.5.2"
-  },
-  "conflict": {
-    "php-ffmpeg/php-ffmpeg": "<0.6.1"
-  },
-  "suggest": {
-    "php-ffmpeg/php-ffmpeg": "Required for generating video thumbnails",
-    "league/flysystem-aws-s3-v3": "Required to use AWS S3 file storage"
-  },
-  "autoload": {
-    "psr-4": {
-      "Spatie\\MediaLibrary\\": "src"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Spatie\\MediaLibrary\\Test\\": "tests"
-    }
-  },
-  "extra": {
-      "laravel": {
-          "providers": [
-              "Spatie\\MediaLibrary\\MediaLibraryServiceProvider"
-          ]
-      }
-  }
 }


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/phpunit.xml.dist

...............................................................  63 / 155 ( 40%)
.............E.........................................E.S..... 126 / 155 ( 81%)
.....................SSSSSS..                                   155 / 155 (100%)

Time: 22.34 seconds, Memory: 32.00MB

There were 2 errors:

1) Spatie\MediaLibrary\Test\HasMediaConversionsTrait\AddMediaTest::it_can_create_a_derived_version_of_a_pdf_if_imagick_exists
ImagickException: Failed to read the file

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/vendor/spatie/pdf-to-image/src/Pdf.php:40
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/src/ImageGenerators/FileTypes/Pdf.php:15
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/src/FileManipulator.php:66
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/src/FileManipulator.php:30
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/src/Filesystem/DefaultFilesystem.php:34
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/src/FileAdder/FileAdder.php:357
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/src/FileAdder/FileAdder.php:345
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/src/FileAdder/FileAdder.php:275
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/tests/HasMediaConversionsTrait/AddMediaTest.php:89

2) Spatie\MediaLibrary\Test\ImageGenerators\PdfTest::it_can_convert_a_pdf
ImagickException: Failed to read the file

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/vendor/spatie/pdf-to-image/src/Pdf.php:40
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/src/ImageGenerators/FileTypes/Pdf.php:15
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/tests/ImageGenerators/PdfTest.php:23

--

There were 7 skipped tests:

1) Spatie\MediaLibrary\Test\ImageGenerators\VideoTest::it_can_convert_a_video
Skipping video test because requirements to run it are not met

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/tests/ImageGenerators/VideoTest.php:17

2) Spatie\MediaLibrary\Test\FileAdder\S3IntegrationTest::it_store_a_file_on_s3
Skipping S3 tests because no S3 env variables found

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/tests/S3Integration/S3IntegrationTest.php:19

3) Spatie\MediaLibrary\Test\FileAdder\S3IntegrationTest::it_store_a_file_and_its_conversion_on_s3
Skipping S3 tests because no S3 env variables found

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/tests/S3Integration/S3IntegrationTest.php:19

4) Spatie\MediaLibrary\Test\FileAdder\S3IntegrationTest::it_can_delete_a_file_on_s3
Skipping S3 tests because no S3 env variables found

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/tests/S3Integration/S3IntegrationTest.php:19

5) Spatie\MediaLibrary\Test\FileAdder\S3IntegrationTest::it_deletes_file_converions_on_s3
Skipping S3 tests because no S3 env variables found

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/tests/S3Integration/S3IntegrationTest.php:19

6) Spatie\MediaLibrary\Test\FileAdder\S3IntegrationTest::it_retrieve_a_media_url_from_s3
Skipping S3 tests because no S3 env variables found

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/tests/S3Integration/S3IntegrationTest.php:19

7) Spatie\MediaLibrary\Test\FileAdder\S3IntegrationTest::it_retrieve_a_media_conversion_url_from_s3
Skipping S3 tests because no S3 env variables found

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-medialibrary/tests/S3Integration/S3IntegrationTest.php:19

ERRORS!
Tests: 155, Assertions: 342, Errors: 2, Skipped: 7.

So there are some errors, but it could work!