### PR TITLE
Added getFirstMediaFullUrl method to HasMediaTrait

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -246,6 +246,22 @@ trait HasMediaTrait
     }
 
     /*
+     * Get the full url of the image for the given conversionName
+     * for first media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getFirstMediaFullUrl(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        $media = $this->getFirstMedia($collectionName);
+
+        if (! $media) {
+            return '';
+        }
+
+        return $media->getFullUrl($conversionName);
+    }
+
+    /*
      * Get the url of the image for the given conversionName
      * for first media for the given collectionName.
      * If no profile is given, return the source's url.

--- a/tests/Feature/HasMediaTrait/GetMediaTest.php
+++ b/tests/Feature/HasMediaTrait/GetMediaTest.php
@@ -190,6 +190,18 @@ class GetMediaTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_full_url_to_first_media_in_a_collection()
+    {
+        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $firstMedia->save();
+
+        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $secondMedia->save();
+
+        $this->assertEquals($firstMedia->getFullUrl(), $this->testModel->getFirstMediaFullUrl('images'));
+    }
+
+    /** @test */
     public function it_can_get_the_path_to_first_media_in_a_collection()
     {
         $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');


### PR DESCRIPTION
I quite often need to get the **full** url of the image for first media, but currently I don't have such ability.
So I've added `getFirstMediaFullUrl` method to `HasMediaTrait`.