### PR TITLE
Add support for forcing checks of both mimetype extension

### DIFF
--- a/src/ImageGenerators/BaseGenerator.php
+++ b/src/ImageGenerators/BaseGenerator.php
@@ -13,15 +13,14 @@ abstract class BaseGenerator implements ImageGenerator
             return false;
         }
 
-        if ($this->supportedExtensions()->contains(strtolower($media->extension))) {
-            return true;
+        $validExtension = $this->canHandleExtension(strtolower($media->extension));
+        $validMimeType = $this->canHandleMime(strtolower($media->mime_type));
+
+        if ($this->shouldMatchBothExtensionsAndMimeTypes()) {
+            return $validExtension && $validMimeType;
         }
 
-        if ($this->supportedMimetypes()->contains(strtolower($media->mime_type))) {
-            return true;
-        }
-
-        return false;
+        return $validExtension || $validMimeType;
     }
 
     public function canHandleMime(string $mime = ''): bool
@@ -32,6 +31,11 @@ abstract class BaseGenerator implements ImageGenerator
     public function canHandleExtension(string $extension = ''): bool
     {
         return $this->supportedExtensions()->contains($extension);
+    }
+
+    public function shouldMatchBothExtensionsAndMimeTypes(): bool
+    {
+        return false;
     }
 
     public function getType(): string

--- a/tests/Support/TestImageGenerator.php
+++ b/tests/Support/TestImageGenerator.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support;
+
+use Illuminate\Support\Collection;
+use Spatie\MediaLibrary\Conversion\Conversion;
+use Spatie\MediaLibrary\ImageGenerators\BaseGenerator;
+
+class TestImageGenerator extends BaseGenerator
+{
+    public $supportedMimetypes;
+    public $supportedExtensions;
+    public $shouldMatchBothExtensionsAndMimetypes = false;
+
+    public function __construct()
+    {
+        $this->supportedExtensions = new Collection();
+        $this->supportedMimetypes = new Collection();
+    }
+
+    public function supportedExtensions(): Collection
+    {
+        return $this->supportedExtensions;
+    }
+
+    public function supportedMimetypes(): Collection
+    {
+        return $this->supportedMimetypes;
+    }
+
+    public function shouldMatchBothExtensionsAndMimeTypes(): bool
+    {
+        return $this->shouldMatchBothExtensionsAndMimetypes;
+    }
+
+    public function convert(string $path, Conversion $conversion = null): string
+    {
+        return $path;
+    }
+
+    public function requirementsAreInstalled(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/ImageGenerators/DualTypeCheckingTest.php
+++ b/tests/Unit/ImageGenerators/DualTypeCheckingTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\MediaLibrary\Tests\Unit\ImageGenerators;
 
 use Spatie\MediaLibrary\Models\Media;
-use Spatie\MediaLibrary\Tests\Support\TestImageGenerator;
 use Spatie\MediaLibrary\Tests\TestCase;
+use Spatie\MediaLibrary\Tests\Support\TestImageGenerator;
 
 class DualTypeCheckingTest extends TestCase
 {
@@ -18,8 +18,8 @@ class DualTypeCheckingTest extends TestCase
         $generator->supportedExtensions->push('supported-extension');
 
         $media = new Media();
-        $media->mime_type = "supported-mime-type";
-        $media->file_name = "some-file.supported-extension";
+        $media->mime_type = 'supported-mime-type';
+        $media->file_name = 'some-file.supported-extension';
 
         $this->assertTrue($generator->canConvert($media));
     }
@@ -34,8 +34,8 @@ class DualTypeCheckingTest extends TestCase
         $generator->supportedExtensions->push('supported-extension');
 
         $media = new Media();
-        $media->mime_type = "invalid-mime-type";
-        $media->file_name = "some-file.invalid-extension";
+        $media->mime_type = 'invalid-mime-type';
+        $media->file_name = 'some-file.invalid-extension';
 
         $this->assertFalse($generator->canConvert($media));
     }
@@ -50,8 +50,8 @@ class DualTypeCheckingTest extends TestCase
         $generator->supportedExtensions->push('supported-extension');
 
         $media = new Media();
-        $media->mime_type = "supported-mime-type";
-        $media->file_name = "some-file.invalid-extension";
+        $media->mime_type = 'supported-mime-type';
+        $media->file_name = 'some-file.invalid-extension';
 
         $this->assertFalse($generator->canConvert($media));
     }
@@ -66,8 +66,8 @@ class DualTypeCheckingTest extends TestCase
         $generator->supportedMimetypes->push('supported-mime-type');
 
         $media = new Media();
-        $media->mime_type = "invalid-mime-type";
-        $media->file_name = "some-file.supported-extension";
+        $media->mime_type = 'invalid-mime-type';
+        $media->file_name = 'some-file.supported-extension';
 
         $this->assertFalse($generator->canConvert($media));
     }

--- a/tests/Unit/ImageGenerators/DualTypeCheckingTest.php
+++ b/tests/Unit/ImageGenerators/DualTypeCheckingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Unit\ImageGenerators;
+
+use Spatie\MediaLibrary\Models\Media;
+use Spatie\MediaLibrary\Tests\Support\TestImageGenerator;
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class DualTypeCheckingTest extends TestCase
+{
+    /** @test */
+    public function it_can_convert_an_image_with_a_valid_extension_and_mime_type()
+    {
+        $generator = new TestImageGenerator();
+        $generator->shouldMatchBothExtensionsAndMimetypes = true;
+
+        $generator->supportedMimetypes->push('supported-mime-type');
+        $generator->supportedExtensions->push('supported-extension');
+
+        $media = new Media();
+        $media->mime_type = "supported-mime-type";
+        $media->file_name = "some-file.supported-extension";
+
+        $this->assertTrue($generator->canConvert($media));
+    }
+
+    /** @test */
+    public function it_cannot_convert_an_image_with_an_invalid_extension_and_mime_type()
+    {
+        $generator = new TestImageGenerator();
+        $generator->shouldMatchBothExtensionsAndMimetypes = true;
+
+        $generator->supportedMimetypes->push('supported-mime-type');
+        $generator->supportedExtensions->push('supported-extension');
+
+        $media = new Media();
+        $media->mime_type = "invalid-mime-type";
+        $media->file_name = "some-file.invalid-extension";
+
+        $this->assertFalse($generator->canConvert($media));
+    }
+
+    /** @test */
+    public function it_cannot_convert_an_image_with_only_a_valid_mime_type()
+    {
+        $generator = new TestImageGenerator();
+        $generator->shouldMatchBothExtensionsAndMimetypes = true;
+
+        $generator->supportedMimetypes->push('supported-mime-type');
+        $generator->supportedExtensions->push('supported-extension');
+
+        $media = new Media();
+        $media->mime_type = "supported-mime-type";
+        $media->file_name = "some-file.invalid-extension";
+
+        $this->assertFalse($generator->canConvert($media));
+    }
+
+    /** @test */
+    public function it_cannot_convert_an_image_with_only_a_valid_extension()
+    {
+        $generator = new TestImageGenerator();
+        $generator->shouldMatchBothExtensionsAndMimetypes = true;
+
+        $generator->supportedExtensions->push('supported-extension');
+        $generator->supportedMimetypes->push('supported-mime-type');
+
+        $media = new Media();
+        $media->mime_type = "invalid-mime-type";
+        $media->file_name = "some-file.supported-extension";
+
+        $this->assertFalse($generator->canConvert($media));
+    }
+}

--- a/tests/Unit/ImageGenerators/NormalTypeCheckingTest.php
+++ b/tests/Unit/ImageGenerators/NormalTypeCheckingTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Unit\ImageGenerators;
+
+use Spatie\MediaLibrary\Models\Media;
+use Spatie\MediaLibrary\Tests\Support\TestImageGenerator;
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class NormalTypeCheckingTest extends TestCase
+{
+    /** @test */
+    public function it_can_convert_an_image_with_a_valid_extension_and_mime_type()
+    {
+        $generator = new TestImageGenerator();
+
+        $generator->supportedMimetypes->push('supported-mime-type');
+        $generator->supportedExtensions->push('supported-extension');
+
+        $media = new Media();
+        $media->mime_type = "supported-mime-type";
+        $media->file_name = "some-file.supported-extension";
+
+        $this->assertTrue($generator->canConvert($media));
+    }
+
+    /** @test */
+    public function it_cannot_convert_an_image_with_an_invalid_extension_and_mime_type()
+    {
+        $generator = new TestImageGenerator();
+
+        $generator->supportedMimetypes->push('supported-mime-type');
+        $generator->supportedExtensions->push('supported-extension');
+
+        $media = new Media();
+        $media->mime_type = "invalid-mime-type";
+        $media->file_name = "some-file.invalid-extension";
+
+        $this->assertFalse($generator->canConvert($media));
+    }
+
+    /** @test */
+    public function it_can_convert_an_image_with_only_a_valid_mime_type()
+    {
+        $generator = new TestImageGenerator();
+
+        $generator->supportedMimetypes->push('supported-mime-type');
+        $generator->supportedExtensions->push('supported-extension');
+
+        $media = new Media();
+        $media->mime_type = "supported-mime-type";
+        $media->file_name = "some-file.invalid-extension";
+
+        $this->assertTrue($generator->canConvert($media));
+    }
+
+    /** @test */
+    public function it_can_convert_an_image_with_only_a_valid_extension()
+    {
+        $generator = new TestImageGenerator();
+
+        $generator->supportedExtensions->push('supported-extension');
+        $generator->supportedMimetypes->push('supported-mime-type');
+
+        $media = new Media();
+        $media->mime_type = "invalid-mime-type";
+        $media->file_name = "some-file.supported-extension";
+
+        $this->assertTrue($generator->canConvert($media));
+    }
+}

--- a/tests/Unit/ImageGenerators/NormalTypeCheckingTest.php
+++ b/tests/Unit/ImageGenerators/NormalTypeCheckingTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\MediaLibrary\Tests\Unit\ImageGenerators;
 
 use Spatie\MediaLibrary\Models\Media;
-use Spatie\MediaLibrary\Tests\Support\TestImageGenerator;
 use Spatie\MediaLibrary\Tests\TestCase;
+use Spatie\MediaLibrary\Tests\Support\TestImageGenerator;
 
 class NormalTypeCheckingTest extends TestCase
 {
@@ -17,8 +17,8 @@ class NormalTypeCheckingTest extends TestCase
         $generator->supportedExtensions->push('supported-extension');
 
         $media = new Media();
-        $media->mime_type = "supported-mime-type";
-        $media->file_name = "some-file.supported-extension";
+        $media->mime_type = 'supported-mime-type';
+        $media->file_name = 'some-file.supported-extension';
 
         $this->assertTrue($generator->canConvert($media));
     }
@@ -32,8 +32,8 @@ class NormalTypeCheckingTest extends TestCase
         $generator->supportedExtensions->push('supported-extension');
 
         $media = new Media();
-        $media->mime_type = "invalid-mime-type";
-        $media->file_name = "some-file.invalid-extension";
+        $media->mime_type = 'invalid-mime-type';
+        $media->file_name = 'some-file.invalid-extension';
 
         $this->assertFalse($generator->canConvert($media));
     }
@@ -47,8 +47,8 @@ class NormalTypeCheckingTest extends TestCase
         $generator->supportedExtensions->push('supported-extension');
 
         $media = new Media();
-        $media->mime_type = "supported-mime-type";
-        $media->file_name = "some-file.invalid-extension";
+        $media->mime_type = 'supported-mime-type';
+        $media->file_name = 'some-file.invalid-extension';
 
         $this->assertTrue($generator->canConvert($media));
     }
@@ -62,8 +62,8 @@ class NormalTypeCheckingTest extends TestCase
         $generator->supportedMimetypes->push('supported-mime-type');
 
         $media = new Media();
-        $media->mime_type = "invalid-mime-type";
-        $media->file_name = "some-file.supported-extension";
+        $media->mime_type = 'invalid-mime-type';
+        $media->file_name = 'some-file.supported-extension';
 
         $this->assertTrue($generator->canConvert($media));
     }


### PR DESCRIPTION
This PR allows the BaseGenerator class to be configured so a check of both the mimetype and file extension are forced.

The default behaviour remains unchainged: a generator matches files with either a valid mimetype OR extension (or both).
Returning true in the method `shouldMatchBothExtensionsAndMimeTypes` only matches files with a valid mimetype AND extension.

This PR is in response to issue #1173 