### PR TITLE
Ability to fetch the last (latest) Media added to a Media Collection

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -278,6 +278,68 @@ trait HasMediaTrait
     }
 
     /**
+     * Get the last media item of a media collection.
+     *
+     * @param string $collectionName
+     * @param array  $filters
+     * @return Media|null
+     */
+    public function getLastMedia(string $collectionName = 'default', array $filters = []): ?Media
+    {
+        $media = $this->getMedia($collectionName, $filters);
+
+        return $media->last();
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for last media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getLastMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        $media = $this->getLastMedia($collectionName);
+
+        if (! $media) {
+            return '';
+        }
+
+        return $media->getUrl($conversionName);
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for last media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getLastTemporaryUrl(DateTimeInterface $expiration, string $collectionName = 'default', string $conversionName = ''): string
+    {
+        $media = $this->getLastMedia($collectionName);
+
+        if (! $media) {
+            return '';
+        }
+
+        return $media->getTemporaryUrl($expiration, $conversionName);
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for last media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getLastMediaPath(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        $media = $this->getLastMedia($collectionName);
+
+        if (! $media) {
+            return '';
+        }
+
+        return $media->getPath($conversionName);
+    }
+
+    /**
      * Update a media collection by deleting and inserting again with new values.
      *
      * @param array $newMediaArray

--- a/tests/Feature/HasMediaTrait/GetMediaTest.php
+++ b/tests/Feature/HasMediaTrait/GetMediaTest.php
@@ -202,6 +202,70 @@ class GetMediaTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_last_media_from_a_collection()
+    {
+        $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $media->name = 'first';
+        $media->save();
+
+        $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $media->name = 'second';
+        $media->save();
+
+        $this->assertEquals('second', $this->testModel->getLastMedia('images')->name);
+    }
+
+    /** @test */
+    public function it_can_get_the_last_media_from_a_collection_using_a_filter()
+    {
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+        $media->name = 'first';
+        $media->save();
+
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->withCustomProperties(['extra_property' => 'yes'])
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+        $media->name = 'second';
+        $media->save();
+
+        $this->assertEquals('second', $this->testModel->getLastMedia('images', ['extra_property' => 'yes'])->name);
+    }
+
+    public function it_returns_false_when_getting_last_media_for_an_empty_collection()
+    {
+        $this->assertFalse($this->testModel->getLastMedia());
+    }
+
+    /** @test */
+    public function it_can_get_the_url_to_last_media_in_a_collection()
+    {
+        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $firstMedia->save();
+
+        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $secondMedia->save();
+
+        $this->assertEquals($secondMedia->getUrl(), $this->testModel->getLastMediaUrl('images'));
+    }
+
+    /** @test */
+    public function it_can_get_the_path_to_last_media_in_a_collection()
+    {
+        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $firstMedia->save();
+
+        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $secondMedia->save();
+
+        $this->assertEquals($secondMedia->getPath(), $this->testModel->getLastMediaPath('images'));
+    }
+
+    /** @test */
     public function it_will_return_preloaded_media_sorting_on_order_column()
     {
         $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');


### PR DESCRIPTION
Following PR #309 abandon I felt like someone had to step in and finish this.

Similar to `getFirstMedia()` (and the other functions based on this function) available from the HasMediaTrait, `getLastMedia()` is aiming to give us the ability to retrieve the last Media from a Media Collection.

----

Functions added to `HasMediaTrait`:

* `getLastMedia()`
* `getLastMediaUrl()`
* `getLastTemporaryUrl()`
* `getLastMediaPath()`

New tests added:

* `it_can_get_the_last_media_from_a_collection`
* `it_can_get_the_last_media_from_a_collection_using_a_filter`
* `it_returns_false_when_getting_last_media_for_an_empty_collection`
* `it_can_get_the_url_to_last_media_in_a_collection`
* `it_can_get_the_path_to_last_media_in_a_collection`

----

Not sure about how to update the documentation, I assume you'll take care of this if that PR happens to be merged.