### PR TITLE
Only set `custom_headers` property if explicitly set

### DIFF
--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -239,7 +239,9 @@ class FileAdder
 
         $media->manipulations = $this->manipulations;
 
-        $media->setCustomHeaders($this->customHeaders);
+        if (filled($this->customHeaders)) {
+            $media->setCustomHeaders($this->customHeaders);
+        }
 
         $media->fill($this->properties);
 

--- a/tests/Feature/Media/CustomHeadersTest.php
+++ b/tests/Feature/Media/CustomHeadersTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Feature\Media;
+
+use Spatie\MediaLibrary\Tests\TestCase;
+
+class CustomHeadersTest extends TestCase
+{
+    /** @test */
+    public function it_does_not_set_empty_custom_headers_when_saved()
+    {
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->toMediaCollection();
+
+        $this->assertFalse($media->hasCustomProperty('custom_headers'));
+        $this->assertEquals([], $media->getCustomHeaders());
+    }
+
+    /** @test */
+    public function it_can_set_and_retrieve_custom_headers_when_explicitly_added()
+    {
+        $headers = [
+            'Header' => 'Present',
+        ];
+
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->toMediaCollection()
+            ->setCustomHeaders($headers);
+
+        $this->assertTrue($media->hasCustomProperty('custom_headers'));
+        $this->assertEquals($headers, $media->getCustomHeaders());
+    }
+}


### PR DESCRIPTION
Fix for #1336. 

In the `toMediaCollection()` method, the call to `setCustomHeaders()` is now only made if the `customHeaders` array is filled.