### PR TITLE
Moving Hard-Coded Hyphen to Configuration File

### DIFF
--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -147,4 +147,9 @@ return [
         'perform_conversions' => Spatie\MediaLibrary\Jobs\PerformConversions::class,
         'generate_responsive_images' => Spatie\MediaLibrary\Jobs\GenerateResponsiveImages::class,
     ],
+
+    /*
+     * The separator character used to identify conversion files.
+     */
+    'conversion_name_separator' => '-',
 ];

--- a/src/Conversion/Conversion.php
+++ b/src/Conversion/Conversion.php
@@ -259,6 +259,7 @@ class Conversion
     public function getConversionFile(string $file): string
     {
         $fileName = pathinfo($file, PATHINFO_FILENAME);
+        $nameSeparator = config('medialibrary.conversion_name_separator');
 
         $extension = $this->getResultExtension();
 
@@ -266,6 +267,6 @@ class Conversion
             $extension = pathinfo($file, PATHINFO_EXTENSION);
         }
 
-        return "{$fileName}-{$this->getName()}.{$extension}";
+        return "{$fileName}{$nameSeparator}{$this->getName()}.{$extension}";
     }
 }

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -95,8 +95,10 @@ class FileManipulator
 
                 $manipulationResult = $this->performManipulations($media, $conversion, $copiedOriginalFile);
 
+                $nameSeparator = config('medialibrary.conversion_name_separator');
+
                 $newFileName = pathinfo($media->file_name, PATHINFO_FILENAME).
-                    '-'.$conversion->getName().
+                    $nameSeparator.$conversion->getName().
                     '.'.$conversion->getResultExtension(pathinfo($copiedOriginalFile, PATHINFO_EXTENSION));
 
                 $renamedFile = MediaLibraryFileHelper::renameInDirectory($manipulationResult, $newFileName);

--- a/src/UrlGenerator/BaseUrlGenerator.php
+++ b/src/UrlGenerator/BaseUrlGenerator.php
@@ -72,9 +72,11 @@ abstract class BaseUrlGenerator implements UrlGenerator
             return $this->pathGenerator->getPath($this->media).($this->media->file_name);
         }
 
+        $nameSeparator = config('medialibrary.conversion_name_separator');
+
         return $this->pathGenerator->getPathForConversions($this->media)
             .pathinfo($this->media->file_name, PATHINFO_FILENAME)
-            .'-'.$this->conversion->getName()
+            .$nameSeparator.$this->conversion->getName()
             .'.'
             .$this->conversion->getResultExtension($this->media->extension);
     }


### PR DESCRIPTION
Overriding the hyphen used when creating conversions can be a big problem.
This can be easily fixed by replacing the hard-coded hyphen used in three
functions with a configuration variable. This may also help for future development.
I ran into a similar situation as @jwtea in issue #1179