### PR TITLE
fix env variable usage in travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - travis_retry composer self-update
 
 install:
-  - travis_retry composer update --prefer-source $PREFER_LOWEST
+  - travis_retry composer update --prefer-source $COMPOSER_FLAGS
   - travis_retry composer require php-ffmpeg/php-ffmpeg
   - travis_retry composer require league/flysystem-aws-s3-v3
   - printf "\n" | pecl install imagick


### PR DESCRIPTION
"--prefer-lowest" in travis is never actually used

Small mistake, but big implication for testing

Cheers,
Chris