### PR TITLE
Fixed URL-encoding for S3 files

### DIFF
--- a/src/UrlGenerator/BaseUrlGenerator.php
+++ b/src/UrlGenerator/BaseUrlGenerator.php
@@ -77,4 +77,9 @@ abstract class BaseUrlGenerator implements UrlGenerator
         .'.'
         .$this->conversion->getResultExtension($this->media->extension);
     }
+
+    public function rawUrlEncodeFilename(string $path = ''): string
+    {
+        return pathinfo($path, PATHINFO_DIRNAME).'/'.rawurlencode(pathinfo($path, PATHINFO_BASENAME));
+    }
 }

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -85,9 +85,4 @@ class LocalUrlGenerator extends BaseUrlGenerator
 
         return $url;
     }
-
-    public function rawUrlEncodeFilename(string $path = ''): string
-    {
-        return pathinfo($path, PATHINFO_DIRNAME).'/'.rawurlencode(pathinfo($path, PATHINFO_BASENAME));
-    }
 }

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -25,7 +25,11 @@ class S3UrlGenerator extends BaseUrlGenerator
      */
     public function getUrl(): string
     {
-        return config('medialibrary.s3.domain').'/'.$this->getPathRelativeToRoot();
+        $url = $this->getPathRelativeToRoot();
+
+        $url = $this->rawUrlEncodeFilename($url);
+
+        return config('medialibrary.s3.domain').'/'.$url;
     }
 
     /**


### PR DESCRIPTION
S3 files return wrong URLs because they're not URL-encoded. For example:

> example.s3-eu-west-1.amazonaws.com/1234/This is an example.odt

instead of

> example.s3-eu-west-1.amazonaws.com/1234/This%20is%20an%20example.odt

This bug is similar to #326 but it only happens for S3 files.

I moved `rawUrlEncodeFilename()` into BaseUrlGenerator because that method is now used by both LocalUrlGenerator and S3UrlGenerator.