### PR TITLE
Responsable

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -6,11 +6,12 @@ use DateTimeInterface;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Helpers\File;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Support\Responsable;
 use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\Conversion\ConversionCollection;
 use Spatie\MediaLibrary\UrlGenerator\UrlGeneratorFactory;
 
-class Media extends Model
+class Media extends Model implements Responsable
 {
     use SortableTrait;
 
@@ -223,5 +224,17 @@ class Media extends Model
         return $conversions->map(function (Conversion $conversion) {
             return $conversion->getName();
         })->toArray();
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function toResponse($request)
+    {
+        return response()
+            ->file($this->getPath(), ['Content-Type' => $this->mime_type]);
     }
 }

--- a/tests/Media/ResponsableTest.php
+++ b/tests/Media/ResponsableTest.php
@@ -7,12 +7,11 @@ use Spatie\MediaLibrary\Test\TestCase;
 class ResponsableTest extends TestCase
 {
     /** @test */
-    public function it_can_be_returned_as_a_response()
+    public function it_can_return_an_image_as_a_response()
     {
         $this->app['router']->get('/upload', function () {
             return $this->testModel
                 ->addMedia($this->getTestJpg())
-                ->usingFileName('othertest.jpg')
                 ->toMediaCollection();
         });
 
@@ -21,5 +20,21 @@ class ResponsableTest extends TestCase
         $this->assertEquals(200, $result->getStatusCode());
         $result->assertHeader('Content-Type', 'image/jpeg');
         $this->assertEquals(29085, $result->baseResponse->getFile()->getSize());
+    }
+    
+    /** @test */
+    public function it_can_return_a_text_as_a_response()
+    {
+        $this->app['router']->get('/upload', function () {
+            return $this->testModel
+                ->addMedia($this->getTestFilesDirectory('test.txt'))
+                ->toMediaCollection();
+        });
+
+        $result = $this->call('get', 'upload');
+
+        $this->assertEquals(200, $result->getStatusCode());
+        $result->assertHeader('Content-Type', 'text/plain');
+        $this->assertEquals(45, $result->baseResponse->getFile()->getSize());
     }
 }

--- a/tests/Media/ResponsableTest.php
+++ b/tests/Media/ResponsableTest.php
@@ -21,7 +21,7 @@ class ResponsableTest extends TestCase
         $result->assertHeader('Content-Type', 'image/jpeg');
         $this->assertEquals(29085, $result->baseResponse->getFile()->getSize());
     }
-    
+
     /** @test */
     public function it_can_return_a_text_as_a_response()
     {

--- a/tests/Media/ResponsableTest.php
+++ b/tests/Media/ResponsableTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test\Media;
+
+use Spatie\MediaLibrary\Test\TestCase;
+
+class ResponsableTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_returned_as_a_response()
+    {
+        $this->app['router']->get('/upload', function () {
+            return $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->usingFileName('othertest.jpg')
+                ->toMediaCollection();
+        });
+
+        $result = $this->call('get', 'upload');
+
+        $this->assertEquals(200, $result->getStatusCode());
+        $result->assertHeader('Content-Type', 'image/jpeg');
+        $this->assertEquals(29085, $result->baseResponse->getFile()->getSize());
+    }
+}


### PR DESCRIPTION
This PR implements the `Illuminate\Contracts\Support\Responsable` interface in the `Media` model.

This allows us to do some stuff like this
```php
Route::get('/some/secret/path/{id}', 'SomeController@secret_download')
        ->middleware(['auth', 
            'role:super_secret_role',
            'permission:can download secret images'
         ]); 

class SomeController 
{
  public function secret_download($id)
  {
        return Media::findOrFail($id);
  }
}
```

Tests provided (image and text file)