### PR TITLE
Fixes #1076

### DIFF
--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -26,7 +26,7 @@ class MediaObserver
             return;
         }
 
-        if ($media->manipulations !== json_decode($media->getOriginal('manipulations'))) {
+        if ($media->manipulations !== json_decode($media->getOriginal('manipulations'), true)) {
             app(FileManipulator::class)->createDerivedFiles($media);
         }
     }

--- a/tests/Feature/Media/UpdateManipulationsTest.php
+++ b/tests/Feature/Media/UpdateManipulationsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Feature\Media;
+
+use Spatie\MediaLibrary\Models\Media;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModel;
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class UpdateManipulationsTest extends TestCase
+{
+    /** @test */
+    public function it_will_create_derived_files_when_manipulations_have_changed()
+    {
+        $testModelClass = new class() extends TestModel
+        {
+            public function registerMediaConversions(Media $media = null)
+            {
+                $this->addMediaConversion('update_test');
+            }
+        };
+
+        $testModel = $testModelClass::find($this->testModel->id);
+
+        /** @var \Spatie\MediaLibrary\Models\Media $media */
+        $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+        touch($media->getPath('update_test'), time() - 1);
+        $conversionModificationTime = filemtime($media->getPath('update_test'));
+
+        $media->manipulations = [
+            'update_test' => [
+                'width' => 1,
+                'height' => 1
+            ]
+        ];
+        $media->save();
+        $modificationTimeAfterManipulationChanged = filemtime($media->getPath('update_test'));
+
+        $this->assertGreaterThan($conversionModificationTime, $modificationTimeAfterManipulationChanged);
+    }
+
+    /** @test */
+    public function it_will_not_create_derived_files_when_manipulations_have_not_changed()
+    {
+        $testModelClass = new class() extends TestModel
+        {
+            public function registerMediaConversions(Media $media = null)
+            {
+                $this->addMediaConversion('update_test');
+            }
+        };
+
+        $testModel = $testModelClass::find($this->testModel->id);
+
+        /** @var \Spatie\MediaLibrary\Models\Media $media */
+        $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+        $media->manipulations = [
+            'update_test' => [
+                'width' => 1,
+                'height' => 1
+            ]];
+        $media->save();
+
+        touch($media->getPath('update_test'), time() - 1);
+        $conversionModificationTime = filemtime($media->getPath('update_test'));
+
+        $media->manipulations = [
+            'update_test' => [
+                'width' => 1,
+                'height' => 1
+            ]];
+        $media->updated_at = now()->addSecond();
+        $media->save();
+
+        $modificationTimeAfterManipulationChanged = filemtime($media->getPath('update_test'));
+
+        $this->assertEquals($conversionModificationTime, $modificationTimeAfterManipulationChanged);
+    }
+}


### PR DESCRIPTION
See issue for details. The test setup was a bit tricky, because I couldn't really figure out how to check what the FileManipulator has done in the observer, so I just use the modification time.
Especially the test for not changed manipulations was tricky because by default we'll have an empty manipulations array, and then in the observer the `json_decode` will return an **array**, even though normally without the second parameter set to true it will return an object... Yeah, thanks php. (https://3v4l.org/2b5oD)