### PR TITLE
[Discussion] ACL headers only for conversion 

### DIFF
--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -52,7 +52,7 @@ class Filesystem
 
         $this->filesystem
             ->disk($media->disk)
-            ->put($destination, $file, $this->getRemoteHeadersForFile($pathToFile, $media->getCustomHeaders()));
+            ->put($destination, $file, $this->getRemoteHeadersForFile($pathToFile, $media->getCustomHeaders($type)));
 
         if (is_resource($file)) {
             fclose($file);

--- a/src/Models/Traits/CustomMediaProperties.php
+++ b/src/Models/Traits/CustomMediaProperties.php
@@ -4,15 +4,19 @@ namespace Spatie\MediaLibrary\Models\Traits;
 
 trait CustomMediaProperties
 {
-    public function setCustomHeaders(array $customHeaders): self
-    {
-        $this->setCustomProperty('custom_headers', $customHeaders);
+	public function setCustomHeaders(array $customHeaders): self
+	{
+		$this->setCustomProperty('custom_headers', $customHeaders);
 
-        return $this;
-    }
+		return $this;
+	}
 
-    public function getCustomHeaders(): array
-    {
-        return $this->getCustomProperty('custom_headers', []);
-    }
+	public function getCustomHeaders($type): array
+	{
+		if (isset($type)) {
+			return ['ACL' => 'public-read'];
+		}
+
+		return $this->getCustomProperty('custom_headers', []);
+	}
 }


### PR DESCRIPTION
Hello!

Please tell me if I'm doing it right.
In my case, I require that the original image was not available for viewing and conversely available conversions.

By default, all files in the bucket are not available for viewing.

Can this be done as something different, without changing the source of the library?