### PR TITLE
Fix for issue #1277

### DIFF
--- a/src/Conversion/Conversion.php
+++ b/src/Conversion/Conversion.php
@@ -81,7 +81,7 @@ class Conversion
         return $this->manipulations;
     }
 
-    public function removeManipulation(string $manipulationName)
+    public function removeManipulation(string $manipulationName) : self
     {
         $this->manipulations->removeManipulation($manipulationName);
 
@@ -106,7 +106,7 @@ class Conversion
      *
      * @return $this
      */
-    public function setManipulations($manipulations)
+    public function setManipulations($manipulations) : self
     {
         if ($manipulations instanceof Manipulations) {
             $this->manipulations = $this->manipulations->mergeManipulations($manipulations);
@@ -126,7 +126,7 @@ class Conversion
      *
      * @return $this
      */
-    public function addAsFirstManipulations(Manipulations $manipulations)
+    public function addAsFirstManipulations(Manipulations $manipulations) : self
     {
         $manipulationSequence = $manipulations->getManipulationSequence()->toArray();
 
@@ -144,7 +144,7 @@ class Conversion
      *
      * @return $this
      */
-    public function performOnCollections(...$collectionNames)
+    public function performOnCollections(...$collectionNames) : self
     {
         $this->performOnCollections = $collectionNames;
 
@@ -174,7 +174,7 @@ class Conversion
      *
      * @return $this
      */
-    public function queued()
+    public function queued() : self
     {
         $this->performOnQueue = true;
 
@@ -186,7 +186,7 @@ class Conversion
      *
      * @return $this
      */
-    public function nonQueued()
+    public function nonQueued() : self
     {
         $this->performOnQueue = false;
 
@@ -198,7 +198,7 @@ class Conversion
      *
      * @return $this
      */
-    public function nonOptimized()
+    public function nonOptimized() : self
     {
         $this->removeManipulation('optimize');
 
@@ -208,7 +208,7 @@ class Conversion
     /**
      * When creating the converted image, responsive images will be created as well.
      */
-    public function withResponsiveImages()
+    public function withResponsiveImages() : self
     {
         $this->generateResponsiveImages = true;
 

--- a/src/Conversion/Conversion.php
+++ b/src/Conversion/Conversion.php
@@ -88,6 +88,13 @@ class Conversion
         return $this;
     }
 
+    public function withoutManipulations() : self
+    {
+        $this->manipulations = new Manipulations();
+
+        return $this;
+    }
+
     public function __call($name, $arguments)
     {
         if (! method_exists($this->manipulations, $name)) {

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -93,13 +93,17 @@ class FileManipulator
 
                 $copiedOriginalFile = $imageGenerator->convert($copiedOriginalFile, $conversion);
 
-                $conversionResult = $this->performConversion($media, $conversion, $copiedOriginalFile);
+                if (!$conversion->getManipulations()->isEmpty()) {
+                    $manipulationResult = $this->performManipulations($media, $conversion, $copiedOriginalFile);
+                } else {
+                    $manipulationResult = $copiedOriginalFile;
+                }
 
                 $newFileName = pathinfo($media->file_name, PATHINFO_FILENAME).
                     '-'.$conversion->getName().
                     '.'.$conversion->getResultExtension(pathinfo($copiedOriginalFile, PATHINFO_EXTENSION));
 
-                $renamedFile = MediaLibraryFileHelper::renameInDirectory($conversionResult, $newFileName);
+                $renamedFile = MediaLibraryFileHelper::renameInDirectory($manipulationResult, $newFileName);
 
                 if ($conversion->shouldGenerateResponsiveImages()) {
                     app(ResponsiveImageGenerator::class)->generateResponsiveImagesForConversion(
@@ -119,7 +123,7 @@ class FileManipulator
         $temporaryDirectory->delete();
     }
 
-    public function performConversion(Media $media, Conversion $conversion, string $imageFile): string
+    public function performManipulations(Media $media, Conversion $conversion, string $imageFile): string
     {
         $conversionTempFile = pathinfo($imageFile, PATHINFO_DIRNAME).'/'.str_random(16)
             .$conversion->getName()

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -93,11 +93,7 @@ class FileManipulator
 
                 $copiedOriginalFile = $imageGenerator->convert($copiedOriginalFile, $conversion);
 
-                if (! $conversion->getManipulations()->isEmpty()) {
-                    $manipulationResult = $this->performManipulations($media, $conversion, $copiedOriginalFile);
-                } else {
-                    $manipulationResult = $copiedOriginalFile;
-                }
+                $manipulationResult = $this->performManipulations($media, $conversion, $copiedOriginalFile);
 
                 $newFileName = pathinfo($media->file_name, PATHINFO_FILENAME).
                     '-'.$conversion->getName().
@@ -125,6 +121,10 @@ class FileManipulator
 
     public function performManipulations(Media $media, Conversion $conversion, string $imageFile): string
     {
+        if ($conversion->getManipulations()->isEmpty()) {
+            return $imageFile;
+        }
+
         $conversionTempFile = pathinfo($imageFile, PATHINFO_DIRNAME).'/'.str_random(16)
             .$conversion->getName()
             .'.'

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -93,7 +93,7 @@ class FileManipulator
 
                 $copiedOriginalFile = $imageGenerator->convert($copiedOriginalFile, $conversion);
 
-                if (!$conversion->getManipulations()->isEmpty()) {
+                if (! $conversion->getManipulations()->isEmpty()) {
                     $manipulationResult = $this->performManipulations($media, $conversion, $copiedOriginalFile);
                 } else {
                     $manipulationResult = $copiedOriginalFile;

--- a/tests/Unit/Conversion/ConversionTest.php
+++ b/tests/Unit/Conversion/ConversionTest.php
@@ -109,6 +109,16 @@ class ConversionTest extends TestCase
     }
 
     /** @test */
+    public function it_can_remove_all_previously_set_manipulations()
+    {
+        $this->assertFalse($this->conversion->getManipulations()->isEmpty());
+
+        $this->conversion->withoutManipulations();
+
+        $this->assertTrue($this->conversion->getManipulations()->isEmpty());
+    }
+
+    /** @test */
     public function it_will_use_the_extract_duration_parameter_if_it_was_given()
     {
         $this->conversion->extractVideoFrameAtSecond(10);

--- a/tests/Unit/FileManipulatorTest.php
+++ b/tests/Unit/FileManipulatorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Unit;
+
+use Spatie\Image\Manipulations;
+use Spatie\MediaLibrary\Tests\TestCase;
+use Spatie\MediaLibrary\FileManipulator;
+use Spatie\MediaLibrary\Conversion\Conversion;
+
+class FileManipulatorTest extends TestCase
+{
+    protected $conversionName = 'test';
+
+    /** @var \Spatie\MediaLibrary\Conversion\Conversion */
+    protected $conversion;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->conversion = new Conversion($this->conversionName);
+    }
+
+    /** @test */
+    public function it_does_not_perform_manipulations_if_not_necessary()
+    {
+        $imageFile = $this->getTestJpg();
+        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaCollection();
+
+        $conversionTempFile = (new FileManipulator)->performManipulations(
+            $media,
+            $this->conversion->withoutManipulations(),
+            $imageFile
+        );
+
+        $this->assertEquals($imageFile, $conversionTempFile);
+    }
+}

--- a/tests/Unit/FileManipulatorTest.php
+++ b/tests/Unit/FileManipulatorTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\MediaLibrary\Tests\Unit;
 
-use Spatie\Image\Manipulations;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\FileManipulator;
 use Spatie\MediaLibrary\Conversion\Conversion;


### PR DESCRIPTION
This PR make two changes:

### Minor: 
The `performConversion` method only perform manipulations has the conversion is made in the `performConversions` method [on line 94](https://github.com/spatie/laravel-medialibrary/compare/master...nicolasbeauvais:master#diff-0d11c445b5c28ccade90cf390e511012L94). 
So it makes more sense to rename it `performManipulations`instead. It will also reduce confusion between `performConversions` and `performConversion`.

### Fix for issue #1277:

#### Problem:
Creating a custom generator that returns a file that is not an image (in that case a .m3u8 file) fail because manipulations are being automatically run on that file which is not compatible.

#### Proposed fix:
The end user needs to disable the default manipulations for the specific conversion like:
```php
$this->addMediaConversion('transcode')
            ->removeManipulation('format')
            ->removeManipulation('optimize')
            ->performOnCollections('file');

// We could also add a base method for this:

$this->addMediaConversion('transcode')
            ->removeAllManipulations()
            ->performOnCollections('file');
```

And in the core, we check if the running conversion has manipulation to be triggered, if not we skip this step and the converted file stay untouched.


I haven't dive in the core code for a long time so I might be missing something here, anyway do not hesitate to indicate any change that could be made to improve this fix.