### PR TITLE
Use default Content-Disposition

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -228,7 +228,7 @@ class Media extends Model implements Responsable, Htmlable
             'Cache-Control' => 'must-revalidate, post-check=0, pre-check=0',
             'Content-Type' => $this->mime_type,
             'Content-Length' => $this->size,
-            'Content-Disposition' => 'attachment; filename="'.$this->file_name.'"',
+            'Content-Disposition' => 'inline; filename="'.$this->file_name.'"',
             'Pragma' => 'public',
         ];
 


### PR DESCRIPTION
This PR changes the Content-Disposition header to the value `inline`, which is also the default for files without any header. (Source: [Content-Disposition | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition))

Benefits are, the browser will display files directly if it can. The user also has the option to download the file instead of being forced. Files that cannot be shown directly will automatically be downloaded.

Related issue: #1126