### PR TITLE
Persist soft_deleted files on the system

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -23,6 +23,7 @@ class CreateMediaTable extends Migration
             $table->json('manipulations');
             $table->json('custom_properties');
             $table->unsignedInteger('order_column')->nullable();
+            $table->softDeletes();
             $table->nullableTimestamps();
         });
     }

--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -31,6 +31,19 @@ class MediaObserver
 
     public function deleted(Media $media)
     {
-        app(Filesystem::class)->removeFiles($media);
+        $softDeleted = false;
+        
+        if (in_array('Illuminate\\Database\\Eloquent\\SoftDeletes', class_uses($media))){
+            $softDeleted = $this->isSoftDeleted($media);
+        }
+        
+        if(!$softDeleted){
+            app(Filesystem::class)->removeFiles($media);
+        }
+    }
+
+    private function isSoftDeleted(Media $media)
+    {
+        return $media->isDirty($media->getDeletedAtColumn());
     }
 }

--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary;
 
 use Spatie\MediaLibrary\Filesystem\Filesystem;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class MediaObserver
 {
@@ -33,16 +34,16 @@ class MediaObserver
     {
         $softDeleted = false;
         
-        if (in_array('Illuminate\\Database\\Eloquent\\SoftDeletes', class_uses($media))){
+        if (in_array(SoftDeletes::class, trait_uses_recursive($media))) {
             $softDeleted = $this->isSoftDeleted($media);
         }
         
-        if(!$softDeleted){
+        if(!$softDeleted) {
             app(Filesystem::class)->removeFiles($media);
         }
     }
 
-    private function isSoftDeleted(Media $media)
+    protected function isSoftDeleted(Media $media)
     {
         return $media->isDirty($media->getDeletedAtColumn());
     }

--- a/tests/TestCustomModelWithSoftDeletes.php
+++ b/tests/TestCustomModelWithSoftDeletes.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\MediaLibrary\Test;
+
+use Spatie\MediaLibrary\Media;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
+use Spatie\MediaLibrary\HasMedia\Interfaces\HasMediaConversions;
+
+class TestCustomModelWithSoftDeletes extends Media implements HasMediaConversions
+{
+    use HasMediaTrait, SoftDeletes;
+
+    protected $table = 'media';
+    protected $guarded = [];
+    public $timestamps = false;
+    protected $dates = ['deleted_at'];
+
+    public function registerMediaConversions(Media $media = null)
+    {
+    }
+}


### PR DESCRIPTION
This PR contains the MediaObserver extension to support maintaining soft deleted files on the system and unit tests supporting it. In order for tests to pass, deleted_at column was added to media table.  