### PR TITLE
Replace url encoded spaces in filenames when adding media from URL

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -129,6 +129,7 @@ trait HasMediaTrait
         $this->guardAgainstInvalidMimeType($temporaryFile, $allowedMimeTypes);
 
         $filename = basename(parse_url($url, PHP_URL_PATH));
+        $filename = str_replace('%20', ' ', $filename);
 
         if ($filename === '') {
             $filename = 'file';

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -320,6 +320,18 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function it_can_add_a_remote_file_with_a_space_in_the_name_to_the_medialibrary()
+    {
+        $url = 'http://spatie.github.io/laravel-medialibrary/tests/Support/testfiles/test%20with%20space.jpg';
+
+        $media = $this->testModel
+            ->addMediaFromUrl($url)
+            ->toMediaCollection();
+
+        $this->assertFileExists($this->getMediaDirectory("{$media->id}/test-with-space.jpg"));
+    }
+
+    /** @test */
     public function it_wil_thrown_an_exception_when_a_remote_file_could_not_be_added()
     {
         $url = 'https://docs.spatie.be/images/medialibrary/thisonedoesnotexist.jpg';


### PR DESCRIPTION
URLs that have encoded spaces (ex. %20) cause problems when creating the filename. It will save it with the %20 in the filename and the file won't be found later during conversion.