### PR TITLE
Fix CleanCommand

### DIFF
--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -102,7 +102,9 @@ class CleanCommand extends Command
     {
         $this->getMediaItems()->each(function (Media $media) {
             $this->deleteConversionFilesForDeprecatedConversions($media);
-            $this->deleteResponsiveImagesForDeprecatedConversions($media);
+            if ($media->responsive_images) {
+                $this->deleteResponsiveImagesForDeprecatedConversions($media);
+            }
         });
     }
 


### PR DESCRIPTION
Threw an error when media did not have responsive images:

```
In CleanCommand.php line 139:
array_keys() expects parameter 1 to be array, null given  
```