### PR TITLE
Reduce test failures on Windows by using DIRECTORY_SEPERATOR

### DIFF
--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -89,7 +89,7 @@ class ToHtmlTest extends TestCase
 
         $image = $media->refresh()->img();
 
-        $this->assertEquals(3, substr_count($image, '/media/2/responsive-images/'));
+        $this->assertEquals(3, substr_count($image, DIRECTORY_SEPARATOR . 'media/2/responsive-images/'));
         $this->assertTrue(str_contains($image, 'data:image/svg+xml;base64,'));
     }
 
@@ -102,7 +102,7 @@ class ToHtmlTest extends TestCase
 
         $image = $media->refresh()->img('thumb');
 
-        $this->assertContains('/media/2/responsive-images/', $image);
+        $this->assertContains(DIRECTORY_SEPARATOR . 'media/2/responsive-images/', $image);
         $this->assertContains('data:image/svg+xml;base64,', $image);
     }
 

--- a/tests/Feature/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/Feature/ResponsiveImages/ResponsiveImageTest.php
@@ -17,13 +17,13 @@ class ResponsiveImageTest extends TestCase
         $media = $this->testModelWithResponsiveImages->getFirstMedia();
 
         $this->assertEquals([
-            '/media/1/responsive-images/test___medialibrary_original_340_280.jpg',
-            '/media/1/responsive-images/test___medialibrary_original_284_233.jpg',
-            '/media/1/responsive-images/test___medialibrary_original_237_195.jpg',
+            DIRECTORY_SEPARATOR . 'media/1/responsive-images/test___medialibrary_original_340_280.jpg',
+            DIRECTORY_SEPARATOR . 'media/1/responsive-images/test___medialibrary_original_284_233.jpg',
+            DIRECTORY_SEPARATOR . 'media/1/responsive-images/test___medialibrary_original_237_195.jpg',
         ], $media->getResponsiveImageUrls());
 
         $this->assertEquals([
-            '/media/1/responsive-images/test___thumb_50_41.jpg',
+            DIRECTORY_SEPARATOR . 'media/1/responsive-images/test___thumb_50_41.jpg',
         ], $media->getResponsiveImageUrls('thumb'));
 
         $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -146,17 +146,17 @@ abstract class TestCase extends Orchestra
 
     public function getTempDirectory($suffix = '')
     {
-        return __DIR__.'/Support/temp'.($suffix == '' ? '' : '/'.$suffix);
+        return __DIR__ . DIRECTORY_SEPARATOR . 'Support' . DIRECTORY_SEPARATOR . 'temp' . ($suffix == '' ? '' : DIRECTORY_SEPARATOR . $suffix);
     }
 
     public function getMediaDirectory($suffix = '')
     {
-        return $this->getTempDirectory().'/media'.($suffix == '' ? '' : '/'.$suffix);
+        return $this->getTempDirectory() . DIRECTORY_SEPARATOR . 'media' . ($suffix == '' ? '' : DIRECTORY_SEPARATOR . $suffix);
     }
 
     public function getTestFilesDirectory($suffix = '')
     {
-        return $this->getTempDirectory().'/testfiles'.($suffix == '' ? '' : '/'.$suffix);
+        return $this->getTempDirectory() . DIRECTORY_SEPARATOR . 'testfiles' . ($suffix == '' ? '' : DIRECTORY_SEPARATOR . $suffix);
     }
 
     public function getTestJpg()


### PR DESCRIPTION
Fixes #1077  .
I skipped fixing the test with the literal html strings in it, then you get really really ugly strings, but if you want it all I can add those as well.

Also, I though about doing 
`define('DS', DIRECTORY_SEPARATOR)`
Don't know how you feel about that, and somehow I got definition errors or something.