### PR TITLE
Add ability to predefine order index on creating Media

### DIFF
--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -35,6 +35,9 @@ class FileAdder
     /** @var array */
     protected $customProperties = [];
 
+    /** @var int */
+    protected $orderColumnValue;
+
     /** @var string */
     protected $pathToFile;
 
@@ -171,6 +174,32 @@ class FileAdder
     }
 
     /**
+     * Set the order of the media.
+     *
+     * @param int $value
+     *
+     * @return $this
+     */
+    public function usingOrder(int $value)
+    {
+        return $this->setOrder($value);
+    }
+
+    /**
+     * Set the order of the media.
+     *
+     * @param int $value
+     *
+     * @return $this
+     */
+    public function setOrder(int $value)
+    {
+        $this->orderColumnValue = $value;
+
+        return $this;
+    }
+
+    /**
      * Set the metadata.
      *
      * @param array $customProperties
@@ -268,6 +297,7 @@ class FileAdder
         $media->mime_type = File::getMimetype($this->pathToFile);
         $media->size = filesize($this->pathToFile);
         $media->custom_properties = $this->customProperties;
+        $media->order_column = $this->orderColumnValue;
         $media->manipulations = [];
 
         $media->fill($this->properties);

--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -8,7 +8,7 @@ class MediaObserver
 {
     public function creating(Media $media)
     {
-        if(is_null($media->order_column)) {
+        if (is_null($media->order_column)) {
             $media->setHighestOrderNumber();
         }
     }

--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -8,7 +8,9 @@ class MediaObserver
 {
     public function creating(Media $media)
     {
-        $media->setHighestOrderNumber();
+        if(is_null($media->order_column)) {
+            $media->setHighestOrderNumber();
+        }
     }
 
     public function updating(Media $media)

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -370,6 +370,21 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function it_can_save_media_in_the_predefined_order()
+    {
+        $media = [];
+        foreach (range(3, 0) as $index) {
+            $media[] = $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->usingOrder($index)
+                ->preservingOriginal()
+                ->toMediaCollection();
+
+            $this->assertEquals($index, $media[3 - $index]->order_column);
+        }
+    }
+
+    /** @test */
     public function it_can_add_properties_to_the_saved_media()
     {
         $media = $this->testModel


### PR DESCRIPTION
Hi. Thank you for great package, that is very simple to use!

In my project I needed to import a whole lot of photos with existing ordering into the laravel-medialibrary.
Unfortunately I found that there is no existing simple method like usingName() or usingFilename() to set order, I need 2 more lines of code and one more database query, right after Media has been saved to set order_column value.

I've just made a small improvement over current implementation of ordering to solve this problem.
I add 2 methods, usingOrder() and setOrder(). I writed a test to proof that preordering is working fine.