### PR TITLE
fix installation command for laravel 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For the creation of thumbnails of svg's or pdf's you should also install [Imagic
 You can install this package via composer using this command:
 
 ```bash
-composer require spatie/laravel-medialibrary:^7.0.0
+composer require spatie/laravel-medialibrary
 ```
 
 The package will automatically register itself.


### PR DESCRIPTION
This should fix #1253.
Probably a new reference for laravel 5.6 should be added in the older versions section with the old ^7.0.0 range.

 
