### PR TITLE
Fix responsive images rendering of conversions

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -229,7 +229,7 @@ class Media extends Model implements Responsable, Htmlable
 
     public function hasResponsiveImages(string $conversionName = ''): bool
     {
-        return count($this->getResponsiveImageUrls());
+        return count($this->getResponsiveImageUrls($conversionName));
     }
 
     public function getSrcset(string $conversionName = ''): string
@@ -279,7 +279,7 @@ class Media extends Model implements Responsable, Htmlable
 
         $width = '';
 
-        if ($this->hasResponsiveImages()) {
+        if ($this->hasResponsiveImages($conversion)) {
             $viewName = config('medialibrary.responsive_images.use_tiny_placeholders')
                 ? 'responsiveImageWithPlaceholder'
                 : 'responsiveImage';

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -94,6 +94,19 @@ class ToHtmlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_render_itself_with_responsive_images_of_a_conversion_and_a_placeholder()
+    {
+        $media = $this->testModelWithResponsiveImages
+            ->addMedia($this->getTestJpg())
+            ->toMediaCollection();
+
+        $image = $media->refresh()->img('thumb');
+
+        $this->assertEquals(1, substr_count($image, '/media/2/responsive-images/'));
+        $this->assertTrue(str_contains($image, 'data:image/svg+xml;base64,'));
+    }
+
+    /** @test */
     public function it_will_not_rendering_extra_javascript_or_including_base64_svg_when_tiny_placeholders_are_turned_off()
     {
         config()->set('medialibrary.responsive_images.use_tiny_placeholders', false);

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -103,7 +103,7 @@ class ToHtmlTest extends TestCase
         $image = $media->refresh()->img('thumb');
 
         $this->assertContains('/media/2/responsive-images/', $image);
-        $this->assertTrue(str_contains($image, 'data:image/svg+xml;base64,'));
+        $this->assertContains('data:image/svg+xml;base64,', $image);
     }
 
     /** @test */

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -102,7 +102,7 @@ class ToHtmlTest extends TestCase
 
         $image = $media->refresh()->img('thumb');
 
-        $this->assertEquals(1, substr_count($image, '/media/2/responsive-images/'));
+        $this->assertContains('/media/2/responsive-images/', $image);
         $this->assertTrue(str_contains($image, 'data:image/svg+xml;base64,'));
     }
 


### PR DESCRIPTION
At the moment the call to `hasResponsiveImages` in `img` only checks if there are any conversions on the current collection, ignoring the given conversion. In which case the rendered output of the conversion would not contain the `srcset` attribute.

This fix checks if there are any responsive images of the given conversion.