### PR TITLE
Add ability to set relations to the saved media

### DIFF
--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -63,6 +63,9 @@ class FileAdder
     /** @var array */
     protected $customHeaders = [];
 
+    /** @var array */
+    protected $relations = [];
+
     /**
      * @param Filesystem $fileSystem
      */
@@ -182,6 +185,13 @@ class FileAdder
         return $this->withProperties($properties);
     }
 
+    public function withRelations(array $relations): self
+    {
+        $this->relations = $relations;
+
+        return $this;
+    }
+
     public function withResponsiveImages(): self
     {
         $this->generateResponsiveImages = true;
@@ -242,6 +252,8 @@ class FileAdder
         $media->setCustomHeaders($this->customHeaders);
 
         $media->fill($this->properties);
+
+        $media->setRelations($this->relations);
 
         $this->attachMedia($media);
 

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -564,7 +564,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    function it_can_set_relations_to_the_saved_media()
+    public function it_can_set_relations_to_the_saved_media()
     {
         $media = $this->testModel
             ->addMedia($this->getTestJpg())

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -562,4 +562,15 @@ class IntegrationTest extends TestCase
 
         $this->assertCount(2, $media);
     }
+
+    /** @test */
+    function it_can_set_relations_to_the_saved_media()
+    {
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->withRelations(['model' => $this->testModel])
+            ->toMediaCollection();
+
+        $this->assertSame($this->testModel, $media->model);
+    }
 }


### PR DESCRIPTION
I have custom PathGenerator implementation which depends on some model attributes:

```php
class MyPathGenerator implements PathGenerator
{
    public function getPath(Media $media): string
    {
        return $this->getBasePath($media).'/';
    }

    public function getPathForConversions(Media $media): string
    {
        return $this->getBasePath($media).'/conversions/';
    }

    public function getPathForResponsiveImages(Media $media): string
    {
        return $this->getBasePath($media).'/responsive-images/';
    }

    protected function getBasePath(Media $media): string
    {
        return $media->model->getMediaPath();
    }
}
```

When I add many media items, `$media->model->getMediaPath()` performs a query on the database 
 to load `model`. So we need to make N + 1 queries.

This PR adds ability to set relations to the saved media:

```php
foreach ($files as $file) {
    $model
        ->addMedia($file)
        ->withRelations(['model' => $model]) // solves the N + 1 problem
        ->toMediaCollection();
}
```