### PR TITLE
Fix issue - S3 Responsive Image URL Generator not using root

### DIFF
--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -73,6 +73,7 @@ class S3UrlGenerator extends BaseUrlGenerator
         if ($root = config('filesystems.disks.'.$this->media->disk.'.root')) {
             $url = $root.'/'.$url;
         }
+        
         return config('medialibrary.s3.domain').'/'.$url;
     }
 }

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -69,6 +69,10 @@ class S3UrlGenerator extends BaseUrlGenerator
      */
     public function getResponsiveImagesDirectoryUrl(): string
     {
-        return config('medialibrary.s3.domain').'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
+        $url = $this->pathGenerator->getPathForResponsiveImages($this->media);
+        if ($root = config('filesystems.disks.'.$this->media->disk.'.root')) {
+            $url = $root.'/'.$url;
+        }
+        return config('medialibrary.s3.domain').'/'.$url;
     }
 }

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -125,7 +125,7 @@ class S3IntegrationTest extends TestCase
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
             ->toMediaCollection('default', 's3_disk');
-
+        
         $this->assertEquals(
             $this->app['config']->get('medialibrary.s3.domain')."/{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg",
             $media->getResponsiveImagesDirectoryUrl('thumb')

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -118,6 +118,19 @@ class S3IntegrationTest extends TestCase
             $media->getUrl('thumb')
         );
     }
+    
+    /** @test */
+    public function it_retrieve_a_media_responsive_url_from_s3()
+    {
+        $media = $this->testModelWithConversion
+            ->addMedia($this->getTestJpg())
+            ->toMediaCollection('default', 's3_disk');
+
+        $this->assertEquals(
+            $this->app['config']->get('medialibrary.s3.domain')."/{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg",
+            $media->getResponsiveImagesDirectoryUrl('thumb')
+        );
+    }
 
     /** @test */
     public function it_retrieves_a_temporary_media_url_from_s3()


### PR DESCRIPTION
Appended root to ResponsiveImagesDirectoryUrl function just like the getUrl function.

Cheers,
Gabriel