### PR TITLE
Dynamic validation and legend strings generation.

### DIFF
--- a/resources/lang/en/medialibrary.php
+++ b/resources/lang/en/medialibrary.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'constraint' => [
+        'dimensions' => [
+            'both'   => 'Min. width : :width px / Min. height : :height px.',
+            'width'  => 'Min. width : :width px.',
+            'height' => 'Min. height : :height px.',
+        ],
+        'mimeTypes'  => 'Accepted MIME Type(s) : :mimetypes.',
+    ],
+];

--- a/resources/lang/en/medialibrary.php
+++ b/resources/lang/en/medialibrary.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+
     'constraint' => [
         'dimensions' => [
             'both'   => 'Min. width : :width px / Min. height : :height px.',
@@ -9,4 +10,5 @@ return [
         ],
         'mimeTypes'  => 'Accepted MIME Type(s) : :mimetypes.',
     ],
+
 ];

--- a/resources/lang/fr/medialibrary.php
+++ b/resources/lang/fr/medialibrary.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'constraint' => [
+        'dimensions' => [
+            'both'   => 'Largeur minimale : :width pixels / Hauteur minimale : :height pixels.',
+            'width'  => 'Largeur minimale : :width pixels.',
+            'height' => 'Hauteur minimale : :height pixels.',
+        ],
+        'mimeTypes'  => 'Type(s) MIME accepté(s) : :mimetypes.',
+    ],
+];

--- a/resources/lang/fr/medialibrary.php
+++ b/resources/lang/fr/medialibrary.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+
     'constraint' => [
         'dimensions' => [
             'both'   => 'Largeur minimale : :width pixels / Hauteur minimale : :height pixels.',
@@ -9,4 +10,5 @@ return [
         ],
         'mimeTypes'  => 'Type(s) MIME accepté(s) : :mimetypes.',
     ],
+
 ];

--- a/src/Exceptions/CollectionNotFound.php
+++ b/src/Exceptions/CollectionNotFound.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\MediaLibrary\Exceptions;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+
+class CollectionNotFound extends Exception
+{
+    public static function notDeclaredInModel(Model $model, string $collectionName)
+    {
+        $modelClass = get_class($model);
+
+        return new static("No collection `{$collectionName}` declared in the {$modelClass}-model");
+    }
+}

--- a/src/Exceptions/ConversionsNotFound.php
+++ b/src/Exceptions/ConversionsNotFound.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\MediaLibrary\Exceptions;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+
+class ConversionsNotFound extends Exception
+{
+    public static function noneDeclaredInModel(Model $model)
+    {
+        $modelClass = get_class($model);
+
+        return new static("No conversion declared in the {$modelClass}-model");
+    }
+}

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -338,12 +338,14 @@ class FileAdder
     protected function guardAgainstDisallowedFileAdditions(Media $media)
     {
         $file = PendingFile::createFromMedia($media);
-
         if (! $collection = $this->getMediaCollection($media->collection_name)) {
             return;
         }
-
-        if (! ($collection->acceptsFile)($file, $this->subject)) {
+        $acceptsFile = ($collection->acceptsFile)($file, $this->subject);
+        $acceptsMimeTypes = ! empty($collection->acceptsMimeTypes) 
+            ? in_array($file->mimeType, $collection->acceptsMimeTypes) 
+            : true;
+        if (! $acceptsFile || ! $acceptsMimeTypes) {
             throw FileUnacceptableForCollection::create($file, $collection, $this->subject);
         }
     }

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -342,8 +342,8 @@ class FileAdder
             return;
         }
         $acceptsFile = ($collection->acceptsFile)($file, $this->subject);
-        $acceptsMimeTypes = ! empty($collection->acceptsMimeTypes) 
-            ? in_array($file->mimeType, $collection->acceptsMimeTypes) 
+        $acceptsMimeTypes = ! empty($collection->acceptsMimeTypes)
+            ? in_array($file->mimeType, $collection->acceptsMimeTypes)
             : true;
         if (! $acceptsFile || ! $acceptsMimeTypes) {
             throw FileUnacceptableForCollection::create($file, $collection, $this->subject);

--- a/src/HasMedia/HasMedia.php
+++ b/src/HasMedia/HasMedia.php
@@ -103,4 +103,49 @@ interface HasMedia
      * Register the media conversions and conversions set in media collections.
      */
     public function registerAllMediaConversions();
+
+    /**
+     * Get the mime types constraints validation string for a media collection.
+     *
+     * @param string $collectionName
+     *
+     * @return string
+     */
+    public function mimeTypesValidationConstraints(string $collectionName): string;
+
+    /**
+     * Get the constraints validation string for a media collection.
+     *
+     * @param string $collectionName
+     *
+     * @return string
+     */
+    public function validationConstraints(string $collectionName): string;
+
+    /**
+     * Get the constraints legend string for a media collection.
+     *
+     * @param string $collectionName
+     *
+     * @return string
+     */
+    public function constraintsLegend(string $collectionName): string;
+
+    /**
+     * Get the dimensions constraints legend string for a media collection.
+     *
+     * @param string $collectionName
+     *
+     * @return string
+     */
+    public function collectionDimensionsLegend(string $collectionName): string;
+
+    /**
+     * Get the mime types constraints legend string for a media collection.
+     *
+     * @param string $collectionName
+     *
+     * @return string
+     */
+    public function collectionMimeTypesLegend(string $collectionName): string;
 }

--- a/src/MediaCollection/MediaCollection.php
+++ b/src/MediaCollection/MediaCollection.php
@@ -16,6 +16,9 @@ class MediaCollection
     /** @var callable */
     public $acceptsFile;
 
+    /** @var array */
+    public $acceptsMimeTypes = [];
+
     /** @var bool */
     public $singleFile = false;
 
@@ -40,6 +43,13 @@ class MediaCollection
     {
         $this->diskName = $diskName;
 
+        return $this;
+    }
+    
+    public function acceptsMimeTypes(array $mimeTypes): self
+    {
+        $this->acceptsMimeTypes = $mimeTypes;
+        
         return $this;
     }
 

--- a/src/MediaCollection/MediaCollection.php
+++ b/src/MediaCollection/MediaCollection.php
@@ -45,11 +45,11 @@ class MediaCollection
 
         return $this;
     }
-    
+
     public function acceptsMimeTypes(array $mimeTypes): self
     {
         $this->acceptsMimeTypes = $mimeTypes;
-        
+
         return $this;
     }
 

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -28,11 +28,17 @@ class MediaLibraryServiceProvider extends ServiceProvider
             __DIR__.'/../resources/views' => resource_path('views/vendor/medialibrary'),
         ], 'views');
 
+        $this->publishes([
+            __DIR__ . '/../resources/lang' => resource_path('lang'),
+        ], 'translations');
+
         $mediaClass = config('medialibrary.media_model');
 
         $mediaClass::observe(new MediaObserver());
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'medialibrary');
+        
+        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'medialibrary');
     }
 
     public function register()

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -29,7 +29,7 @@ class MediaLibraryServiceProvider extends ServiceProvider
         ], 'views');
 
         $this->publishes([
-            __DIR__ . '/../resources/lang' => resource_path('lang'),
+            __DIR__.'/../resources/lang' => resource_path('lang'),
         ], 'translations');
 
         $mediaClass = config('medialibrary.media_model');
@@ -37,8 +37,8 @@ class MediaLibraryServiceProvider extends ServiceProvider
         $mediaClass::observe(new MediaObserver());
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'medialibrary');
-        
-        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'medialibrary');
+
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'medialibrary');
     }
 
     public function register()

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -157,6 +157,51 @@ class MediaCollectionTest extends TestCase
     }
 
     /** @test */
+    public function it_can_accept_certain_mime_types()
+    {
+        $testModel = new class extends TestModelWithConversion {
+            public function registerMediaCollections()
+            {
+                $this
+                    ->addMediaCollection('images')
+                    ->acceptsMimeTypes(['image/jpeg']);
+            }
+        };
+
+        $model = $testModel::create(['name' => 'testmodel']);
+
+        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+        $this->expectException(FileUnacceptableForCollection::class);
+
+        $model->addMedia($this->getTestPng())->preservingOriginal()->toMediaCollection('images');
+    }
+
+    /** @test */
+    public function it_can_accept_certain_files_and_mime_types()
+    {
+        $testModel = new class extends TestModelWithConversion {
+            public function registerMediaCollections()
+            {
+                $this
+                    ->addMediaCollection('images')
+                    ->acceptsFile(function (File $file) {
+                        return $file->size <= 30000;
+                    })
+                    ->acceptsMimeTypes(['image/jpeg']);
+            }
+        };
+
+        $model = $testModel::create(['name' => 'testmodel']);
+
+        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+        $this->expectException(FileUnacceptableForCollection::class);
+
+        $model->addMedia($this->getTestPng())->preservingOriginal()->toMediaCollection('images');
+    }
+
+    /** @test */
     public function if_the_single_file_method_is_specified_it_will_delete_all_other_media_and_will_only_keep_the_new_one()
     {
         $testModel = new class extends TestModelWithConversion {

--- a/tests/Support/TestModels/TestModel.php
+++ b/tests/Support/TestModels/TestModel.php
@@ -18,7 +18,9 @@ class TestModel extends Model implements HasMedia
     /**
      * Register the conversions that should be performed.
      *
-     * @return array
+     * @param \Spatie\MediaLibrary\Models\Media|null $media
+     *
+     * @return void
      */
     public function registerMediaConversions(Media $media = null)
     {

--- a/tests/Support/TestModels/TestModelWithCollectionConversionsOnly.php
+++ b/tests/Support/TestModels/TestModelWithCollectionConversionsOnly.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support\TestModels;
+
+use Spatie\Image\Manipulations;
+use Spatie\MediaLibrary\Models\Media;
+
+class TestModelWithCollectionConversionsOnly extends TestModel
+{
+    /**
+     * Register the media collections.
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     *
+     * @return void
+     */
+    public function registerMediaCollections()
+    {
+        $this->addMediaCollection('logo')
+            ->acceptsMimeTypes(['image/jpeg', 'image/png'])
+            ->registerMediaConversions(function(Media $media = null) {
+                $this->addMediaConversion('admin-panel')
+                    ->crop(Manipulations::CROP_CENTER, 100, 140);
+                $this->addMediaConversion('mail')
+                    ->crop(Manipulations::CROP_CENTER, 120, 100);
+            });
+    }
+
+    /**
+     * Register the media conversions.
+     *
+     * @param \Spatie\MediaLibrary\Models\Media|null $media
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
+     */
+    public function registerMediaConversions(Media $media = null)
+    {
+        $this->addMediaConversion('thumb')->crop(Manipulations::CROP_CENTER, 40, 40);
+    }
+}

--- a/tests/Support/TestModels/TestModelWithCollectionConversionsOnly.php
+++ b/tests/Support/TestModels/TestModelWithCollectionConversionsOnly.php
@@ -17,7 +17,7 @@ class TestModelWithCollectionConversionsOnly extends TestModel
     {
         $this->addMediaCollection('logo')
             ->acceptsMimeTypes(['image/jpeg', 'image/png'])
-            ->registerMediaConversions(function(Media $media = null) {
+            ->registerMediaConversions(function (Media $media = null) {
                 $this->addMediaConversion('admin-panel')
                     ->crop(Manipulations::CROP_CENTER, 100, 140);
                 $this->addMediaConversion('mail')

--- a/tests/Support/TestModels/TestModelWithCollectionWithoutConversions.php
+++ b/tests/Support/TestModels/TestModelWithCollectionWithoutConversions.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support\TestModels;
+
+class TestModelWithCollectionWithoutConversions extends TestModel
+{
+    /**
+     * Register the media collections.
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     *
+     * @return void
+     */
+    public function registerMediaCollections()
+    {
+        $this->addMediaCollection('logo')->acceptsMimeTypes(['image/jpeg', 'image/png']);
+    }
+}

--- a/tests/Support/TestModels/TestModelWithConversion.php
+++ b/tests/Support/TestModels/TestModelWithConversion.php
@@ -9,7 +9,10 @@ class TestModelWithConversion extends TestModel
     /**
      * Register the conversions that should be performed.
      *
-     * @return array
+     * @param \Spatie\MediaLibrary\Models\Media|null $media
+     *
+     * @return void
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
      */
     public function registerMediaConversions(Media $media = null)
     {

--- a/tests/Support/TestModels/TestModelWithGlobalAndCollectionConversions.php
+++ b/tests/Support/TestModels/TestModelWithGlobalAndCollectionConversions.php
@@ -17,7 +17,7 @@ class TestModelWithGlobalAndCollectionConversions extends TestModel
     {
         $this->addMediaCollection('logo')
             ->acceptsMimeTypes(['image/jpeg', 'image/png'])
-            ->registerMediaConversions(function(Media $media = null) {
+            ->registerMediaConversions(function (Media $media = null) {
                 $this->addMediaConversion('admin-panel')
                     ->crop(Manipulations::CROP_CENTER, 20, 80);
             });

--- a/tests/Support/TestModels/TestModelWithGlobalAndCollectionConversions.php
+++ b/tests/Support/TestModels/TestModelWithGlobalAndCollectionConversions.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support\TestModels;
+
+use Spatie\Image\Manipulations;
+use Spatie\MediaLibrary\Models\Media;
+
+class TestModelWithGlobalAndCollectionConversions extends TestModel
+{
+    /**
+     * Register the media collections.
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     *
+     * @return void
+     */
+    public function registerMediaCollections()
+    {
+        $this->addMediaCollection('logo')
+            ->acceptsMimeTypes(['image/jpeg', 'image/png'])
+            ->registerMediaConversions(function(Media $media = null) {
+                $this->addMediaConversion('admin-panel')
+                    ->crop(Manipulations::CROP_CENTER, 20, 80);
+            });
+    }
+
+    /**
+     * Register the media conversions.
+     *
+     * @param \Spatie\MediaLibrary\Models\Media|null $media
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
+     */
+    public function registerMediaConversions(Media $media = null)
+    {
+        $this->addMediaConversion('thumb')->crop(Manipulations::CROP_CENTER, 100, 70);
+    }
+}

--- a/tests/Support/TestModels/TestModelWithGlobalConversionOnly.php
+++ b/tests/Support/TestModels/TestModelWithGlobalConversionOnly.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support\TestModels;
+
+use Spatie\Image\Manipulations;
+use Spatie\MediaLibrary\Models\Media;
+
+class TestModelWithGlobalConversionOnly extends TestModel
+{
+    /**
+     * Register the media collections.
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     *
+     * @return void
+     */
+    public function registerMediaCollections()
+    {
+        $this->addMediaCollection('logo');
+    }
+    
+    /**
+     * Register the media conversions.
+     *
+     * @param \Spatie\MediaLibrary\Models\Media|null $media
+     *
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
+     */
+    public function registerMediaConversions(Media $media = null)
+    {
+        $this->addMediaConversion('thumb')->crop(Manipulations::CROP_CENTER, 60, 20);
+    }
+}

--- a/tests/Support/TestModels/TestModelWithGlobalConversionOnly.php
+++ b/tests/Support/TestModels/TestModelWithGlobalConversionOnly.php
@@ -17,7 +17,7 @@ class TestModelWithGlobalConversionOnly extends TestModel
     {
         $this->addMediaCollection('logo');
     }
-    
+
     /**
      * Register the media conversions.
      *

--- a/tests/Support/TestModels/TestModelWithGlobalConversionOnlyWithoutCollection.php
+++ b/tests/Support/TestModels/TestModelWithGlobalConversionOnlyWithoutCollection.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support\TestModels;
+
+use Spatie\Image\Manipulations;
+use Spatie\MediaLibrary\Models\Media;
+
+class TestModelWithGlobalConversionOnlyWithoutCollection extends TestModel
+{
+    /**
+     * Register the media conversions.
+     *
+     * @param \Spatie\MediaLibrary\Models\Media|null $media
+     *
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
+     */
+    public function registerMediaConversions(Media $media = null)
+    {
+        $this->addMediaConversion('thumb')->crop(Manipulations::CROP_CENTER, 60, 20);
+    }
+}

--- a/tests/Support/TestModels/TestModelWithGlobalConversionWithNoSize.php
+++ b/tests/Support/TestModels/TestModelWithGlobalConversionWithNoSize.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support\TestModels;
+
+use Spatie\MediaLibrary\Models\Media;
+
+class TestModelWithGlobalConversionWithNoSize extends TestModel
+{
+    /**
+     * Register the media collections.
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     *
+     * @return void
+     */
+    public function registerMediaCollections()
+    {
+        $this->addMediaCollection('logo')->acceptsMimeTypes(['image/jpeg', 'image/png']);
+    }
+
+    /**
+     * Register the media conversions.
+     *
+     * @param \Spatie\MediaLibrary\Models\Media|null $media
+     */
+    public function registerMediaConversions(Media $media = null)
+    {
+        $this->addMediaConversion('thumb');
+    }
+}

--- a/tests/Support/TestModels/TestModelWithGlobalConversionWithNoSizeAndNoMimeTypes.php
+++ b/tests/Support/TestModels/TestModelWithGlobalConversionWithNoSizeAndNoMimeTypes.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support\TestModels;
+
+use Spatie\MediaLibrary\Models\Media;
+
+class TestModelWithGlobalConversionWithNoSizeAndNoMimeTypes extends TestModel
+{
+    /**
+     * Register the media collections.
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     *
+     * @return void
+     */
+    public function registerMediaCollections()
+    {
+        $this->addMediaCollection('logo');
+    }
+
+    /**
+     * Register the media conversions.
+     *
+     * @param \Spatie\MediaLibrary\Models\Media|null $media
+     */
+    public function registerMediaConversions(Media $media = null)
+    {
+        $this->addMediaConversion('thumb');
+    }
+}

--- a/tests/Support/TestModels/TestModelWithGlobalConversionWithOnlyHeight.php
+++ b/tests/Support/TestModels/TestModelWithGlobalConversionWithOnlyHeight.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support\TestModels;
+
+use Spatie\MediaLibrary\Models\Media;
+
+class TestModelWithGlobalConversionWithOnlyHeight extends TestModel
+{
+    /**
+     * Register the media collections.
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     *
+     * @return void
+     */
+    public function registerMediaCollections()
+    {
+        $this->addMediaCollection('logo')->acceptsMimeTypes(['image/jpeg', 'image/png']);
+    }
+
+    /**
+     * Register the media conversions.
+     *
+     * @param \Spatie\MediaLibrary\Models\Media|null $media
+     *
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
+     */
+    public function registerMediaConversions(Media $media = null)
+    {
+        $this->addMediaConversion('thumb')->height(30);
+    }
+}

--- a/tests/Support/TestModels/TestModelWithGlobalConversionWithOnlyWidth.php
+++ b/tests/Support/TestModels/TestModelWithGlobalConversionWithOnlyWidth.php
@@ -16,7 +16,7 @@ class TestModelWithGlobalConversionWithOnlyWidth extends TestModel
     {
         $this->addMediaCollection('logo')->acceptsMimeTypes(['image/jpeg', 'image/png']);
     }
-    
+
     /**
      * Register the media conversions.
      *

--- a/tests/Support/TestModels/TestModelWithGlobalConversionWithOnlyWidth.php
+++ b/tests/Support/TestModels/TestModelWithGlobalConversionWithOnlyWidth.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support\TestModels;
+
+use Spatie\MediaLibrary\Models\Media;
+
+class TestModelWithGlobalConversionWithOnlyWidth extends TestModel
+{
+    /**
+     * Register the media collections.
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     *
+     * @return void
+     */
+    public function registerMediaCollections()
+    {
+        $this->addMediaCollection('logo')->acceptsMimeTypes(['image/jpeg', 'image/png']);
+    }
+    
+    /**
+     * Register the media conversions.
+     *
+     * @param \Spatie\MediaLibrary\Models\Media|null $media
+     *
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
+     */
+    public function registerMediaConversions(Media $media = null)
+    {
+        $this->addMediaConversion('thumb')->width(120);
+    }
+}

--- a/tests/Support/TestModels/TestModelWithResponsiveImages.php
+++ b/tests/Support/TestModels/TestModelWithResponsiveImages.php
@@ -10,6 +10,7 @@ class TestModelWithResponsiveImages extends TestModel
      * Register the conversions that should be performed.
      *
      * @return array
+     * @throws \Spatie\Image\Exceptions\InvalidManipulation
      */
     public function registerMediaConversions(Media $media = null)
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,15 @@ use Illuminate\Database\Schema\Blueprint;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModel;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithCollectionConversionsOnly;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithCollectionWithoutConversions;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalAndCollectionConversions;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnly;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithNoSize;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithNoSizeAndNoMimeTypes;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithOnlyHeight;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithOnlyWidth;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithMorphMap;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithResponsiveImages;
@@ -35,6 +44,33 @@ abstract class TestCase extends Orchestra
     /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithResponsiveImages */
     protected $testModelWithResponsiveImages;
 
+    /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnly */
+    protected $testModelWithGlobalConversionOnly;
+
+    /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection */
+    protected $testModelWithGlobalConversionOnlyWithoutCollection;
+    
+    /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithCollectionWithoutConversions */
+    protected $testModelWithCollectionWithoutConversions;
+    
+    /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithCollectionConversionsOnly */
+    protected $testModelWithCollectionConversionsOnly;
+    
+    /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalAndCollectionConversions */
+    protected $testModelWithGlobalAndCollectionConversions;
+    
+    /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithOnlyWidth */
+    protected $testModelWithGlobalConversionWithOnlyWidth;
+    
+    /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithOnlyHeight */
+    protected $testModelWithGlobalConversionWithOnlyHeight;
+    
+    /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithNoSize */
+    protected $testModelWithGlobalConversionWithNoSize;
+    
+    /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithNoSizeAndNoMimeTypes */
+    protected $testModelWithGlobalConversionWithNoSizeAndNoMimeTypes;
+
     public function setUp()
     {
         $this->loadEnvironmentVariables();
@@ -51,6 +87,15 @@ abstract class TestCase extends Orchestra
         $this->testModelWithoutMediaConversions = TestModelWithoutMediaConversions::first();
         $this->testModelWithMorphMap = TestModelWithMorphMap::first();
         $this->testModelWithResponsiveImages = TestModelWithResponsiveImages::first();
+        $this->testModelWithGlobalConversionOnlyWithoutCollection = TestModelWithGlobalConversionOnlyWithoutCollection::first();
+        $this->testModelWithCollectionWithoutConversions = TestModelWithCollectionWithoutConversions::first();
+        $this->testModelWithGlobalConversionOnly = TestModelWithGlobalConversionOnly::first();
+        $this->testModelWithCollectionConversionsOnly = TestModelWithCollectionConversionsOnly::first();
+        $this->testModelWithGlobalAndCollectionConversions = TestModelWithGlobalAndCollectionConversions::first();
+        $this->testModelWithGlobalConversionWithOnlyWidth = TestModelWithGlobalConversionWithOnlyWidth::first();
+        $this->testModelWithGlobalConversionWithOnlyHeight = TestModelWithGlobalConversionWithOnlyHeight::first();
+        $this->testModelWithGlobalConversionWithNoSize = TestModelWithGlobalConversionWithNoSize::first();
+        $this->testModelWithGlobalConversionWithNoSizeAndNoMimeTypes = TestModelWithGlobalConversionWithNoSizeAndNoMimeTypes::first();
     }
 
     protected function loadEnvironmentVariables()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,19 +10,19 @@ use Illuminate\Database\Schema\Blueprint;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModel;
-use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithCollectionConversionsOnly;
-use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithCollectionWithoutConversions;
-use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalAndCollectionConversions;
-use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnly;
-use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection;
-use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithNoSize;
-use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithNoSizeAndNoMimeTypes;
-use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithOnlyHeight;
-use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithOnlyWidth;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithMorphMap;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithResponsiveImages;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithoutMediaConversions;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnly;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithCollectionConversionsOnly;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithNoSize;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithCollectionWithoutConversions;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithOnlyWidth;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalAndCollectionConversions;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithOnlyHeight;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection;
+use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithNoSizeAndNoMimeTypes;
 
 abstract class TestCase extends Orchestra
 {
@@ -49,25 +49,25 @@ abstract class TestCase extends Orchestra
 
     /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection */
     protected $testModelWithGlobalConversionOnlyWithoutCollection;
-    
+
     /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithCollectionWithoutConversions */
     protected $testModelWithCollectionWithoutConversions;
-    
+
     /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithCollectionConversionsOnly */
     protected $testModelWithCollectionConversionsOnly;
-    
+
     /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalAndCollectionConversions */
     protected $testModelWithGlobalAndCollectionConversions;
-    
+
     /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithOnlyWidth */
     protected $testModelWithGlobalConversionWithOnlyWidth;
-    
+
     /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithOnlyHeight */
     protected $testModelWithGlobalConversionWithOnlyHeight;
-    
+
     /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithNoSize */
     protected $testModelWithGlobalConversionWithNoSize;
-    
+
     /** @var \Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionWithNoSizeAndNoMimeTypes */
     protected $testModelWithGlobalConversionWithNoSizeAndNoMimeTypes;
 

--- a/tests/Unit/LegendGenerator/CollectionDimensionLegendTest.php
+++ b/tests/Unit/LegendGenerator/CollectionDimensionLegendTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Unit\UrlGenerator;
+
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class CollectionDimensionLegendTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\CollectionNotFound
+     * @expectedExceptionMessage No collection `logo` declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_collection()
+    {
+        $this->testModelWithGlobalConversionOnlyWithoutCollection->collectionDimensionsLegend('logo');
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\ConversionsNotFound
+     * @expectedExceptionMessage No conversion declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithoutMediaConversions-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_conversions()
+    {
+        $this->testModelWithCollectionWithoutConversions->collectionDimensionsLegend('logo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_width_dimension_legend_when_only_width_is_declared()
+    {
+        $dimensionsLegendString = $this->testModelWithGlobalConversionWithOnlyWidth->collectionDimensionsLegend('logo');
+        $this->assertEquals(__('medialibrary::medialibrary.constraint.dimensions.width', [
+            'width'  => 120,
+        ]), $dimensionsLegendString);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_height_dimension_legend_when_only_height_is_declared()
+    {
+        $dimensionsLegendString = $this->testModelWithGlobalConversionWithOnlyHeight->collectionDimensionsLegend('logo');
+        $this->assertEquals(__('medialibrary::medialibrary.constraint.dimensions.height', [
+            'height'  => 30,
+        ]), $dimensionsLegendString);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_dimension_legend_when_no_size_is_declared()
+    {
+        $dimensionsLegendString = $this->testModelWithGlobalConversionWithNoSize->collectionDimensionsLegend('logo');
+        $this->assertEquals('', $dimensionsLegendString);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_width_and_height_dimension_legend_when_both_are_declared()
+    {
+        $dimensionsLegendString = $this->testModelWithGlobalAndCollectionConversions->collectionDimensionsLegend('logo');
+        $this->assertEquals(__('medialibrary::medialibrary.constraint.dimensions.both', [
+            'width'  => 100,
+            'height' => 80,
+        ]), $dimensionsLegendString);
+    }
+}

--- a/tests/Unit/LegendGenerator/CollectionLegendTest.php
+++ b/tests/Unit/LegendGenerator/CollectionLegendTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Unit\UrlGenerator;
+
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class CollectionLegendTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\CollectionNotFound
+     * @expectedExceptionMessage No collection `logo` declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_collection()
+    {
+        $this->testModelWithGlobalConversionOnlyWithoutCollection->constraintsLegend('logo');
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\ConversionsNotFound
+     * @expectedExceptionMessage No conversion declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithoutMediaConversions-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_conversions()
+    {
+        $this->testModelWithCollectionWithoutConversions->constraintsLegend('logo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_legend_when_no_constraint_is_declared()
+    {
+        $legendString = $this->testModelWithGlobalConversionWithNoSizeAndNoMimeTypes->constraintsLegend('logo');
+        $this->assertEquals('', $legendString);
+    }
+    
+    /**
+     * @test
+     */
+    public function it_returns_only_dimension_legend_when_only_dimensions_declared()
+    {
+        $legendString = $this->testModelWithGlobalConversionOnly->constraintsLegend('logo');
+        $this->assertEquals(__('medialibrary::medialibrary.constraint.dimensions.both', [
+            'width'  => 60,
+            'height' => 20,
+        ]), $legendString);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_mime_types_legend_when_only_mime_types_declared()
+    {
+        $legendString = $this->testModelWithGlobalConversionWithNoSize->constraintsLegend('logo');
+        $this->assertEquals(__('medialibrary::medialibrary.constraint.mimeTypes', [
+            'mimetypes'  => 'image/jpeg, image/png',
+        ]), $legendString);
+    }
+}

--- a/tests/Unit/LegendGenerator/CollectionLegendTest.php
+++ b/tests/Unit/LegendGenerator/CollectionLegendTest.php
@@ -41,7 +41,7 @@ class CollectionLegendTest extends TestCase
         $legendString = $this->testModelWithGlobalConversionWithNoSizeAndNoMimeTypes->constraintsLegend('logo');
         $this->assertEquals('', $legendString);
     }
-    
+
     /**
      * @test
      */

--- a/tests/Unit/LegendGenerator/CollectionMimeTypesLegendTest.php
+++ b/tests/Unit/LegendGenerator/CollectionMimeTypesLegendTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Unit\UrlGenerator;
+
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class CollectionMimeTypesLegendTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\CollectionNotFound
+     * @expectedExceptionMessage No collection `logo` declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_collection()
+    {
+        $this->testModelWithGlobalConversionOnlyWithoutCollection->collectionMimeTypesLegend('logo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_mime_types_legend_when_none_declared()
+    {
+        $dimensionsLegendString = $this->testModelWithGlobalConversionOnly->collectionMimeTypesLegend('logo');
+        $this->assertEquals('', $dimensionsLegendString);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_mime_types_legend_when_are_declared()
+    {
+        $dimensionsLegendString = $this->testModelWithGlobalAndCollectionConversions->collectionMimeTypesLegend('logo');
+        $this->assertEquals(__('medialibrary::medialibrary.constraint.mimeTypes', [
+            'mimetypes'  => 'image/jpeg, image/png',
+        ]), $dimensionsLegendString);
+    }
+}

--- a/tests/Unit/ValidationGenerator/CollectionDimensionValidationConstraintsTest.php
+++ b/tests/Unit/ValidationGenerator/CollectionDimensionValidationConstraintsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Unit\UrlGenerator;
+
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class CollectionDimensionValidationConstraintsTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\CollectionNotFound
+     * @expectedExceptionMessage No collection `logo` declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_collection()
+    {
+        $this->testModelWithGlobalConversionOnlyWithoutCollection->dimensionValidationConstraints('logo');
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\ConversionsNotFound
+     * @expectedExceptionMessage No conversion declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithoutMediaConversions-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_conversions()
+    {
+        $this->testModelWithCollectionWithoutConversions->dimensionValidationConstraints('logo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_global_conversion_dimension_validation_constraints_when_no_collection_conversions_declared()
+    {
+        $dimensionsValidationConstraintsString = $this->testModelWithGlobalConversionOnly->dimensionValidationConstraints('logo');
+        $this->assertEquals('dimensions:min_width=60,min_height=20', $dimensionsValidationConstraintsString);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_width_dimension_validation_constraint_when_only_width_is_declared()
+    {
+        $dimensionsValidationConstraintsString = $this->testModelWithGlobalConversionWithOnlyWidth->dimensionValidationConstraints('logo');
+        $this->assertEquals('dimensions:min_width=120', $dimensionsValidationConstraintsString);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_height_dimension_validation_constraint_when_only_height_is_declared()
+    {
+        $dimensionsValidationConstraintsString = $this->testModelWithGlobalConversionWithOnlyHeight->dimensionValidationConstraints('logo');
+        $this->assertEquals('dimensions:min_height=30', $dimensionsValidationConstraintsString);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_dimension_validation_constraint_when_no_size_is_declared()
+    {
+        $dimensionsValidationConstraintsString = $this->testModelWithGlobalConversionWithNoSize->dimensionValidationConstraints('logo');
+        $this->assertEquals('', $dimensionsValidationConstraintsString);
+    }
+    
+    /**
+     * @test
+     */
+    public function it_returns_collection_dimension_validation_constraints_when_no_global_conversions_declared()
+    {
+        $dimensionsValidationConstraintsString = $this->testModelWithCollectionConversionsOnly->dimensionValidationConstraints('logo');
+        $this->assertEquals('dimensions:min_width=120,min_height=140', $dimensionsValidationConstraintsString);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_global_and_collection_dimension_validation_constraints_when_both_are_declared()
+    {
+        $dimensionsValidationConstraintsString = $this->testModelWithGlobalAndCollectionConversions->dimensionValidationConstraints('logo');
+        $this->assertEquals('dimensions:min_width=100,min_height=80', $dimensionsValidationConstraintsString);
+    }
+}

--- a/tests/Unit/ValidationGenerator/CollectionDimensionValidationConstraintsTest.php
+++ b/tests/Unit/ValidationGenerator/CollectionDimensionValidationConstraintsTest.php
@@ -68,7 +68,7 @@ class CollectionDimensionValidationConstraintsTest extends TestCase
         $dimensionsValidationConstraintsString = $this->testModelWithGlobalConversionWithNoSize->dimensionValidationConstraints('logo');
         $this->assertEquals('', $dimensionsValidationConstraintsString);
     }
-    
+
     /**
      * @test
      */

--- a/tests/Unit/ValidationGenerator/CollectionMaxSizeTest.php
+++ b/tests/Unit/ValidationGenerator/CollectionMaxSizeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Unit\UrlGenerator;
+
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class CollectionMaxSizeTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\CollectionNotFound
+     * @expectedExceptionMessage No collection `logo` declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_collection()
+    {
+        $this->testModelWithGlobalConversionOnlyWithoutCollection->collectionMaxSizes('logo');
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\ConversionsNotFound
+     * @expectedExceptionMessage No conversion declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithoutMediaConversions-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_conversions()
+    {
+        $this->testModelWithCollectionWithoutConversions->collectionMaxSizes('logo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_global_conversion_max_sizes_when_no_collection_conversions_declared()
+    {
+        $maxSizes = $this->testModelWithGlobalConversionOnly->collectionMaxSizes('logo');
+        $this->assertEquals(60, $maxSizes['width']);
+        $this->assertEquals(20, $maxSizes['height']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_width_when_only_width_is_declared()
+    {
+        $maxSizes = $this->testModelWithGlobalConversionWithOnlyWidth->collectionMaxSizes('logo');
+        $this->assertEquals(120, $maxSizes['width']);
+        $this->assertNull($maxSizes['height']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_height_when_only_height_is_declared()
+    {
+        $maxSizes = $this->testModelWithGlobalConversionWithOnlyHeight->collectionMaxSizes('logo');
+        $this->assertNull($maxSizes['width']);
+        $this->assertEquals(30, $maxSizes['height']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_size_when_none_is_declared()
+    {
+        $maxSizes = $this->testModelWithGlobalConversionWithNoSize->collectionMaxSizes('logo');
+        $this->assertNull($maxSizes['width']);
+        $this->assertNull($maxSizes['height']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_collection_conversions_max_sizes_when_no_global_conversions_declared()
+    {
+        $maxSizes = $this->testModelWithCollectionConversionsOnly->collectionMaxSizes('logo');
+        $this->assertEquals(120, $maxSizes['width']);
+        $this->assertEquals(140, $maxSizes['height']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_global_and_collection_conversions_max_sizes_when_both_are_declared()
+    {
+        $maxSizes = $this->testModelWithGlobalAndCollectionConversions->collectionMaxSizes('logo');
+        $this->assertEquals(100, $maxSizes['width']);
+        $this->assertEquals(80, $maxSizes['height']);
+    }
+}

--- a/tests/Unit/ValidationGenerator/CollectionMimeTypesValidationConstraintsTest.php
+++ b/tests/Unit/ValidationGenerator/CollectionMimeTypesValidationConstraintsTest.php
@@ -30,7 +30,7 @@ class CollectionMimeTypesValidationConstraintsTest extends TestCase
         $mimeTypesValidationConstraintsString = $this->testModelWithGlobalAndCollectionConversions->mimeTypesValidationConstraints('logo');
         $this->assertEquals('mimetypes:image/jpeg,image/png', $mimeTypesValidationConstraintsString);
     }
-    
+
     /**
      * @test
      */

--- a/tests/Unit/ValidationGenerator/CollectionMimeTypesValidationConstraintsTest.php
+++ b/tests/Unit/ValidationGenerator/CollectionMimeTypesValidationConstraintsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Unit\UrlGenerator;
+
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class CollectionMimeTypesValidationConstraintsTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\CollectionNotFound
+     * @expectedExceptionMessage No collection `logo` declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_collection()
+    {
+        $this->testModelWithGlobalConversionOnlyWithoutCollection->mimeTypesValidationConstraints('logo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_mime_types_validation_constraints_when_declared_in_collection()
+    {
+        $mimeTypesValidationConstraintsString = $this->testModelWithGlobalAndCollectionConversions->mimeTypesValidationConstraints('logo');
+        $this->assertEquals('mimetypes:image/jpeg,image/png', $mimeTypesValidationConstraintsString);
+    }
+    
+    /**
+     * @test
+     */
+    public function it_returns_no_collection_mime_types_validation_constraints_when_none_declared()
+    {
+        $mimeTypesValidationConstraintsString = $this->testModelWithGlobalConversionOnly->mimeTypesValidationConstraints('logo');
+        $this->assertEquals('', $mimeTypesValidationConstraintsString);
+    }
+}

--- a/tests/Unit/ValidationGenerator/CollectionValidationConstraintsTest.php
+++ b/tests/Unit/ValidationGenerator/CollectionValidationConstraintsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Unit\UrlGenerator;
+
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class CollectionValidationConstraintsTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\CollectionNotFound
+     * @expectedExceptionMessage No collection `logo` declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithGlobalConversionOnlyWithoutCollection-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_collection()
+    {
+        $this->testModelWithGlobalConversionOnlyWithoutCollection->validationConstraints('logo');
+    }
+
+    /**
+     * @test
+     * @expectedException \Spatie\MediaLibrary\Exceptions\ConversionsNotFound
+     * @expectedExceptionMessage No conversion declared in the
+     *                           Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithoutMediaConversions-model
+     */
+    public function it_throws_exception_when_it_is_called_with_inexistant_conversions()
+    {
+        $this->testModelWithCollectionWithoutConversions->validationConstraints('logo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_validation_constraint_when_none_is_declared()
+    {
+        $validationConstraintsString = $this->testModelWithGlobalConversionWithNoSizeAndNoMimeTypes->validationConstraints('logo');
+        $this->assertEquals('', $validationConstraintsString);
+    }
+    
+    /**
+     * @test
+     */
+    public function it_returns_only_dimension_validation_constraints_when_only_dimensions_declared()
+    {
+        $validationConstraintsString = $this->testModelWithGlobalConversionOnly->validationConstraints('logo');
+        $this->assertEquals('dimensions:min_width=60,min_height=20', $validationConstraintsString);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_mime_types_validation_constraints_when_only_mime_types_declared()
+    {
+        $validationConstraintsString = $this->testModelWithGlobalConversionWithNoSize->validationConstraints('logo');
+        $this->assertEquals('mimetypes:image/jpeg,image/png', $validationConstraintsString);
+    }
+}

--- a/tests/Unit/ValidationGenerator/CollectionValidationConstraintsTest.php
+++ b/tests/Unit/ValidationGenerator/CollectionValidationConstraintsTest.php
@@ -41,7 +41,7 @@ class CollectionValidationConstraintsTest extends TestCase
         $validationConstraintsString = $this->testModelWithGlobalConversionWithNoSizeAndNoMimeTypes->validationConstraints('logo');
         $this->assertEquals('', $validationConstraintsString);
     }
-    
+
     /**
      * @test
      */


### PR DESCRIPTION
@freekmurze, here is my implementation proposition (https://github.com/spatie/laravel-medialibrary/issues/858).  
This full tested pull request provides the following additional features :

#### Ability to add the mime types constraints for each collection.
In addition to the `acceptsFile` method, this implementation give the possibility to add the following constraint, which would be used for the following added features (see below), but also to trigger the `FileUnacceptableForCollection` exception if not respected : `acceptsMimeTypes(array $mimeTypes)` 
Example :  
```php
public function registerMediaCollections()
{
    $this->addMediaCollection('images')->acceptsFile(function (File $file) {
        return $file->size <= 30000;
    })->acceptsMimeTypes(['image/jpeg']);
}
```

#### Ability to dynamically generate a collection-related validation string.
Example :  
```php
// in your user storing form request
public function rules()
{
    return [
        'avatar' => app(User::class)->validationConstraints('avatar'),
        // example : "dimensions:min_width=60,min_height=20|mimetypes:image/jpeg,image/png"
        // other validation rules
    ];
}
```

This method call itself the `dimensionValidationConstraints($collectionName):string` and the `mimeTypesValidationConstraints($collectionName):string` methods, which can be called separately if needed.  


#### Ability to dynamically generate a collection-related input legend string.
Example :  
```html
// in your HTML form
<label for="avatar">Choose a profile picture :</label>
<input type=" id="avatar" name="avatar" value="{{ $avatarFileName }}">
<small>{{ app(User::class)->constraintsLegend('avatar') }}</small>
<!-- for example : "Min. width : 150 px / Min. height : 70 px. Accepted MIME Type(s) : image/jpeg, image/png." -->
``` 

This method call itself the `collectionDimensionsLegend($collectionName):string` and the `collectionMimeTypesLegend($collectionName):string` methods, which can be also be called separately.

#### Extra methods
Those features both use the `collectionMaxSizes(collectionName): array` method, which also can be used if needed (public method).