### PR TITLE
avoid removing the file when the model uses SoftDelete

### DIFF
--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -4,6 +4,7 @@ namespace Spatie\MediaLibrary;
 
 use Spatie\MediaLibrary\Models\Media;
 use Spatie\MediaLibrary\Filesystem\Filesystem;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class MediaObserver
 {
@@ -32,6 +33,12 @@ class MediaObserver
 
     public function deleted(Media $media)
     {
+        if (in_array(SoftDeletes::class, class_uses_recursive($media))) {
+            if (!$media->forceDeleting) {
+                return;
+            }
+        }
+
         app(Filesystem::class)->removeAllFiles($media);
     }
 }

--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -3,8 +3,8 @@
 namespace Spatie\MediaLibrary;
 
 use Spatie\MediaLibrary\Models\Media;
-use Spatie\MediaLibrary\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\MediaLibrary\Filesystem\Filesystem;
 
 class MediaObserver
 {
@@ -34,7 +34,7 @@ class MediaObserver
     public function deleted(Media $media)
     {
         if (in_array(SoftDeletes::class, class_uses_recursive($media))) {
-            if (!$media->forceDeleting) {
+            if (! $media->forceDeleting) {
                 return;
             }
         }

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -5,9 +5,9 @@ namespace Spatie\MediaLibrary\Tests\Feature\Models\Media;
 use File;
 use Spatie\MediaLibrary\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\MediaLibrary\Tests\Support\TestPathGenerator;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModel;
-use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DeleteTest extends TestCase
 {
@@ -114,6 +114,5 @@ class DeleteTest extends TestCase
         $testModel->delete();
 
         $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
-
     }
 }

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -7,6 +7,7 @@ use Spatie\MediaLibrary\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\Support\TestPathGenerator;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModel;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DeleteTest extends TestCase
 {
@@ -95,5 +96,24 @@ class DeleteTest extends TestCase
         $testModel->delete();
 
         $this->assertNull(Media::find($media->id));
+    }
+
+    /** @test */
+    public function it_will_not_remove_the_file_when_model_uses_softdelete()
+    {
+        $testModelClass = new class() extends TestModel {
+            use SoftDeletes;
+        };
+
+        $testModel = $testModelClass::find($this->testModel->id);
+
+        $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+
+        $testModel = $testModel->fresh();
+
+        $testModel->delete();
+
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+
     }
 }


### PR DESCRIPTION
Currently when we delete a media using SoftDelete, the Media row is keeped but the file is removed.
Now the file is still present on the system, and we are able to restore it.