### PR TITLE
Add support for temporary URLs when using S3 as storage

### DIFF
--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -144,7 +144,7 @@ return [
      * If set to null, no temporary urls will be used.
      */
 
-    's3_responsive_images_expiration' => 5,
+    's3_responsive_images_expiration' => null,
 
     /*
      * Here you can override the class names of the jobs used by this package. Make sure

--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -140,6 +140,13 @@ return [
     'temporary_directory_path' => null,
 
     /*
+     * When using S3 you can set this to use temporary urls for responsive images. Set the expiration time in minutes.
+     * If set to null, no temporary urls will be used.
+     */
+
+    's3_responsive_images_expiration' => 5,
+
+    /*
      * Here you can override the class names of the jobs used by this package. Make sure
      * your custom jobs extend the ones provided by the package.
      */

--- a/src/ResponsiveImages/ResponsiveImage.php
+++ b/src/ResponsiveImages/ResponsiveImage.php
@@ -48,7 +48,7 @@ class ResponsiveImage
     {
         $urlGenerator = UrlGeneratorFactory::createForMedia($this->media);
 
-        if(config('medialibrary.s3_responsive_images_expiration')) {
+        if(config('medialibrary.s3_responsive_images_expiration') && method_exists($urlGenerator, 'getTemporaryResponsiveImageUrl')) {
             return $urlGenerator->getTemporaryResponsiveImageUrl($this->fileName, \Carbon\Carbon::now()->addMinutes(config('medialibrary.s3_responsive_images_expiration')));
         }
 

--- a/src/ResponsiveImages/ResponsiveImage.php
+++ b/src/ResponsiveImages/ResponsiveImage.php
@@ -48,6 +48,10 @@ class ResponsiveImage
     {
         $urlGenerator = UrlGeneratorFactory::createForMedia($this->media);
 
+        if(config('medialibrary.s3_responsive_images_expiration')) {
+            return $urlGenerator->getTemporaryResponsiveImageUrl($this->fileName, \Carbon\Carbon::now()->addMinutes(config('medialibrary.s3_responsive_images_expiration')));
+        }
+
         return $urlGenerator->getResponsiveImagesDirectoryUrl().$this->fileName;
     }
 

--- a/src/ResponsiveImages/ResponsiveImage.php
+++ b/src/ResponsiveImages/ResponsiveImage.php
@@ -48,7 +48,7 @@ class ResponsiveImage
     {
         $urlGenerator = UrlGeneratorFactory::createForMedia($this->media);
 
-        if(config('medialibrary.s3_responsive_images_expiration') && method_exists($urlGenerator, 'getTemporaryResponsiveImageUrl')) {
+        if (config('medialibrary.s3_responsive_images_expiration') && method_exists($urlGenerator, 'getTemporaryResponsiveImageUrl')) {
             return $urlGenerator->getTemporaryResponsiveImageUrl($this->fileName, \Carbon\Carbon::now()->addMinutes(config('medialibrary.s3_responsive_images_expiration')));
         }
 

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -95,4 +95,20 @@ class LocalUrlGenerator extends BaseUrlGenerator
     {
         return $this->getBaseMediaDirectoryUrl().'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
     }
+
+    /**
+     * Get the temporary url for a responsive media item.
+     *
+     * @param string $filename
+     * @param \DateTimeInterface $expiresAt
+     * @param array $options
+     *
+     * @return string
+     *
+     * @throws \Spatie\MediaLibrary\Exceptions\UrlCannotBeDetermined
+     */
+    public function getTemporaryResponsiveImageUrl(string $filename, DateTimeInterface $expiresAt, array $options = []): string
+    {
+        throw UrlCannotBeDetermined::filesystemDoesNotSupportTemporaryUrls();
+    }
 }

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -76,16 +76,16 @@ class S3UrlGenerator extends BaseUrlGenerator
      * Get the temporary url for a responsive media item.
      *
      * @param string $filename
-     * @param \DateTimeInterface $expiration
+     * @param \DateTimeInterface $expiresAt
      * @param array $options
      *
      * @return string
      */
-    public function getTemporaryResponsiveImageUrl(string $filename, DateTimeInterface $expiration, array $options = []): string
+    public function getTemporaryResponsiveImageUrl(string $filename, DateTimeInterface $expiresAt, array $options = []): string
     {
         return $this
             ->filesystemManager
             ->disk($this->media->disk)
-            ->temporaryUrl($this->pathGenerator->getPathForResponsiveImages($this->media) . $filename, $expiration, $options);
+            ->temporaryUrl($this->pathGenerator->getPathForResponsiveImages($this->media).$filename, $expiresAt, $options);
     }
 }

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -71,4 +71,21 @@ class S3UrlGenerator extends BaseUrlGenerator
     {
         return config('medialibrary.s3.domain').'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
     }
+
+    /**
+     * Get the temporary url for a responsive media item.
+     *
+     * @param string $filename
+     * @param \DateTimeInterface $expiration
+     * @param array $options
+     *
+     * @return string
+     */
+    public function getTemporaryResponsiveImageUrl(string $filename, DateTimeInterface $expiration, array $options = []): string
+    {
+        return $this
+            ->filesystemManager
+            ->disk($this->media->disk)
+            ->temporaryUrl($this->pathGenerator->getPathForResponsiveImages($this->media) . $filename, $expiration, $options);
+    }
 }

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -164,6 +164,43 @@ class S3IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function it_retrieves_a_temporary_responsive_image_url_from_s3()
+    {
+
+        $this->app['config']->set('medialibrary.s3_responsive_images_expiration', 5);
+
+        $media = $this->testModelWithResponsiveImages
+            ->addMedia($this->getTestJpg())
+            ->withResponsiveImages()
+            ->toMediaCollection('default', 's3_disk');
+
+        $media = $this->testModelWithResponsiveImages->getFirstMedia();
+
+        $this->assertContains(
+            "/{$this->s3BaseDirectory}/{$media->id}/responsive-images/test___medialibrary_original_340_280.jpg",
+            $media->getResponsiveImageUrls()[0]
+        );
+
+        $this->assertContains(
+            "/{$this->s3BaseDirectory}/{$media->id}/responsive-images/test___medialibrary_original_284_233.jpg",
+            $media->getResponsiveImageUrls()[1]
+        );
+
+        $this->assertContains(
+            "/{$this->s3BaseDirectory}/{$media->id}/responsive-images/test___medialibrary_original_237_195.jpg",
+            $media->getResponsiveImageUrls()[2]
+        );
+
+        $this->assertContains(
+            "/{$this->s3BaseDirectory}/{$media->id}/responsive-images/test___thumb_50_41.jpg",
+            $media->getResponsiveImageUrls('thumb')[0]
+        );
+
+        $this->app['config']->set('medialibrary.s3_responsive_images_expiration', null);
+
+    }
+
+    /** @test */
     public function custom_headers_are_used_for_all_conversions()
     {
         $media = $this->testModelWithConversion

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -166,7 +166,6 @@ class S3IntegrationTest extends TestCase
     /** @test */
     public function it_retrieves_a_temporary_responsive_image_url_from_s3()
     {
-
         $this->app['config']->set('medialibrary.s3_responsive_images_expiration', 5);
 
         $media = $this->testModelWithResponsiveImages
@@ -197,7 +196,6 @@ class S3IntegrationTest extends TestCase
         );
 
         $this->app['config']->set('medialibrary.s3_responsive_images_expiration', null);
-
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds support for using S3 as a non-public storage engine when also using responsive images. Currently the combination between S3 and responsive images only works when the S3 repo bucket is public. This is not always possible so with this PR I hope to add support for  this combination. 

This is my first contribution to this project and I have not written any tests yet. I know this is required before this PR can even be considered so can anyone point me in the right direction as to how to write a test for this new functionality? Many thanks!