### PR TITLE
Fix issue where soft deleted files are removed from the filesystem

### DIFF
--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -31,6 +31,19 @@ class MediaObserver
 
     public function deleted(Media $media)
     {
-        app(Filesystem::class)->removeFiles($media);
+        $softDeleted = false;
+        
+        if (in_array('Illuminate\\Database\\Eloquent\\SoftDeletes', class_uses($media))){
+            $softDeleted = $this->isSoftDeleted($media);
+        }
+        
+        if(!$softDeleted){
+            app(Filesystem::class)->removeFiles($media);
+        }
+    }
+
+    private function isSoftDeleted(Media $media)
+    {
+        return $media->isDirty($media->getDeletedAtColumn());
     }
 }

--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary;
 
 use Spatie\MediaLibrary\Filesystem\Filesystem;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class MediaObserver
 {
@@ -33,16 +34,16 @@ class MediaObserver
     {
         $softDeleted = false;
         
-        if (in_array('Illuminate\\Database\\Eloquent\\SoftDeletes', class_uses($media))){
+        if (in_array(SoftDeletes::class, trait_uses_recursive($media))) {
             $softDeleted = $this->isSoftDeleted($media);
         }
         
-        if(!$softDeleted){
+        if(!$softDeleted) {
             app(Filesystem::class)->removeFiles($media);
         }
     }
 
-    private function isSoftDeleted(Media $media)
+    protected function isSoftDeleted(Media $media)
     {
         return $media->isDirty($media->getDeletedAtColumn());
     }


### PR DESCRIPTION
Hello,

I discovered what I think is a bug in the package. 

I was using soft deletes together with a custom model with the hope that soft deleted files will not be gone from my file system. However, whether I was using a soft delete or a hard delete, my files were disappearing. 

I then debugged it and realized that deleted function from the MediaObserver is triggered on both types of deletes and calls the removeFiles function, which removes them from my file system.

In this PR, I added the check to see whether the file is soft deleted or not and removeFiles function is now only called on hard deletes. This fix solved the issue in my project.
I have also made sure that all tests are still passing.

Will look forward for your feedback,

Airidas