### PR TITLE
Fix ->extractVideoFrameAtSecond(10)

### DIFF
--- a/src/ImageGenerators/FileTypes/Video.php
+++ b/src/ImageGenerators/FileTypes/Video.php
@@ -20,7 +20,7 @@ class Video extends BaseGenerator
         ]);
 
         $video = $ffmpeg->open($file);
-        $duration = $ffmpeg->getDuration();
+        $duration = $ffmpeg->getFFProbe()->format($file)->get('duration');
 
         $seconds = $conversion ? $conversion->getExtractVideoFrameAtSecond() : 0;
         $seconds = $duration < $seconds ? 0 : $seconds;


### PR DESCRIPTION
getDuration for videos should be taken via FFProbe, not FFMpeg directly.

As an example look here:
https://github.com/PHP-FFMpeg/PHP-FFMpeg/blob/master/src/FFMpeg/FFProbe.php#L185