### PR TITLE
Updates PHPDoc for media() method of HasMediaTrait

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -54,7 +54,7 @@ trait HasMediaTrait
     /**
      * Set the polymorphic relation.
      *
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
     public function media()
     {


### PR DESCRIPTION
This method always returns `\Illuminate\Database\Eloquent\Relations\MorphMany`.
So why not to change the return type specified in PHPDoc in order to improve highlighting in IDE? 