### PR TITLE
Custom headers for conversions

### DIFF
--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -60,6 +60,9 @@ class FileAdder
     /** @var bool */
     protected $generateResponsiveImages = false;
 
+    /** @var array */
+    protected $customHeaders = [];
+
     /**
      * @param Filesystem $fileSystem
      */
@@ -188,6 +191,8 @@ class FileAdder
 
     public function addCustomHeaders(array $customRemoteHeaders): self
     {
+        $this->customHeaders = $customRemoteHeaders;
+
         $this->filesystem->addCustomRemoteHeaders($customRemoteHeaders);
 
         return $this;
@@ -209,6 +214,7 @@ class FileAdder
         }
 
         $mediaClass = config('medialibrary.media_model');
+        /** @var \Spatie\MediaLibrary\Models\Media $media */
         $media = new $mediaClass();
 
         $media->name = $this->mediaName;
@@ -232,6 +238,8 @@ class FileAdder
         $media->responsive_images = [];
 
         $media->manipulations = $this->manipulations;
+
+        $media->setCustomHeaders($this->customHeaders);
 
         $media->fill($this->properties);
 

--- a/src/Filesystem/DefaultFilesystem.php
+++ b/src/Filesystem/DefaultFilesystem.php
@@ -51,7 +51,7 @@ class DefaultFilesystem implements Filesystem
 
         $this->filesystem
             ->disk($media->disk)
-            ->put($destination, $file, $this->getRemoteHeadersForFile($pathToFile));
+            ->put($destination, $file, $this->getRemoteHeadersForFile($pathToFile, $media->getCustomHeaders()));
 
         if (is_resource($file)) {
             fclose($file);
@@ -63,13 +63,13 @@ class DefaultFilesystem implements Filesystem
         $this->customRemoteHeaders = $customRemoteHeaders;
     }
 
-    public function getRemoteHeadersForFile(string $file) : array
+    public function getRemoteHeadersForFile(string $file, array $mediaCustomHeaders = []) : array
     {
         $mimeTypeHeader = ['ContentType' => File::getMimeType($file)];
 
         $extraHeaders = config('medialibrary.remote.extra_headers');
 
-        return array_merge($mimeTypeHeader, $extraHeaders, $this->customRemoteHeaders);
+        return array_merge($mimeTypeHeader, $extraHeaders, $this->customRemoteHeaders, $mediaCustomHeaders);
     }
 
     public function getStream(Media $media)

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -17,13 +17,15 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Spatie\MediaLibrary\Helpers\TemporaryDirectory;
 use Spatie\MediaLibrary\Conversion\ConversionCollection;
 use Spatie\MediaLibrary\ImageGenerators\FileTypes\Image;
+use Spatie\MediaLibrary\Models\Traits\CustomMediaProperties;
 use Spatie\MediaLibrary\UrlGenerator\UrlGeneratorFactory;
 use Spatie\MediaLibrary\ResponsiveImages\ResponsiveImages;
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
 
 class Media extends Model implements Responsable, Htmlable
 {
-    use IsSorted;
+    use IsSorted,
+        CustomMediaProperties;
 
     const TYPE_OTHER = 'other';
 
@@ -326,18 +328,6 @@ class Media extends Model implements Responsable, Htmlable
     public function responsiveImages(string $conversionName = ''): RegisteredResponsiveImages
     {
         return new RegisteredResponsiveImages($this, $conversionName);
-    }
-
-    public function setCustomHeaders(array $customHeaders): self
-    {
-        $this->setCustomProperty('custom_headers', $customHeaders);
-
-        return $this;
-    }
-
-    public function getCustomHeaders(): array
-    {
-        return $this->getCustomProperty('custom_headers', []);
     }
 
     public function stream()

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -17,7 +17,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Spatie\MediaLibrary\Helpers\TemporaryDirectory;
 use Spatie\MediaLibrary\Conversion\ConversionCollection;
 use Spatie\MediaLibrary\ImageGenerators\FileTypes\Image;
-use Spatie\MediaLibrary\ResponsiveImages\ResponsiveImage;
 use Spatie\MediaLibrary\UrlGenerator\UrlGeneratorFactory;
 use Spatie\MediaLibrary\ResponsiveImages\ResponsiveImages;
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
@@ -327,6 +326,18 @@ class Media extends Model implements Responsable, Htmlable
     public function responsiveImages(string $conversionName = ''): RegisteredResponsiveImages
     {
         return new RegisteredResponsiveImages($this, $conversionName);
+    }
+
+    public function setCustomHeaders(array $customHeaders): self
+    {
+        $this->setCustomProperty('custom_headers', $customHeaders);
+
+        return $this;
+    }
+
+    public function getCustomHeaders(): array
+    {
+        return $this->getCustomProperty('custom_headers', []);
     }
 
     public function stream()

--- a/src/Models/Traits/CustomMediaProperties.php
+++ b/src/Models/Traits/CustomMediaProperties.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\MediaLibrary\Models\Traits;
+
+trait CustomMediaProperties
+{
+    public function setCustomHeaders(array $customHeaders): self
+    {
+        $this->setCustomProperty('custom_headers', $customHeaders);
+
+        return $this;
+    }
+
+    public function getCustomHeaders(): array
+    {
+        return $this->getCustomProperty('custom_headers', []);
+    }
+}

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\MediaLibrary\Tests\Feature\S3Integration;
 
+use Aws\S3\S3Client;
 use Carbon\Carbon;
+use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Support\Facades\Storage;
 use Spatie\MediaLibrary\Tests\TestCase;
 
@@ -160,6 +162,35 @@ class S3IntegrationTest extends TestCase
         );
     }
 
+    /** @test */
+    public function custom_headers_are_used_for_all_conversions()
+    {
+        $media = $this->testModelWithConversion
+            ->addMedia($this->getTestJpg())
+            ->addCustomHeaders([
+                'ACL' => 'public-read',
+            ])
+            ->toMediaCollection('default', 's3_disk');
+
+        $client = $this->getS3Client();
+
+        /** @var \Aws\Result $responseForMainItem */
+        $responseForMainItem = $client->execute($client->getCommand('GetObjectAcl', [
+            'Bucket' => getenv('AWS_BUCKET'),
+            'Key' => $media->getPath(),
+        ]));
+
+        $this->assertEquals('READ', $responseForMainItem->get('Grants')[1]['Permission'] ?? null);
+
+        /** @var \Aws\Result $responseForConversion**/
+        $responseForConversion = $client->execute($client->getCommand('GetObjectAcl', [
+            'Bucket' => getenv('AWS_BUCKET'),
+            'Key' => $media->getPath('thumb'),
+        ]));
+
+        $this->assertEquals('READ', $responseForConversion->get('Grants')[1]['Permission'] ?? null);
+    }
+
     protected function cleanUpS3()
     {
         collect(Storage::disk('s3_disk')->allDirectories(self::getS3BaseTestDirectory()))->each(function ($directory) {
@@ -170,6 +201,17 @@ class S3IntegrationTest extends TestCase
     public function canTestS3()
     {
         return ! empty(getenv('AWS_KEY'));
+    }
+
+    protected function getS3Client(): S3Client
+    {
+        /** @var \Illuminate\Filesystem\FilesystemAdapter $disk */
+        $disk = app(Factory::class)->disk('s3_disk');
+
+        /** @var \Aws\S3\S3Client $client */
+        $client = $disk->getDriver()->getAdapter()->getClient();
+
+        return $client;
     }
 
     public static function getS3BaseTestDirectory(): string


### PR DESCRIPTION
This PR addresses #868 

The `DefaultFilesystem` is always re-created, and so looses the custom header information when saving a media item's conversions. This PR fixes that issue by persisting custom header configuration in the media item, and loading it again when saving a conversion.