### PR TITLE
Adds support for passing a filter callable to `getFirstMediaUrl`

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -217,7 +217,7 @@ trait HasMediaTrait
      *
      * @return Media|null
      */
-    public function getFirstMedia(string $collectionName = 'default', array $filters = [])
+    public function getFirstMedia(string $collectionName = 'default', $filters = [])
     {
         $media = $this->getMedia($collectionName, $filters);
 
@@ -229,9 +229,9 @@ trait HasMediaTrait
      * for first media for the given collectionName.
      * If no profile is given, return the source's url.
      */
-    public function getFirstMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
+    public function getFirstMediaUrl(string $collectionName = 'default', string $conversionName = '', callable $filter = null): string
     {
-        $media = $this->getFirstMedia($collectionName);
+        $media = $this->getFirstMedia($collectionName, $filter);
 
         if (! $media) {
             return '';

--- a/tests/HasMediaTrait/GetMediaTest.php
+++ b/tests/HasMediaTrait/GetMediaTest.php
@@ -190,6 +190,22 @@ class GetMediaTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_url_to_first_media_in_a_collection_using_a_filter()
+    {
+        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $firstMedia->name = 'first';
+        $firstMedia->save();
+
+        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $secondMedia->name = 'second';
+        $secondMedia->save();
+
+        $this->assertEquals($secondMedia->getUrl(), $this->testModel->getFirstMediaUrl('images', '', function($value, $key) {
+            return $value->name=='second';
+        }));
+    }
+
+    /** @test */
     public function it_can_get_the_path_to_first_media_in_a_collection()
     {
         $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');

--- a/tests/HasMediaTrait/GetMediaTest.php
+++ b/tests/HasMediaTrait/GetMediaTest.php
@@ -200,8 +200,8 @@ class GetMediaTest extends TestCase
         $secondMedia->name = 'second';
         $secondMedia->save();
 
-        $this->assertEquals($secondMedia->getUrl(), $this->testModel->getFirstMediaUrl('images', '', function($value, $key) {
-            return $value->name=='second';
+        $this->assertEquals($secondMedia->getUrl(), $this->testModel->getFirstMediaUrl('images', '', function ($value, $key) {
+            return $value->name == 'second';
         }));
     }
 


### PR DESCRIPTION
This should fix #911, and is my first contribution to this package. :)

Tested via the `it_can_get_the_url_to_first_media_in_a_collection_using_a_filter` method in `tests/HasMediaTrait/GetMediaTest.php`.

