### PR TITLE
added original file location in ConversionWillStartEvent

### DIFF
--- a/src/Events/ConversionWillStart.php
+++ b/src/Events/ConversionWillStart.php
@@ -16,10 +16,15 @@ class ConversionWillStart
     /** @var \Spatie\MediaLibrary\Conversion\Conversion */
     public $conversion;
 
-    public function __construct(Media $media, Conversion $conversion)
+    /** @var String */
+    public $copiedOriginalFile;
+
+    public function __construct(Media $media, Conversion $conversion, String $copiedOriginalFile)
     {
         $this->media = $media;
 
         $this->conversion = $conversion;
+
+        $this->copiedOriginalFile = $copiedOriginalFile;
     }
 }

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -89,7 +89,7 @@ class FileManipulator
                 return $onlyIfMissing && Storage::disk($media->disk)->exists($relativePath);
             })
             ->each(function (Conversion $conversion) use ($media, $imageGenerator, $copiedOriginalFile) {
-                event(new ConversionWillStart($media, $conversion));
+                event(new ConversionWillStart($media, $conversion, $copiedOriginalFile));
 
                 $copiedOriginalFile = $imageGenerator->convert($copiedOriginalFile, $conversion);
 


### PR DESCRIPTION
Adding $copiedOriginalFile info in  ConversionWillStartEvent event, gives us ability to get extra info of  original file.

Like I have used to get duration and dimension for Video file and then save it back to media library as customeProperty.

Below is my piece of ConversionWillStartEvent Listener's code.

$ffmpeg =  FFMpeg::create([
                'ffmpeg.binaries' => config('medialibrary.ffmpeg_path'),
                'ffprobe.binaries' => config('medialibrary.ffprobe_path')
            ]);

            $ffprobe = $ffmpeg->getFFProbe();
            $file = $event->copiedOriginalFile;
            $probeVideo = $ffprobe->streams($file)
                                ->videos()                   
                                ->first();
          
            $duration = $probeVideo->get('duration');                    
            $videoDimension = $probeVideo->getDimensions();
            $width = $videoDimension->getWidth();
            $height = $videoDimension->getHeight();
            $event->media->setCustomProperty('duration', $duration)
                        ->setCustomProperty('width', $width)
                        ->setCustomProperty('height', $height)
                        ->save();

`

