### PR TITLE
Checking traits of parent classes when checking for SoftDeletes trait

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -41,7 +41,7 @@ trait HasMediaTrait
                 return;
             }
 
-            if (in_array(SoftDeletes::class, trait_uses_recursive($entity))) {
+            if (in_array(SoftDeletes::class, class_uses_recursive($entity))) {
                 if (! $entity->forceDeleting) {
                     return;
                 }


### PR DESCRIPTION
`trait_uses_recursive` does not include any traits used by a parent class while `class_uses_recursive` does.  
This change will prevent media from being deleted if your class inherits from a class that uses the SoftDeletes trait.  Addresses Issue #1049.