### PR TITLE
Making sure that the $file is a resource before calling fclose()

### DIFF
--- a/src/Filesystem/DefaultFilesystem.php
+++ b/src/Filesystem/DefaultFilesystem.php
@@ -58,7 +58,9 @@ class DefaultFilesystem implements Filesystem
             ->disk($media->disk)
             ->put($destination, $file, $this->getRemoteHeadersForFile($pathToFile));
 
-        fclose($file);
+        if (is_resource($file)) {
+            fclose($file);
+        }
     }
 
     /**


### PR DESCRIPTION
Some flysystem adapters (google cloud storage) may have already closed the file at this point, making $file point to a ‘Closed resource’. If you try to call fclose() on a Closed resource then you will get an exception. This simply makes sure that $file is still a resource before attempting to close it.

This is related to issue #698. 