### PR TITLE
Add `hasGeneratedConversion` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 7.2.0 - 2018-04-30
+
+- Add `hasGeneratedConversion` helper on `Media` model.
+
 ## 7.1.8 - 2018-04-06
 
 - avoid removing the file when the model uses `SoftDeletes`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,12 @@
 
 Because there are many breaking changes an upgrade is not that easy. There are many edge cases this guide does not cover. We accept PRs to improve this guide.
 
+## 7.2.0
+
+- Before `hasGeneratedConversion` will work, the custom properties 
+of every media item will have to be re-written in the database, or all conversions must be regenerated.
+This won't break any existing code, but in order to use the new feature, you will need to do a manual update of your media items.
+
 ## 7.1.0
 
 - The `Filesystem` interface is removed, and the `DefaultFilesystem` implementation is renamed to `Filesystem`.

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -190,6 +190,8 @@ class CleanCommand extends Command
 
             $media->markAsConversionGenerated($generatedConversionName, false);
 
+            $media->save();
+
             break;
         }
     }

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -188,7 +188,7 @@ class CleanCommand extends Command
                 continue;
             }
 
-            $media->markAsConvertionGenerated($generatedConversionName, false);
+            $media->markAsConversionGenerated($generatedConversionName, false);
 
             break;
         }

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -120,6 +120,8 @@ class CleanCommand extends Command
             ->each(function (string $currentFilePath) use ($media) {
                 if (! $this->isDryRun) {
                     $this->fileSystem->disk($media->disk)->delete($currentFilePath);
+
+                    $this->markConversionAsRemoved($media, $currentFilePath);
                 }
 
                 $this->info("Deprecated conversion file `{$currentFilePath}` ".($this->isDryRun ? 'found' : 'has been removed'));
@@ -173,5 +175,22 @@ class CleanCommand extends Command
 
                 $this->info("Orphaned media directory `{$directory}` ".($this->isDryRun ? 'found' : 'has been removed'));
             });
+    }
+
+    protected function markConversionAsRemoved(Media $media, string $conversionPath)
+    {
+        $conversionFile = pathinfo($conversionPath, PATHINFO_FILENAME);
+
+        $generatedConversionName = null;
+
+        foreach ($media->getGeneratedConversions() as $generatedConversionName => $isGenerated) {
+            if (! str_contains($conversionFile, $generatedConversionName)) {
+                continue;
+            }
+
+            $media->markAsConvertionGenerated($generatedConversionName, false);
+
+            break;
+        }
     }
 }

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -183,16 +183,14 @@ class CleanCommand extends Command
 
         $generatedConversionName = null;
 
-        foreach ($media->getGeneratedConversions() as $generatedConversionName => $isGenerated) {
-            if (! str_contains($conversionFile, $generatedConversionName)) {
-                continue;
-            }
+        $media->getGeneratedConversions()
+            ->filter(function (bool $isGenerated, string $generatedConversionName) use ($conversionFile) {
+                return str_contains($conversionFile, $generatedConversionName);
+            })
+            ->each(function (bool $isGenerated, string $generatedConversionName) use ($media) {
+                $media->markAsConversionGenerated($generatedConversionName, false);
+            });
 
-            $media->markAsConversionGenerated($generatedConversionName, false);
-
-            $media->save();
-
-            break;
-        }
+        $media->save();
     }
 }

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -111,7 +111,7 @@ class FileManipulator
 
                 app(Filesystem::class)->copyToMediaLibrary($renamedFile, $media, 'conversions');
 
-                $media->markAsConvertionGenerated($conversion->getName(), true);
+                $media->markAsConversionGenerated($conversion->getName(), true);
 
                 event(new ConversionHasBeenCompleted($media, $conversion));
             });

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -111,7 +111,7 @@ class FileManipulator
 
                 app(Filesystem::class)->copyToMediaLibrary($renamedFile, $media, 'conversions');
 
-                $media->setConversionIsGenerated($conversion->getName(), true);
+                $media->markAsConvertionGenerated($conversion->getName(), true);
 
                 event(new ConversionHasBeenCompleted($media, $conversion));
             });

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -111,6 +111,8 @@ class FileManipulator
 
                 app(Filesystem::class)->copyToMediaLibrary($renamedFile, $media, 'conversions');
 
+                $media->setConversionIsGenerated($conversion->getName(), true);
+
                 event(new ConversionHasBeenCompleted($media, $conversion));
             });
 

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -205,6 +205,8 @@ class Media extends Model implements Responsable, Htmlable
     {
         $this->setCustomProperty("generated_conversions.{$conversionName}", $generated);
 
+        $this->save();
+
         return $this;
     }
 

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -201,7 +201,7 @@ class Media extends Model implements Responsable, Htmlable
         return $generatedConversions[$conversionName] ?? false;
     }
 
-    public function markAsConvertionGenerated(string $conversionName, bool $generated): self
+    public function markAsConversionGenerated(string $conversionName, bool $generated): self
     {
         $this->setCustomProperty("generated_conversions.{$conversionName}", $generated);
 

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -205,8 +205,6 @@ class Media extends Model implements Responsable, Htmlable
     {
         $this->setCustomProperty("generated_conversions.{$conversionName}", $generated);
 
-        $this->save();
-
         return $this;
     }
 

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -194,6 +194,25 @@ class Media extends Model implements Responsable, Htmlable
         })->toArray();
     }
 
+    public function hasGeneratedConversion(string $conversionName): bool
+    {
+        $generatedConversions = $this->getGeneratedConversions();
+
+        return $generatedConversions[$conversionName] ?? false;
+    }
+
+    public function setConversionIsGenerated(string $conversionName, bool $generated): self
+    {
+        $this->setCustomProperty("generated_conversions.{$conversionName}", $generated);
+
+        return $this;
+    }
+
+    public function getGeneratedConversions(): array
+    {
+        return $this->getCustomProperty('generated_conversions', []);
+    }
+
     /**
      * Create an HTTP response that represents the object.
      *

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -201,7 +201,7 @@ class Media extends Model implements Responsable, Htmlable
         return $generatedConversions[$conversionName] ?? false;
     }
 
-    public function setConversionIsGenerated(string $conversionName, bool $generated): self
+    public function markAsConvertionGenerated(string $conversionName, bool $generated): self
     {
         $this->setCustomProperty("generated_conversions.{$conversionName}", $generated);
 

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -208,9 +208,9 @@ class Media extends Model implements Responsable, Htmlable
         return $this;
     }
 
-    public function getGeneratedConversions(): array
+    public function getGeneratedConversions(): Collection
     {
-        return $this->getCustomProperty('generated_conversions', []);
+        return collect($this->getCustomProperty('generated_conversions', []));
     }
 
     /**

--- a/tests/Feature/Commands/CleanCommandTest/CleanConversionsTest.php
+++ b/tests/Feature/Commands/CleanCommandTest/CleanConversionsTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\MediaLibrary\Tests\Feature\Commands;
 
 use DB;
-use Illuminate\Support\Facades\Artisan;
 use Spatie\MediaLibrary\Models\Media;
+use Illuminate\Support\Facades\Artisan;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithConversion;
@@ -68,7 +68,7 @@ class CleanConversionsTest extends TestCase
         /** @var \Spatie\MediaLibrary\Models\Media $media */
         $media = $this->media['model2']['collection1'];
 
-        Media::where('id' , '<>', $media->id)->delete();
+        Media::where('id', '<>', $media->id)->delete();
 
         $media->markAsConvertionGenerated('test-deprecated', true);
 

--- a/tests/Feature/Commands/CleanCommandTest/CleanConversionsTest.php
+++ b/tests/Feature/Commands/CleanCommandTest/CleanConversionsTest.php
@@ -72,6 +72,8 @@ class CleanConversionsTest extends TestCase
 
         $media->markAsConversionGenerated('test-deprecated', true);
 
+        $media->save();
+
         $this->assertTrue($media->hasGeneratedConversion('test-deprecated'));
 
         $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-deprecated.jpg");

--- a/tests/Feature/Commands/CleanCommandTest/CleanConversionsTest.php
+++ b/tests/Feature/Commands/CleanCommandTest/CleanConversionsTest.php
@@ -4,6 +4,7 @@ namespace Spatie\MediaLibrary\Tests\Feature\Commands;
 
 use DB;
 use Illuminate\Support\Facades\Artisan;
+use Spatie\MediaLibrary\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithConversion;
@@ -59,6 +60,29 @@ class CleanConversionsTest extends TestCase
 
         $this->assertFileNotExists($deprecatedImage);
         $this->assertFileExists($this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg"));
+    }
+
+    /** @test */
+    public function generated_conversion_are_cleared_after_cleanup()
+    {
+        /** @var \Spatie\MediaLibrary\Models\Media $media */
+        $media = $this->media['model2']['collection1'];
+
+        Media::where('id' , '<>', $media->id)->delete();
+
+        $media->markAsConvertionGenerated('test-deprecated', true);
+
+        $this->assertTrue($media->hasGeneratedConversion('test-deprecated'));
+
+        $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-deprecated.jpg");
+
+        touch($deprecatedImage);
+
+        Artisan::call('medialibrary:clean');
+
+        $media->refresh();
+
+        $this->assertFalse($media->hasGeneratedConversion('test-deprecated'));
     }
 
     /** @test */

--- a/tests/Feature/Commands/CleanCommandTest/CleanConversionsTest.php
+++ b/tests/Feature/Commands/CleanCommandTest/CleanConversionsTest.php
@@ -70,7 +70,7 @@ class CleanConversionsTest extends TestCase
 
         Media::where('id', '<>', $media->id)->delete();
 
-        $media->markAsConvertionGenerated('test-deprecated', true);
+        $media->markAsConversionGenerated('test-deprecated', true);
 
         $this->assertTrue($media->hasGeneratedConversion('test-deprecated'));
 

--- a/tests/Feature/Media/HasConversionTest.php
+++ b/tests/Feature/Media/HasConversionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Feature\Media;
+
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class HasConversionTest extends TestCase
+{
+    /** @test */
+    public function test()
+    {
+        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
+
+        $this->assertTrue($media->hasGeneratedConversion('thumb'));
+    }
+}


### PR DESCRIPTION
This PR addresses #1020. **The current implementation of this branch is not finished yet.** I need some input though.

Because we want to do this in a non-breaking way for v7, we'll be using the custom properties of a media item to store whether a conversion has been generated or not. I've added some helper methods on the model so we can change this behaviour when v8 comes around. It would be better to not use the custom properties field, but rather a dedicated field for storing this information.

I don't think I've covered all possible scenarios with this implementation, but I'm unsure where I should add the following: what happens when a conversion file is removed?