### PR TITLE
Add functionality to allow comma-separated list into regenerate command

### DIFF
--- a/src/Commands/RegenerateCommand.php
+++ b/src/Commands/RegenerateCommand.php
@@ -89,6 +89,8 @@ class RegenerateCommand extends Command
         if ($mediaIds) {
             if (! is_array($mediaIds)) {
                 $mediaIds = explode(',', $mediaIds);
+            } elseif (count ($mediaIds) === 1 && str_contains($mediaIds[0], ',')) {
+                $mediaIds = explode(',', $mediaIds[0]);
             }
 
             return $this->mediaRepository->getByIds($mediaIds);

--- a/src/Commands/RegenerateCommand.php
+++ b/src/Commands/RegenerateCommand.php
@@ -89,7 +89,7 @@ class RegenerateCommand extends Command
         if ($mediaIds) {
             if (! is_array($mediaIds)) {
                 $mediaIds = explode(',', $mediaIds);
-            } elseif (count ($mediaIds) === 1 && str_contains($mediaIds[0], ',')) {
+            } elseif (count($mediaIds) === 1 && str_contains($mediaIds[0], ',')) {
                 $mediaIds = explode(',', $mediaIds[0]);
             }
 

--- a/tests/Feature/Commands/RegenerateCommandTest.php
+++ b/tests/Feature/Commands/RegenerateCommandTest.php
@@ -157,6 +157,33 @@ class RegenerateCommandTest extends TestCase
     }
 
     /** @test */
+    public function it_can_regenerate_files_by_comma_separated_media_ids()
+    {
+        $media = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+
+        $media2 = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->toMediaCollection('images');
+
+        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+
+        unlink($derivedImage);
+        unlink($derivedImage2);
+
+        $this->assertFileNotExists($derivedImage);
+        $this->assertFileNotExists($derivedImage2);
+
+        Artisan::call('medialibrary:regenerate', ['--ids' => ['1,2']]);
+
+        $this->assertFileExists($derivedImage);
+        $this->assertFileExists($derivedImage2);
+    }
+
+    /** @test */
     public function it_can_regenerate_files_even_if_there_are_files_missing()
     {
         $media = $this


### PR DESCRIPTION
This functionality allows a comma-separated list of IDs to be entered into the `medialibrary:regenerate` command. e.g. `medialibrary:regenerate --ids=1,2`

Fixes #1104 