### PR TITLE
clean responsive_images files and urls on (re)generation

### DIFF
--- a/src/ResponsiveImages/ResponsiveImageGenerator.php
+++ b/src/ResponsiveImages/ResponsiveImageGenerator.php
@@ -155,19 +155,23 @@ class ResponsiveImageGenerator
         }
     }
 
-    private function cleanResponsiveImages(Media $media, string $conversionName = 'medialibrary_original'): Media
+    private function cleanResponsiveImages(Media $media, string $conversionName = 'medialibrary_original') : Media
     {
         $responsiveImages = $media->responsive_images;
         $responsiveImages[$conversionName]['urls'] = [];
         $media->responsive_images = $responsiveImages;
 
+        $responsiveImagesDirectory = $this->filesystem->getResponsiveImagesDirectory($media);
+        $storage = Storage::disk($media->disk);
+
         $files = array_filter(
-            Storage::disk('media')->allFiles("{$media->id}/responsive-images"),
+            $storage->allFiles($responsiveImagesDirectory),
             function ($path) use ($conversionName) {
                 return str_contains($path, $conversionName);
             }
         );
-        Storage::disk('media')->delete($files);
+
+        $storage->delete($files);
 
         return $media;
     }

--- a/src/ResponsiveImages/ResponsiveImageGenerator.php
+++ b/src/ResponsiveImages/ResponsiveImageGenerator.php
@@ -4,6 +4,7 @@ namespace Spatie\MediaLibrary\ResponsiveImages;
 
 use Spatie\MediaLibrary\Helpers\File;
 use Spatie\MediaLibrary\Models\Media;
+use Illuminate\Support\Facades\Storage;
 use Spatie\MediaLibrary\Helpers\ImageFactory;
 use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\Filesystem\Filesystem;
@@ -13,7 +14,6 @@ use Spatie\MediaLibrary\ResponsiveImages\Exceptions\InvalidTinyJpg;
 use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\WidthCalculator;
 use Spatie\TemporaryDirectory\TemporaryDirectory as BaseTemporaryDirectory;
 use Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\TinyPlaceholderGenerator;
-use Illuminate\Support\Facades\Storage;
 
 class ResponsiveImageGenerator
 {
@@ -155,7 +155,7 @@ class ResponsiveImageGenerator
         }
     }
 
-    private function cleanResponsiveImages(Media $media, string $conversionName = 'medialibrary_original') : Media
+    protected function cleanResponsiveImages(Media $media, string $conversionName = 'medialibrary_original') : Media
     {
         $responsiveImages = $media->responsive_images;
         $responsiveImages[$conversionName]['urls'] = [];

--- a/src/ResponsiveImages/ResponsiveImageGenerator.php
+++ b/src/ResponsiveImages/ResponsiveImageGenerator.php
@@ -46,6 +46,8 @@ class ResponsiveImageGenerator
             $temporaryDirectory->path(str_random(16).'.'.$media->extension)
         );
 
+        $media = $this->cleanResponsiveImagesUrls($media, 'medialibrary_original');
+
         foreach ($this->widthCalculator->calculateWidthsFromFile($baseImage) as $width) {
             $this->generateResponsiveImage($media, $baseImage, 'medialibrary_original', $width, $temporaryDirectory);
         }
@@ -60,6 +62,8 @@ class ResponsiveImageGenerator
     public function generateResponsiveImagesForConversion(Media $media, Conversion $conversion, string $baseImage)
     {
         $temporaryDirectory = TemporaryDirectory::create();
+
+        $media = $this->cleanResponsiveImagesUrls($media, $conversion->getName());
 
         foreach ($this->widthCalculator->calculateWidthsFromFile($baseImage) as $width) {
             $this->generateResponsiveImage($media, $baseImage, $conversion->getName(), $width, $temporaryDirectory);
@@ -148,5 +152,14 @@ class ResponsiveImageGenerator
         if ($mimeType !== 'image/jpeg') {
             throw InvalidTinyJpg::hasWrongMimeType($tinyPlaceholderPath);
         }
+    }
+
+    private function cleanResponsiveImagesUrls(Media $media, string $conversionName)
+    {
+        $responsiveImages = $media->responsive_images;
+        $responsiveImages[$conversionName]['urls'] = [];
+        $media->responsive_images = $responsiveImages;
+
+        return $media;
     }
 }

--- a/tests/Feature/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/Feature/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Tests\Feature\ResponsiveImages;
 
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Artisan;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Events\ResponsiveImagesGenerated;
 
@@ -43,5 +44,22 @@ class ResponsiveImageGeneratorTest extends TestCase
             ->toMediaCollection();
 
         Event::assertDispatched(ResponsiveImagesGenerated::class);
+    }
+
+    /** @test */
+    public function it_cleans_the_responsive_images_urls_from_the_db_before_regeneration()
+    {
+        $media = $this->testModelWithResponsiveImages
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->withResponsiveImages()
+            ->toMediaCollection();
+
+        $this->assertCount(1, $media->fresh()->responsive_images['thumb']['urls']);
+
+        sleep(1);
+
+        Artisan::call('medialibrary:regenerate');
+
+        $this->assertCount(1, $media->fresh()->responsive_images['thumb']['urls']);
     }
 }


### PR DESCRIPTION
Related to #1115.

When generating responsive images the new urls are appended to the `urls` array in db, but that array is never cleaned, which means if we regenerate the images another time (using the artisan command for example) this new urls will also be applied to the `urls` array instead of replacing the existing one.

I also saw that when generating responsive images it wasn't removing the old physical files. This could be potentially harmful.
If you make a modification in a conversion size and regenerate images on your production env, the old images would still be present, thus it could still use those images because it matches the `sizes` attribute better.

I'm not sure this is the best way to achieve this, so comments are welcome 👍 