### PR TITLE
Accept sync queue on config file

### DIFF
--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -150,8 +150,14 @@ class FileManipulator
 
         $job = new $performConversionsJobClass($queuedConversions, $media);
 
-        if ($customQueue = config('medialibrary.queue_name')) {
+        $customQueue = config('medialibrary.queue_name');
+
+        if (strlen($customQueue)>0 && $customQueue!='sync') {
             $job->onQueue($customQueue);
+        }
+        
+        if (isset($customQueue) && $customQueue=='sync') {
+            return app(Dispatcher::class)->dispatchNow($job);
         }
 
         app(Dispatcher::class)->dispatch($job);

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -155,7 +155,7 @@ class FileManipulator
         if (strlen($customQueue) > 0 && $customQueue != 'sync') {
             $job->onQueue($customQueue);
         }
-        
+
         if (isset($customQueue) && $customQueue == 'sync') {
             return app(Dispatcher::class)->dispatchNow($job);
         }

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -152,11 +152,11 @@ class FileManipulator
 
         $customQueue = config('medialibrary.queue_name');
 
-        if (strlen($customQueue)>0 && $customQueue!='sync') {
+        if (strlen($customQueue) > 0 && $customQueue != 'sync') {
             $job->onQueue($customQueue);
         }
         
-        if (isset($customQueue) && $customQueue=='sync') {
+        if (isset($customQueue) && $customQueue == 'sync') {
             return app(Dispatcher::class)->dispatchNow($job);
         }
 


### PR DESCRIPTION
Right now i have as default queue value the database, i was trying to make the jobs from this package to execute inmediately with sync but it wasnt successfull.

So this pull request will help that anyone that puts `'queue_name' => 'sync',` on the config file will make the jobs from the package to be executed inmediately and not by a queue.

Hope you accept this pull request.
Regards