### PR TITLE
Default Windows php has pdo_sqlite not enabled, error early

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "spatie/temporary-directory": "^1.1"
   },
   "require-dev": {
+    "ext-pdo_sqlite": "*",
     "doctrine/dbal": "^2.5.2",
     "guzzlehttp/guzzle": "^6.3",
     "league/flysystem-aws-s3-v3": "^1.0.13",


### PR DESCRIPTION
On Windows it's confusing to get error on database problem, so be more clear with this composer.json entry. All tests run with sqlite and an in-memory db.

Closes #1078 