### PR TITLE
fix call to undefined method FFMpeg::getDuration() #1371

### DIFF
--- a/src/ImageGenerators/FileTypes/Video.php
+++ b/src/ImageGenerators/FileTypes/Video.php
@@ -20,7 +20,7 @@ class Video extends BaseGenerator
         ]);
 
         $video = $ffmpeg->open($file);
-        $duration = $ffmpeg->getDuration();
+        $duration = $ffmpeg->getFFProbe()->format($file)->get('duration');
 
         $seconds = $conversion ? $conversion->getExtractVideoFrameAtSecond() : 0;
         $seconds = $duration < $seconds ? 0 : $seconds;


### PR DESCRIPTION
This pr fixes issue #1371

No tests needed as this fixes failing tests:

* `Spatie\MediaLibrary\Tests\Feature\Conversion\ConversionFileExtensionTest::it_always_defaults_to_jpg_when_the_original_file_is_not_an_image`
* `Spatie\MediaLibrary\Tests\Unit\ImageGenerators\VideoTest::it_can_convert_a_video`