### PR TITLE
Fixed 'updated' in observer

### DIFF
--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -24,7 +24,7 @@ class MediaObserver
             return;
         }
 
-        if ($media->manipulations !== json_decode($media->getOriginal('manipulations'))) {
+        if ($media->manipulations !== json_decode($media->getOriginal('manipulations'), true)) {
             app(FileManipulator::class)->createDerivedFiles($media);
         }
     }


### PR DESCRIPTION
Comparing array (see $casts on Media model) with model will always fail.

We do some direct setting of the manipulations array. According to the casts property that should go well. However, on save we noticed the manipulations being remade, even though nothing changed. That's because json_decode will by default return object, never equalling an array. 

Currently unfortunately not in position to provide tests. Would be nice if either this still could be merged or someone at Spatie could redo this pull with tests. Love your work guys.

