### PR TITLE
Null check for placeholder svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 7.0.3 - 2018-03-21
+
+- Add null fallback when placeholder SVG isn't rendered yet (#967)
+
 ## 7.0.2 - 2018-03-21
 
 - Support custom headers for conversions (#868)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `laravel-medialibrary` will be documented in this file
 ## 7.0.3 - 2018-03-21
 
 - Add null fallback when placeholder SVG isn't rendered yet (#967)
+- Add ResponsiveImagesGenerated event
 
 ## 7.0.2 - 2018-03-21
 

--- a/src/Events/ResponsiveImagesGenerated.php
+++ b/src/Events/ResponsiveImagesGenerated.php
@@ -10,10 +10,10 @@ class ResponsiveImagesGenerated
     use SerializesModels;
 
     /** @var \Spatie\MediaLibrary\Models\Media */
-    public $model;
+    public $media;
 
-    public function __construct(Media $model)
+    public function __construct(Media $media)
     {
-        $this->model = $model;
+        $this->media = $media;
     }
 }

--- a/src/Events/ResponsiveImagesGenerated.php
+++ b/src/Events/ResponsiveImagesGenerated.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\MediaLibrary\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Spatie\MediaLibrary\Models\Media;
+
+class ResponsiveImagesGenerated
+{
+    use SerializesModels;
+
+    /** @var \Spatie\MediaLibrary\Models\Media */
+    public $model;
+
+    public function __construct(Media $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/src/ResponsiveImages/RegisteredResponsiveImages.php
+++ b/src/ResponsiveImages/RegisteredResponsiveImages.php
@@ -50,16 +50,19 @@ class RegisteredResponsiveImages
             })
             ->implode(', ');
 
-        if (config('medialibrary.responsive_images.use_tiny_placeholders')) {
-            $filesSrcset .= ', '.$this->getPlaceholderSvg().' 32w';
+        $mayAddPlaceholderSvg = config('medialibrary.responsive_images.use_tiny_placeholders')
+            && $this->getPlaceholderSvg();
+
+        if ($mayAddPlaceholderSvg) {
+            $filesSrcset .= ', ' . $this->getPlaceholderSvg() . ' 32w';
         }
 
         return $filesSrcset;
     }
 
-    public function getPlaceholderSvg(): string
+    public function getPlaceholderSvg(): ?string
     {
-        return $this->media->responsive_images[$this->generatedFor]['base64svg'];
+        return $this->media->responsive_images[$this->generatedFor]['base64svg'] ?? null;
     }
 
     public function delete()

--- a/src/ResponsiveImages/RegisteredResponsiveImages.php
+++ b/src/ResponsiveImages/RegisteredResponsiveImages.php
@@ -50,10 +50,10 @@ class RegisteredResponsiveImages
             })
             ->implode(', ');
 
-        $mayAddPlaceholderSvg = config('medialibrary.responsive_images.use_tiny_placeholders')
+        $shouldAddPlaceholderSvg = config('medialibrary.responsive_images.use_tiny_placeholders')
             && $this->getPlaceholderSvg();
 
-        if ($mayAddPlaceholderSvg) {
+        if ($shouldAddPlaceholderSvg) {
             $filesSrcset .= ', ' . $this->getPlaceholderSvg() . ' 32w';
         }
 

--- a/src/ResponsiveImages/ResponsiveImageGenerator.php
+++ b/src/ResponsiveImages/ResponsiveImageGenerator.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\ResponsiveImages;
 
 use Spatie\Image\Image;
+use Spatie\MediaLibrary\Events\ResponsiveImagesGenerated;
 use Spatie\MediaLibrary\Helpers\File;
 use Spatie\MediaLibrary\Models\Media;
 use Spatie\MediaLibrary\Conversion\Conversion;
@@ -48,6 +49,8 @@ class ResponsiveImageGenerator
         foreach ($this->widthCalculator->calculateWidthsFromFile($baseImage) as $width) {
             $this->generateResponsiveImage($media, $baseImage, 'medialibrary_original', $width, $temporaryDirectory);
         }
+
+        event(new ResponsiveImagesGenerated($media));
 
         $this->generateTinyJpg($media, $baseImage, 'medialibrary_original', $temporaryDirectory);
 

--- a/tests/Feature/ResponsiveImages/RegisteredResponsiveImagesTest.php
+++ b/tests/Feature/ResponsiveImages/RegisteredResponsiveImagesTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\MediaLibrary\Tests\Feature\ResponsiveImages;
 
+use Spatie\MediaLibrary\Models\Media;
+use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
 use Spatie\MediaLibrary\Tests\TestCase;
 
 class RegisteredResponsiveImagesTest extends TestCase
@@ -21,5 +23,28 @@ class RegisteredResponsiveImagesTest extends TestCase
             'test___medialibrary_original_284_233.jpg',
             'test___medialibrary_original_237_195.jpg',
         ], $media->responsive_images['medialibrary_original']['urls']);
+    }
+
+    /** @test */
+    public function it_can_render_a_srcset_when_the_base64svg_is_not_rendered_yet()
+    {
+        $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->withResponsiveImages()
+            ->toMediaCollection();
+
+        $media = $this->testModel->getFirstMedia();
+
+        $responsiveImages = $media->responsive_images;
+
+        unset($responsiveImages['medialibrary_original']['base64svg']);
+
+        $media->responsive_images = $responsiveImages;
+
+        $registeredResponsiveImage = new RegisteredResponsiveImages($media);
+
+        $this->assertNull($registeredResponsiveImage->getPlaceholderSvg());
+
+        $this->assertNotEmpty($registeredResponsiveImage->getSrcset());
     }
 }

--- a/tests/Feature/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/Feature/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -35,7 +35,7 @@ class ResponsiveImageGeneratorTest extends TestCase
     /** @test */
     public function it_triggers_an_event_when_the_responsive_images_are_generated()
     {
-        Event::fake([ResponsiveImagesGenerated::class]);
+        Event::fake(ResponsiveImagesGenerated::class);
 
         $this->testModelWithResponsiveImages
             ->addMedia($this->getTestJpg())

--- a/tests/Feature/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/Feature/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\MediaLibrary\Tests\Feature\ResponsiveImages;
 
+use Illuminate\Support\Facades\Event;
+use Spatie\MediaLibrary\Events\ResponsiveImagesGenerated;
 use Spatie\MediaLibrary\Tests\TestCase;
 
 class ResponsiveImageGeneratorTest extends TestCase
@@ -28,5 +30,18 @@ class ResponsiveImageGeneratorTest extends TestCase
                     ->toMediaCollection();
 
         $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___thumb_50_41.jpg'));
+    }
+
+    /** @test */
+    public function it_triggers_an_event_when_the_responsive_images_are_generated()
+    {
+        Event::fake([ResponsiveImagesGenerated::class]);
+
+        $this->testModelWithResponsiveImages
+            ->addMedia($this->getTestJpg())
+            ->withResponsiveImages()
+            ->toMediaCollection();
+
+        Event::assertDispatched(ResponsiveImagesGenerated::class);
     }
 }


### PR DESCRIPTION
This PR addresses #967.

The problem lies in the placeholder not being rendered with an asynchronous queue when rendering the image in a blade file. I've added a test which mimics this scenario, without relying on the whole queue setup. 