### PR TITLE
Meaningful default for s3 domain

### DIFF
--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -46,7 +46,7 @@ return [
         /*
          * The domain that should be prepended when generating urls.
          */
-        'domain' => 'https://xxxxxxx.s3.amazonaws.com',
+        'domain' => 'https://' . env('AWS_BUCKET') . '.s3.amazonaws.com',
     ],
 
     'remote' => [


### PR DESCRIPTION
Laravel 5.5 suggest to use some keys for env variables needed to configure AWS services, it would be nice to follow their schema and put a meaningful default based on the AWS_BUCKET key.