### PR TITLE
Fix duplicate filenames in zip stream

### DIFF
--- a/src/MediaStream.php
+++ b/src/MediaStream.php
@@ -63,15 +63,51 @@ class MediaStream implements Responsable
         return new StreamedResponse(function () {
             $zip = new ZipStream($this->zipName);
 
-            $this->mediaItems->each(function (Media $media) use ($zip) {
-                $stream = $media->stream();
+            $this->getZipStreamContents()->each(function (array $mediaInZip) use ($zip) {
+                $stream = $mediaInZip['media']->stream();
 
-                $zip->addFileFromStream($media->file_name, $stream);
+                $zip->addFileFromStream($mediaInZip['fileNameInZip'], $stream);
 
                 fclose($stream);
             });
 
             $zip->finish();
         });
+    }
+
+    protected function getZipStreamContents(): Collection
+    {
+        return $this->mediaItems->map(function (Media $media, $mediaItemIndex) {
+            return [
+                'fileNameInZip' => $this->getFileNameWithSuffix($this->mediaItems, $mediaItemIndex),
+                'media' => $media,
+            ];
+        });
+    }
+
+    protected function getFileNameWithSuffix(Collection $mediaItems, int $currentIndex): string
+    {
+        $fileNameCount = 0;
+
+        $fileName = $mediaItems[$currentIndex]->file_name;
+
+        foreach($mediaItems as $index => $media) {
+            if ($index >= $currentIndex) {
+                break;
+            }
+
+            if ($media->file_name === $fileName) {
+                $fileNameCount++;
+            }
+        }
+
+        if ($fileNameCount === 0) {
+            return $fileName;
+        }
+
+        $extension = pathinfo($fileName, PATHINFO_EXTENSION);
+        $fileNameWithoutExtension = pathinfo($fileName, PATHINFO_FILENAME);
+
+        return "{$fileNameWithoutExtension} ({$fileNameCount}).{$extension}";
     }
 }

--- a/tests/Feature/MediaStreamTest.php
+++ b/tests/Feature/MediaStreamTest.php
@@ -6,7 +6,9 @@ use Spatie\MediaLibrary\MediaStream;
 use Illuminate\Support\Facades\Route;
 use Spatie\MediaLibrary\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use ZipArchive;
 
 class MediaStreamTest extends TestCase
 {
@@ -39,6 +41,24 @@ class MediaStreamTest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_a_stream_of_multiple_files_with_the_same_filename()
+    {
+        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+        ob_start();
+        @$zipStreamResponse->toResponse(request())->sendContent();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $temporaryDirectory = (new TemporaryDirectory())->create();
+        file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+        $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');
+        $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test (1).jpg');
+        $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test (2).jpg');
+    }
+
+    /** @test */
     public function media_can_be_added_to_it_one_by_one()
     {
         $zipStreamResponse = MediaStream::create('my-media.zip')
@@ -55,5 +75,23 @@ class MediaStreamTest extends TestCase
             ->addMedia([Media::find(1), Media::find(2)]);
 
         $this->assertEquals(2, $zipStreamResponse->getMediaItems()->count());
+    }
+
+    protected function assertFileExistsInZip($zipPath, $filename)
+    {
+        $this->assertTrue($this->fileExistsInZip($zipPath, $filename), "Failed to assert that {$zipPath} contains a file name {$filename}");
+    }
+    protected function assertFileDoesntExistsInZip($zipPath, $filename)
+    {
+        $this->assertFalse($this->fileExistsInZip($zipPath, $filename), "Failed to assert that {$zipPath} doesn't contain a file name {$filename}");
+    }
+    protected function fileExistsInZip($zipPath, $filename): bool
+    {
+        $zip = new ZipArchive();
+
+        if ($zip->open($zipPath) === true) {
+            return $zip->locateName($filename, ZipArchive::FL_NODIR) !== false;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
When creating a `MediaStream` files used to overwrite each other. This PR adds a suffix to duplicate files in a `MediaStream` to avoid this.

Image a `MediaStream` containing 3 `test.jpg` files; the resulting zip will contain;
```
test.jpg
test (1).jpg
test (2).jpg
```