### PR TITLE
Set the fileName of the file using a callable

### DIFF
--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -307,6 +307,21 @@ class FileAdder
         return str_replace(['#', '/', '\\'], '-', $fileName);
     }
 
+
+    /**
+     * Set the fileName of the file using a callable
+     *
+     * @param callable $function
+     *
+     * @return $this
+     */
+    public function sanitizingFileName(callable $function)
+    {
+        $this->fileName = $function($this->fileName);
+
+        return $this;
+    }
+
     /**
      * @param Media $media
      */

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -309,7 +309,7 @@ class FileAdder
 
 
     /**
-     * Set the fileName of the file using a callable
+     * Set the fileName of the file using a callable.
      *
      * @param callable $function
      *

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -307,7 +307,6 @@ class FileAdder
         return str_replace(['#', '/', '\\'], '-', $fileName);
     }
 
-
     /**
      * Set the fileName of the file using a callable.
      *

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -356,6 +356,20 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function it_will_sanitize_the_file_name_using_callable()
+    {
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->sanitizingFileName(function ($fileName) {
+                return "new_file_name.jpg";
+            })
+            ->toMediaCollection();
+
+        $this->assertEquals('test', $media->name);
+        $this->assertFileExists($this->getMediaDirectory($media->id.'/new_file_name.jpg'));
+    }
+
+    /** @test */
     public function it_can_save_media_in_the_right_order()
     {
         $media = [];

--- a/tests/FileAdder/IntegrationTest.php
+++ b/tests/FileAdder/IntegrationTest.php
@@ -361,7 +361,7 @@ class IntegrationTest extends TestCase
         $media = $this->testModel
             ->addMedia($this->getTestJpg())
             ->sanitizingFileName(function ($fileName) {
-                return "new_file_name.jpg";
+                return 'new_file_name.jpg';
             })
             ->toMediaCollection();
 


### PR DESCRIPTION
Following #792

You can use a callable to sanitize the filename

```php
$item->addMediaFromRequest('image')
     ->sanitizingFileName(function($fileName) {
         return strtolower(str_replace(['#', '/', '\\', ' '], '-', $fileName));
     })
     ->toMediaCollection();
```

Test included