### PR TITLE
add compatibility with jenssegers/laravel-mongodb

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -15,6 +15,8 @@ class Media extends Model
     use SortableTrait;
 
     const TYPE_OTHER = 'other';
+    
+    protected $connection = 'mysql';
 
     protected $guarded = [];
 


### PR DESCRIPTION
This change may look trivial but without it it's not possible to retrieve media items assigned to a MongoDB model.