### PR TITLE
Added support for absolute urls to use a responsive image sources

### DIFF
--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -68,6 +68,12 @@ return [
          * the medialibrary will use a tiny blurred jpg image.
          */
         'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
+
+        /*
+         * By enabling this setting, the sources generated for the responsive images
+         * will include the domain based on the app url.
+         */
+        'generate_absolute_urls' => false,
     ],
 
     /*

--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -68,12 +68,6 @@ return [
          * the medialibrary will use a tiny blurred jpg image.
          */
         'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
-
-        /*
-         * By enabling this setting, the sources generated for the responsive images
-         * will include the domain based on the app url.
-         */
-        'generate_absolute_urls' => false,
     ],
 
     /*

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -107,6 +107,6 @@ class LocalUrlGenerator extends BaseUrlGenerator
      */
     public function getResponsiveImagesDirectoryUrl(): string
     {
-        return $this->getResponsiveDomain().'/'.$this->getBaseMediaDirectoryUrl().'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
+        return $this->getResponsiveDomain().$this->getBaseMediaDirectoryUrl().'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
     }
 }

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -93,11 +93,11 @@ class LocalUrlGenerator extends BaseUrlGenerator
      */
     protected function getResponsiveDomain(): string
     {
-        if (!$this->config->get('medialibrary.responsive_images.generate_absolute_urls')) {
-            return '';
+        if ($this->config->get('medialibrary.responsive_images.generate_absolute_urls')) {
+            return url('');
         }
 
-        return url('');
+        return '';
     }
 
     /**

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -86,20 +86,6 @@ class LocalUrlGenerator extends BaseUrlGenerator
         return $url;
     }
 
-    /*
-     * Returns the base url if the setting allows for it
-     *
-     * @return string
-     */
-    protected function getResponsiveDomain(): string
-    {
-        if ($this->config->get('medialibrary.responsive_images.generate_absolute_urls')) {
-            return url('');
-        }
-
-        return '';
-    }
-
     /**
      * Get the url to the directory containing responsive images.
      *
@@ -107,6 +93,6 @@ class LocalUrlGenerator extends BaseUrlGenerator
      */
     public function getResponsiveImagesDirectoryUrl(): string
     {
-        return $this->getResponsiveDomain().$this->getBaseMediaDirectoryUrl().'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
+        return url().$this->getBaseMediaDirectoryUrl().'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
     }
 }

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -86,6 +86,20 @@ class LocalUrlGenerator extends BaseUrlGenerator
         return $url;
     }
 
+    /*
+     * Returns the base url if settings allow for it
+     *
+     * @return string
+     */
+    protected function getResponsiveDomain(): string
+    {
+        if (!$this->config->get('medialibrary.responsive_images.generate_absolute_urls')) {
+            return '';
+        }
+
+        return url('');
+    }
+
     /**
      * Get the url to the directory containing responsive images.
      *
@@ -93,6 +107,6 @@ class LocalUrlGenerator extends BaseUrlGenerator
      */
     public function getResponsiveImagesDirectoryUrl(): string
     {
-        return $this->getBaseMediaDirectoryUrl().'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
+        return $this->getResponsiveDomain().'/'.$this->getBaseMediaDirectoryUrl().'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
     }
 }

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -93,6 +93,6 @@ class LocalUrlGenerator extends BaseUrlGenerator
      */
     public function getResponsiveImagesDirectoryUrl(): string
     {
-        return url().$this->getBaseMediaDirectoryUrl().'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
+        return url($this->getBaseMediaDirectoryUrl().'/'.$this->pathGenerator->getPathForResponsiveImages($this->media)).'/';
     }
 }

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -87,7 +87,7 @@ class LocalUrlGenerator extends BaseUrlGenerator
     }
 
     /*
-     * Returns the base url if settings allow for it
+     * Returns the base url if the setting allows for it
      *
      * @return string
      */

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -118,6 +118,6 @@ class ToHtmlTest extends TestCase
 
         $imgTag = $media->refresh()->img();
 
-        $this->assertEquals('<img srcset="/media/2/responsive-images/test___medialibrary_original_340_280.jpg 340w, /media/2/responsive-images/test___medialibrary_original_284_233.jpg 284w, /media/2/responsive-images/test___medialibrary_original_237_195.jpg 237w" src="/media/2/test.jpg" width="340">', $imgTag);
+        $this->assertEquals('<img srcset="http://localhost/media/2/responsive-images/test___medialibrary_original_340_280.jpg 340w, http://localhost/media/2/responsive-images/test___medialibrary_original_284_233.jpg 284w, http://localhost/media/2/responsive-images/test___medialibrary_original_237_195.jpg 237w" src="/media/2/test.jpg" width="340">', $imgTag);
     }
 }

--- a/tests/Feature/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/Feature/ResponsiveImages/ResponsiveImageTest.php
@@ -17,13 +17,13 @@ class ResponsiveImageTest extends TestCase
         $media = $this->testModelWithResponsiveImages->getFirstMedia();
 
         $this->assertEquals([
-            '/media/1/responsive-images/test___medialibrary_original_340_280.jpg',
-            '/media/1/responsive-images/test___medialibrary_original_284_233.jpg',
-            '/media/1/responsive-images/test___medialibrary_original_237_195.jpg',
+            'http://localhost/media/1/responsive-images/test___medialibrary_original_340_280.jpg',
+            'http://localhost/media/1/responsive-images/test___medialibrary_original_284_233.jpg',
+            'http://localhost/media/1/responsive-images/test___medialibrary_original_237_195.jpg',
         ], $media->getResponsiveImageUrls());
 
         $this->assertEquals([
-            '/media/1/responsive-images/test___thumb_50_41.jpg',
+            'http://localhost/media/1/responsive-images/test___thumb_50_41.jpg',
         ], $media->getResponsiveImageUrls('thumb'));
 
         $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));
@@ -40,13 +40,13 @@ class ResponsiveImageTest extends TestCase
         $media = $this->testModelWithResponsiveImages->getFirstMedia();
 
         $this->assertContains(
-            '/media/1/responsive-images/test___medialibrary_original_340_280.jpg 340w, /media/1/responsive-images/test___medialibrary_original_284_233.jpg 284w, /media/1/responsive-images/test___medialibrary_original_237_195.jpg 237w',
+            'http://localhost/media/1/responsive-images/test___medialibrary_original_340_280.jpg 340w, http://localhost/media/1/responsive-images/test___medialibrary_original_284_233.jpg 284w, http://localhost/media/1/responsive-images/test___medialibrary_original_237_195.jpg 237w',
              $media->getSrcset()
         );
         $this->assertContains('data:image/svg+xml;base64', $media->getSrcset());
 
         $this->assertContains(
-            '/media/1/responsive-images/test___thumb_50_41.jpg 50w',
+            'http://localhost/media/1/responsive-images/test___thumb_50_41.jpg 50w',
              $media->getSrcset('thumb')
         );
         $this->assertContains('data:image/svg+xml;base64,', $media->getSrcset('thumb'));


### PR DESCRIPTION
This PR allows absolute urls to be generated as sources for responsive images. This can be helpful if the html will be used on a different domain than the laravel instance is running on.