### PR TITLE
Deleting media files with custom path generator

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -32,7 +32,7 @@ trait HasMediaTrait
 
     public static function bootHasMediaTrait()
     {
-        static::deleted(function (HasMedia $entity) {
+        static::deleting(function (HasMedia $entity) {
             if ($entity->shouldDeletePreservingMedia()) {
                 return;
             }

--- a/tests/Media/DeleteTest.php
+++ b/tests/Media/DeleteTest.php
@@ -6,6 +6,7 @@ use File;
 use Spatie\MediaLibrary\Media;
 use Spatie\MediaLibrary\Test\TestCase;
 use Spatie\MediaLibrary\Test\TestModel;
+use Spatie\MediaLibrary\Test\TestPathGenerator;
 
 class DeleteTest extends TestCase
 {
@@ -19,6 +20,23 @@ class DeleteTest extends TestCase
         $this->testModel->delete();
 
         $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
+    }
+
+    /** @test */
+    public function it_will_remove_files_when_deleting_a_media_object_with_a_custom_path_generator()
+    {
+        config(['medialibrary.custom_path_generator_class' => TestPathGenerator::class]);
+
+        $pathGenerator = new TestPathGenerator();
+
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+        $path = $pathGenerator->getPath($media);
+
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+
+        $this->testModel->delete();
+
+        $this->assertFalse(File::isDirectory($this->getTempDirectory($path)));
     }
 
     /**

--- a/tests/TestPathGenerator.php
+++ b/tests/TestPathGenerator.php
@@ -9,12 +9,10 @@ class TestPathGenerator implements PathGenerator
 {
     public function getPath(Media $media): string
     {
-        $game = TestModel::find($media->model_id);
+        $entry = TestModel::find($media->model_id);
 
         $fileFolder = md5($media->id);
-        $path = "{$game->id}/{$fileFolder}/";
-
-        return $path;
+        return "{$entry->id}/{$fileFolder}/";
     }
 
     public function getPathForConversions(Media $media): string

--- a/tests/TestPathGenerator.php
+++ b/tests/TestPathGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test;
+
+use Spatie\MediaLibrary\Media;
+use Spatie\MediaLibrary\PathGenerator\PathGenerator;
+
+class TestPathGenerator implements PathGenerator
+{
+    public function getPath(Media $media): string
+    {
+        $game = TestModel::find($media->model_id);
+
+        $fileFolder = md5($media->id);
+        $path = "{$game->id}/{$fileFolder}/";
+
+        return $path;
+    }
+
+    public function getPathForConversions(Media $media): string
+    {
+        return $this->getPath($media) . '/convertions/';
+    }
+}

--- a/tests/TestPathGenerator.php
+++ b/tests/TestPathGenerator.php
@@ -12,11 +12,12 @@ class TestPathGenerator implements PathGenerator
         $entry = TestModel::find($media->model_id);
 
         $fileFolder = md5($media->id);
+
         return "{$entry->id}/{$fileFolder}/";
     }
 
     public function getPathForConversions(Media $media): string
     {
-        return $this->getPath($media) . '/convertions/';
+        return $this->getPath($media).'/convertions/';
     }
 }


### PR DESCRIPTION
This PR changes the observed event for deleting media files from `deleted` to `deleting`.

Removing media files before the parent model is removed, allows us to still use that model in a custom path generator, like so:

```php
public function getPath(Media $media): string
{
    $entry = TestModel::find($media->model_id);

    $fileFolder = md5($media->id);
    return "{$entry->id}/{$fileFolder}/";
}
```

This PR address the first part of this issue: #805 