### PR TITLE
Add a simple rate limiting strategy to CleanCommand

### DIFF
--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -71,7 +71,7 @@ class CleanCommand extends Command
         }
 
         $this->isDryRun = $this->option('dry-run');
-        $this->rateLimit = (int)$this->option('rate-limit');
+        $this->rateLimit = (int) $this->option('rate-limit');
 
         $this->deleteFilesGeneratedForDeprecatedConversions();
 
@@ -107,11 +107,11 @@ class CleanCommand extends Command
     {
         $this->getMediaItems()->each(function (Media $media) {
             $this->deleteConversionFilesForDeprecatedConversions($media);
-          
+
             if ($media->responsive_images) {
                 $this->deleteResponsiveImagesForDeprecatedConversions($media);
             }
-          
+
             if ($this->rateLimit) {
                 usleep((1 / $this->rateLimit) * 1000000 * 2);
             }

--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -21,7 +21,8 @@ class CleanCommand extends Command
 
     protected $signature = 'medialibrary:clean {modelType?} {collectionName?} {disk?}
     {--dry-run : List files that will be removed without removing them},
-    {--force : Force the operation to run when in production}';
+    {--force : Force the operation to run when in production},
+    {--rate-limit= : Limit the number of request per second }';
 
     protected $description = 'Clean deprecated conversions and files without related model.';
 
@@ -39,6 +40,9 @@ class CleanCommand extends Command
 
     /** @var bool */
     protected $isDryRun = false;
+
+    /** @var int */
+    protected $rateLimit = 0;
 
     /**
      * @param \Spatie\MediaLibrary\MediaRepository                 $mediaRepository
@@ -67,6 +71,7 @@ class CleanCommand extends Command
         }
 
         $this->isDryRun = $this->option('dry-run');
+        $this->rateLimit = (int)$this->option('rate-limit');
 
         $this->deleteFilesGeneratedForDeprecatedConversions();
 
@@ -103,6 +108,10 @@ class CleanCommand extends Command
         $this->getMediaItems()->each(function (Media $media) {
             $this->deleteConversionFilesForDeprecatedConversions($media);
             $this->deleteResponsiveImagesForDeprecatedConversions($media);
+
+            if ($this->rateLimit) {
+                usleep((1 / $this->rateLimit) * 1000000 * 2);
+            }
         });
     }
 
@@ -171,6 +180,10 @@ class CleanCommand extends Command
             })->each(function (string $directory) use ($diskName) {
                 if (! $this->isDryRun) {
                     $this->fileSystem->disk($diskName)->deleteDirectory($directory);
+                }
+
+                if ($this->rateLimit) {
+                    usleep((1 / $this->rateLimit) * 1000000);
                 }
 
                 $this->info("Orphaned media directory `{$directory}` ".($this->isDryRun ? 'found' : 'has been removed'));


### PR DESCRIPTION
When using [Digital Ocean Spaces](https://www.digitalocean.com/products/spaces/) the API rate limit (~200 requests / s) can quickly be triggered if you have a lot of already clean files.

This PR implement a simple rate limit strategy that is far from perfect but it avoids getting a 503 from DO that would stop the script:

```
Server error: `GET https://xxxxx.ams3.digitaloceanspaces.com/?prefix=media  
  %2F15229%2Fconversions%2F&delimiter=%2F&encoding-type=url` resulted in a `5  
  03 Slow Down` response:                                                      
  <?xml version="1.0" encoding="UTF-8"?>                                       
  <Error>                                                                      
  <Code>Slowdown</Code>                                                        
  <Message>Please reduce your request rate.</Message> (truncated...) 
```