### PR TITLE
publish static migration name

### DIFF
--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -19,11 +19,9 @@ class MediaLibraryServiceProvider extends ServiceProvider
             __DIR__.'/../config/medialibrary.php' => config_path('medialibrary.php'),
         ], 'config');
 
-        if (! class_exists('CreateMediaTable')) {
-            $this->publishes([
-                __DIR__.'/../database/migrations/create_media_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_media_table.php'),
-            ], 'migrations');
-        }
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_media_table.php.stub' => database_path('migrations/2018_03_20_105038_create_media_table.php'),
+        ], 'migrations');
 
         $mediaClass = config('medialibrary.media_model');
 


### PR DESCRIPTION
generate static migration file name to stop duplicate when run `php artisan vendor:publish`