### PR TITLE
Persist generated conversions

### DIFF
--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -112,6 +112,7 @@ class FileManipulator
                 app(Filesystem::class)->copyToMediaLibrary($renamedFile, $media, 'conversions');
 
                 $media->markAsConversionGenerated($conversion->getName(), true);
+                $media->save();
 
                 event(new ConversionHasBeenCompleted($media, $conversion));
             });

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -112,7 +112,6 @@ class FileManipulator
                 app(Filesystem::class)->copyToMediaLibrary($renamedFile, $media, 'conversions');
 
                 $media->markAsConversionGenerated($conversion->getName(), true);
-                $media->save();
 
                 event(new ConversionHasBeenCompleted($media, $conversion));
             });

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -204,7 +204,8 @@ class Media extends Model implements Responsable, Htmlable
     public function markAsConversionGenerated(string $conversionName, bool $generated): self
     {
         $this->setCustomProperty("generated_conversions.{$conversionName}", $generated);
-
+        $this->save();
+        
         return $this;
     }
 


### PR DESCRIPTION
When regenerating through the command line, the generated_conversions custom property is not stored in the database.
This seems to be because the custom field is set but the model is not saved.

I don't know if this line is the best place to do this, but in my installation it works.
Let me know if i should move it elsewhere.