### PR TITLE
Bugfix: remove getTemporaryUrl from UrlGenerator interface

### DIFF
--- a/src/UrlGenerator/UrlGenerator.php
+++ b/src/UrlGenerator/UrlGenerator.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\MediaLibrary\UrlGenerator;
 
-use DateTimeInterface;
 use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\PathGenerator\PathGenerator;

--- a/src/UrlGenerator/UrlGenerator.php
+++ b/src/UrlGenerator/UrlGenerator.php
@@ -17,16 +17,6 @@ interface UrlGenerator
     public function getUrl(): string;
 
     /**
-     * Get the temporary url for the profile of a media item.
-     *
-     * @param \DateTimeInterface $expiration
-     * @param array $options
-     *
-     * @return string
-     */
-    public function getTemporaryUrl(DateTimeInterface $expiration, array $options = []): string;
-
-    /**
      * @param \Spatie\MediaLibrary\Media $media
      *
      * @return \Spatie\MediaLibrary\UrlGenerator\UrlGenerator


### PR DESCRIPTION
Version 6.1.0 accidentally introduced a breaking `getTemporaryUrl` method on the `UrlGenerator` interface. This PR removes this method from the interface.
