### PR TITLE
Fix wrong queue for responsive image generation (close #888)

### DIFF
--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -397,7 +397,13 @@ class FileAdder
         }
 
         if ($this->generateResponsiveImages && (new ImageGenerator())->canConvert($media)) {
-            dispatch(new GenerateResponsiveImages($media));
+            $job = new GenerateResponsiveImages($media);
+
+            if ($customQueue = config('medialibrary.queue_name')) {
+                $job->onQueue($customQueue);
+            }
+
+            dispatch($job);
         }
 
         if (optional($this->getMediaCollection($media->collection_name))->singleFile) {


### PR DESCRIPTION
This PR should push original responsive image generation to the configured queue.
It should pass all current tests, and should fix #888