### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "guzzlehttp/guzzle": "^6.3",
     "league/flysystem-aws-s3-v3": "^1.0.13",
     "phpunit/phpunit" : "^6.2",
-    "mockery/mockery": "^0.9.4",
+    "mockery/mockery": "^1.0",
     "orchestra/testbench": "~3.5.0",
     "doctrine/dbal": "^2.5.2"
   },


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).

PS: I won't apply [this](https://styleci.io/analyses/8ABZaV) StyleCI changes 'cause there are not related to this PR :sweat_smile: 