### PR TITLE
Pull S3 domain/base url from filesystem config if available

### DIFF
--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -33,7 +33,12 @@ class S3UrlGenerator extends BaseUrlGenerator
 
         $url = $this->rawUrlEncodeFilename($url);
 
-        return config('medialibrary.s3.domain').'/'.$url;
+        $base = config('medialibrary.s3.domain');
+        if ($root = config('filesystems.disks.'.$this->media->disk.'.generator_url')) {
+            $base = config('filesystems.disks.'.$this->media->disk.'.generator_url');
+        }
+
+        return $base.'/'.$url;
     }
 
     /**
@@ -69,6 +74,10 @@ class S3UrlGenerator extends BaseUrlGenerator
      */
     public function getResponsiveImagesDirectoryUrl(): string
     {
-        return config('medialibrary.s3.domain').'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
+        $base = config('medialibrary.s3.domain');
+        if ($root = config('filesystems.disks.'.$this->media->disk.'.generator_url')) {
+            $base = config('filesystems.disks.'.$this->media->disk.'.generator_url');
+        }
+        return $base.'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
     }
 }

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -34,7 +34,7 @@ class S3UrlGenerator extends BaseUrlGenerator
         $url = $this->rawUrlEncodeFilename($url);
 
         $base = config('medialibrary.s3.domain');
-        if ($root = config('filesystems.disks.'.$this->media->disk.'.generator_url')) {
+        if (config('filesystems.disks.'.$this->media->disk.'.generator_url')) {
             $base = config('filesystems.disks.'.$this->media->disk.'.generator_url');
         }
 
@@ -75,7 +75,7 @@ class S3UrlGenerator extends BaseUrlGenerator
     public function getResponsiveImagesDirectoryUrl(): string
     {
         $base = config('medialibrary.s3.domain');
-        if ($root = config('filesystems.disks.'.$this->media->disk.'.generator_url')) {
+        if (config('filesystems.disks.'.$this->media->disk.'.generator_url')) {
             $base = config('filesystems.disks.'.$this->media->disk.'.generator_url');
         }
         return $base.'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);


### PR DESCRIPTION
When using a compatible S3 storage like DigitalOcean Spaces or Minio, the default url generator creates a url with `.s3.amazonaws.com` in it due to the config:

```
    's3' => [
        /*
         * The domain that should be prepended when generating urls.
         */
        'domain' => 'https://'.env('AWS_BUCKET').'.s3.amazonaws.com',
    ],
```

Obviously DO Spaces, Minio, or others wouldn't use `.s3.amazonaws.com` in the url.  In order to make the package work with non-AWS storage, we need to publish and modify the medialibrary config file and create a custom url generator class.  Instead, it would be nice to use an optional config setting on the filesystem disk (if available) to generate the url.  This would avoid the need to create a custom url generator just for to make this url work.  Here is a sample filesystem config which would use the custom option:

```
'minio' => [
    'driver' => 's3',
    'key' => env('MINIO_KEYKEY'),
    'secret' => env('MINIO_KEYSECRET'),
    'region' => env('MINIO_KEYREGION', 'us-east-1'),
    'bucket' => env('MINIO_KEYBUCKET'),
    'endpoint' => env('MINIO_KEYENDPOINT'),
    'generator_url' => env('MINIO_KEYGENERATOR_URL', 'http://localhost:9000/my-bucket'),
    'root' => env('MINIO_KEYROOT', ''),
    'visibility' => env('MINIO_KEYVISIBILITY', 'public'),
    'bucket_endpoint' => env('MINIO_KEYBUCKET_ENDPOINT', false),
    'use_path_style_endpoint' => env('MINIO_KEYPATH_STYLE_ENDPOINT', true),
],
```

This allows the `generator_url` option to act as a base for generated urls without needing to write a custom class and bring in the medialibrary config file.