### PR TITLE
Regenerate only missing conversions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs
 vendor
 tests/temp
 composer.lock
+phpunit.xml

--- a/src/Commands/RegenerateCommand.php
+++ b/src/Commands/RegenerateCommand.php
@@ -15,6 +15,7 @@ class RegenerateCommand extends Command
     use ConfirmableTrait;
 
     protected $signature = 'medialibrary:regenerate {modelType?} {--ids=*}
+    {--only-missing : Regenerate only missing conversions}
     {-- force : Force the operation to run when in production}';
 
     protected $description = 'Regenerate the derived images of media';
@@ -50,7 +51,7 @@ class RegenerateCommand extends Command
 
         $mediaFiles->each(function (Media $media) use ($progressBar) {
             try {
-                $this->fileManipulator->createDerivedFiles($media);
+                $this->fileManipulator->createDerivedFiles($media, $this->option('only-missing'));
             } catch (Exception $exception) {
                 $this->errorMessages[$media->id] = $exception->getMessage();
             }

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -27,7 +27,7 @@ class FileManipulator
     {
         $profileCollection = ConversionCollection::createForMedia($media);
 
-        if (!empty($only)) {
+        if (! empty($only)) {
             $profileCollection = $profileCollection->filter(function ($collection) use ($only) {
                 return in_array($collection->getName(), $only);
             });

--- a/tests/Commands/RegenerateCommandTest.php
+++ b/tests/Commands/RegenerateCommandTest.php
@@ -100,7 +100,7 @@ class RegenerateCommandTest extends TestCase
 
         Artisan::call('medialibrary:regenerate', [
             '--only-missing' => true,
-            '--only' => 'thumb'
+            '--only' => 'thumb',
         ]);
 
         $this->assertFileExists($derivedMissingImage);

--- a/tests/Commands/RegenerateCommandTest.php
+++ b/tests/Commands/RegenerateCommandTest.php
@@ -85,16 +85,16 @@ class RegenerateCommandTest extends TestCase
 
         $derivedImageExists = $this->getMediaDirectory("{$mediaExists->id}/conversions/thumb.jpg");
         $derivedMissingImage = $this->getMediaDirectory("{$mediaMissing->id}/conversions/thumb.jpg");
-        $derivedMissingImageXl = $this->getMediaDirectory("{$mediaMissing->id}/conversions/thumb_xl.jpg");
+        $derivedMissingImageOriginal = $this->getMediaDirectory("{$mediaMissing->id}/conversions/keep_original_format.png");
 
         $existsCreatedAt = filemtime($derivedImageExists);
         $missingCreatedAt = filemtime($derivedMissingImage);
 
         unlink($derivedMissingImage);
-        unlink($derivedMissingImageXl);
+        unlink($derivedMissingImageOriginal);
 
         $this->assertFileNotExists($derivedMissingImage);
-        $this->assertFileNotExists($derivedMissingImageXl);
+        $this->assertFileNotExists($derivedMissingImageOriginal);
 
         sleep(1);
 
@@ -104,7 +104,7 @@ class RegenerateCommandTest extends TestCase
         ]);
 
         $this->assertFileExists($derivedMissingImage);
-        $this->assertFileNotExists($derivedMissingImageXl);
+        $this->assertFileNotExists($derivedMissingImageOriginal);
         $this->assertSame($existsCreatedAt, filemtime($derivedImageExists));
         $this->assertGreaterThan($missingCreatedAt, filemtime($derivedMissingImage));
     }

--- a/tests/Commands/RegenerateCommandTest.php
+++ b/tests/Commands/RegenerateCommandTest.php
@@ -28,7 +28,7 @@ class RegenerateCommandTest extends TestCase
     }
 
     /** @test */
-    function it_can_regenerate_only_missing_files()
+    public function it_can_regenerate_only_missing_files()
     {
         $mediaExists = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection('images');
         $mediaMissing = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.png'))->toMediaCollection('images');
@@ -46,7 +46,7 @@ class RegenerateCommandTest extends TestCase
         sleep(1);
 
         Artisan::call('medialibrary:regenerate', [
-            '--only-missing' => true
+            '--only-missing' => true,
         ]);
 
         $this->assertFileExists($derivedImageMissing);

--- a/tests/TestModelWithConversion.php
+++ b/tests/TestModelWithConversion.php
@@ -17,10 +17,6 @@ class TestModelWithConversion extends TestModel
             ->width(50)
             ->nonQueued();
 
-        $this->addMediaConversion('thumb_xl')
-            ->width(150)
-            ->nonQueued();
-
         $this->addMediaConversion('keep_original_format')
             ->keepOriginalImageFormat()
             ->nonQueued();


### PR DESCRIPTION
Added "--only-missing" option to regenerate command

Solves https://github.com/spatie/laravel-medialibrary/issues/809

```
artisan medialibrary:regenerate --only-missing
```