### PR TITLE
Sync both filename and disk

### DIFF
--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -14,8 +14,8 @@ class MediaObserver
 
     public function updating(Media $media)
     {
-        if ($media->file_name !== $media->getOriginal('file_name')) {
-            app(Filesystem::class)->syncFileNames($media);
+        if ($media->file_name !== $media->getOriginal('file_name') || $media->disk !== $media->getOriginal('disk')) {
+            app(Filesystem::class)->syncFiles($media);
         }
     }
 

--- a/tests/Feature/Media/ChangeDiskTest.php
+++ b/tests/Feature/Media/ChangeDiskTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Feature\Models\Media;
+
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class ChangeDiskTest extends TestCase
+{
+    /** @test */
+    public function it_wil_move_file_to_other_disk_if_it_is_changed_on_the_media_object()
+    {
+        $testFile = $this->getTestFilesDirectory('test.jpg');
+
+        $media = $this->testModel->addMedia($testFile)->toMediaCollection();
+
+        $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+
+        $media->disk = 'secondMediaDisk';
+        $media->save();
+
+        $this->assertFileNotExists($this->getMediaDirectory($media->id.'/test.jpg'));
+        $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
+    }
+
+    /** @test */
+    public function it_wil_move_and_rename_file_to_other_disk_if_it_is_changed_on_the_media_object()
+    {
+        $testFile = $this->getTestFilesDirectory('test.jpg');
+
+        $media = $this->testModel->addMedia($testFile)->toMediaCollection();
+
+        $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+
+        $media->disk = 'secondMediaDisk';
+        $media->file_name = 'new.jpg';
+        $media->save();
+
+        $this->assertFileNotExists($this->getMediaDirectory($media->id.'/test.jpg'));
+        $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/new.jpg');
+    }
+}


### PR DESCRIPTION
Simplified version of my earlier PR. 
Medialibrary allows changing the `file_name` and moves filesystem files accordingly. 
This is not the case with `disk`. 
This PR refactors the renaming functionality to not only sync filename, but disk as well. 