### PR TITLE
Add ability to specify a custom config file

### DIFF
--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Commands;
 
 use Illuminate\Console\Command;
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Models\Media;
 use Illuminate\Console\ConfirmableTrait;
 use Spatie\MediaLibrary\FileManipulator;
@@ -166,7 +167,7 @@ class CleanCommand extends Command
 
     protected function deleteOrphanedDirectories()
     {
-        $diskName = $this->argument('disk') ?: config('medialibrary.disk_name');
+        $diskName = $this->argument('disk') ?: MediaLibrary::config('disk_name');
 
         if (is_null(config("filesystems.disks.{$diskName}"))) {
             throw FileCannotBeAdded::diskDoesNotExist($diskName);

--- a/src/Conversion/Conversion.php
+++ b/src/Conversion/Conversion.php
@@ -4,6 +4,7 @@ namespace Spatie\MediaLibrary\Conversion;
 
 use BadMethodCallException;
 use Spatie\Image\Manipulations;
+use Spatie\MediaLibrary\MediaLibrary;
 
 /** @mixin \Spatie\Image\Manipulations */
 class Conversion
@@ -34,7 +35,7 @@ class Conversion
         $this->name = $name;
 
         $this->manipulations = (new Manipulations())
-            ->optimize(config('medialibrary.image_optimizers'))
+            ->optimize(MediaLibrary::config('image_optimizers'))
             ->format('jpg');
     }
 

--- a/src/Exceptions/FileCannotBeAdded/FileIsTooBig.php
+++ b/src/Exceptions/FileCannotBeAdded/FileIsTooBig.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Exceptions\FileCannotBeAdded;
 
 use Spatie\MediaLibrary\Helpers\File;
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded;
 
 class FileIsTooBig extends FileCannotBeAdded
@@ -11,7 +12,7 @@ class FileIsTooBig extends FileCannotBeAdded
     {
         $fileSize = File::getHumanReadableSize(filesize($path));
 
-        $maxFileSize = File::getHumanReadableSize(config('medialibrary.max_file_size'));
+        $maxFileSize = File::getHumanReadableSize(MediaLibrary::config('max_file_size'));
 
         return new static("File `{$path}` has a size of {$fileSize} which is greater than the maximum allowed {$maxFileSize}");
     }

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\FileAdder;
 
 use Spatie\MediaLibrary\Helpers\File;
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Models\Media;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\MediaLibrary\HasMedia\HasMedia;
@@ -209,11 +210,11 @@ class FileAdder
             throw FileDoesNotExist::create($this->pathToFile);
         }
 
-        if (filesize($this->pathToFile) > config('medialibrary.max_file_size')) {
+        if (filesize($this->pathToFile) > MediaLibrary::config('max_file_size')) {
             throw FileIsTooBig::create($this->pathToFile);
         }
 
-        $mediaClass = config('medialibrary.media_model');
+        $mediaClass = MediaLibrary::config('media_model');
         /** @var \Spatie\MediaLibrary\Models\Media $media */
         $media = new $mediaClass();
 
@@ -264,7 +265,7 @@ class FileAdder
             }
         }
 
-        return config('medialibrary.disk_name');
+        return MediaLibrary::config('disk_name');
     }
 
     public function defaultSanitizer(string $fileName): string
@@ -311,11 +312,11 @@ class FileAdder
         }
 
         if ($this->generateResponsiveImages && (new ImageGenerator())->canConvert($media)) {
-            $generateResponsiveImagesJobClass = config('medialibrary.jobs.generate_responsive_images', GenerateResponsiveImages::class);
+            $generateResponsiveImagesJobClass = MediaLibrary::config('jobs.generate_responsive_images', GenerateResponsiveImages::class);
 
             $job = new $generateResponsiveImagesJobClass($media);
 
-            if ($customQueue = config('medialibrary.queue_name')) {
+            if ($customQueue = MediaLibrary::config('queue_name')) {
                 $job->onQueue($customQueue);
             }
 

--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -146,11 +146,11 @@ class FileManipulator
 
     protected function dispatchQueuedConversions(Media $media, ConversionCollection $queuedConversions)
     {
-        $performConversionsJobClass = config('medialibrary.jobs.perform_conversions', PerformConversions::class);
+        $performConversionsJobClass = MediaLibrary::config('jobs.perform_conversions', PerformConversions::class);
 
         $job = new $performConversionsJobClass($queuedConversions, $media);
 
-        if ($customQueue = config('medialibrary.queue_name')) {
+        if ($customQueue = MediaLibrary::config('queue_name')) {
             $job->onQueue($customQueue);
         }
 

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Filesystem;
 
 use Spatie\MediaLibrary\Helpers\File;
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Models\Media;
 use Spatie\MediaLibrary\FileManipulator;
 use Illuminate\Contracts\Filesystem\Factory;
@@ -68,7 +69,7 @@ class Filesystem
     {
         $mimeTypeHeader = ['ContentType' => File::getMimeType($file)];
 
-        $extraHeaders = config('medialibrary.remote.extra_headers');
+        $extraHeaders = MediaLibrary::config('remote.extra_headers');
 
         return array_merge($mimeTypeHeader, $extraHeaders, $this->customRemoteHeaders, $mediaCustomHeaders);
     }

--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary\HasMedia;
 use DateTimeInterface;
 use Illuminate\Http\File;
 use Illuminate\Support\Collection;
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Models\Media;
 use Spatie\MediaLibrary\MediaRepository;
 use Illuminate\Support\Facades\Validator;
@@ -58,7 +59,7 @@ trait HasMediaTrait
      */
     public function media()
     {
-        return $this->morphMany(config('medialibrary.media_model'), 'model');
+        return $this->morphMany(MediaLibrary::config('media_model'), 'model');
     }
 
     /**
@@ -295,7 +296,7 @@ trait HasMediaTrait
             ->map(function (array $newMediaItem) use ($collectionName) {
                 static $orderColumn = 1;
 
-                $mediaClass = config('medialibrary.media_model');
+                $mediaClass = MediaLibrary::config('media_model');
                 $currentMedia = $mediaClass::findOrFail($newMediaItem['id']);
 
                 if ($currentMedia->collection_name !== $collectionName) {

--- a/src/Helpers/ImageFactory.php
+++ b/src/Helpers/ImageFactory.php
@@ -3,12 +3,13 @@
 namespace Spatie\MediaLibrary\Helpers;
 
 use Spatie\Image\Image;
+use Spatie\MediaLibrary\MediaLibrary;
 
 class ImageFactory
 {
     public static function load(string $path): Image
     {
         return Image::load($path)
-            ->useImageDriver(config('medialibrary.image_driver'));
+            ->useImageDriver(MediaLibrary::config('image_driver'));
     }
 }

--- a/src/Helpers/TemporaryDirectory.php
+++ b/src/Helpers/TemporaryDirectory.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\Helpers;
 
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\TemporaryDirectory\TemporaryDirectory as BaseTemporaryDirectory;
 
 class TemporaryDirectory
@@ -13,7 +14,7 @@ class TemporaryDirectory
 
     protected static function getTemporaryDirectoryPath(): string
     {
-        $path = config('medialibrary.temporary_directory_path') ?? storage_path('medialibrary/temp');
+        $path = MediaLibrary::config('temporary_directory_path') ?? storage_path('medialibrary/temp');
 
         return $path.DIRECTORY_SEPARATOR.str_random(32);
     }

--- a/src/ImageGenerators/FileTypes/Video.php
+++ b/src/ImageGenerators/FileTypes/Video.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary\ImageGenerators\FileTypes;
 use FFMpeg\FFMpeg;
 use FFMpeg\Coordinate\TimeCode;
 use Illuminate\Support\Collection;
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Conversion\Conversion;
 use Spatie\MediaLibrary\ImageGenerators\BaseGenerator;
 
@@ -15,8 +16,8 @@ class Video extends BaseGenerator
         $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
 
         $ffmpeg = FFMpeg::create([
-            'ffmpeg.binaries' => config('medialibrary.ffmpeg_path'),
-            'ffprobe.binaries' => config('medialibrary.ffprobe_path'),
+            'ffmpeg.binaries' => MediaLibrary::config('ffmpeg_path'),
+            'ffprobe.binaries' => MediaLibrary::config('ffprobe_path'),
         ]);
 
         $video = $ffmpeg->open($file);

--- a/src/MediaLibrary.php
+++ b/src/MediaLibrary.php
@@ -39,28 +39,55 @@ class MediaLibrary
     }
 
     /**
-     * Get the config array, or a value from it.
+     * Get / set the specified configuration value.
      *
-     * @param  string|null  $key
-     * @param  mixed        $default
-     * @return mixed
+     * If an array is passed as the key, we will assume you want to set an array of values.
+     *
+     * @param  array|string  $key
+     * @param  mixed         $default
+     * @return mixed|array
      */
     public static function config($key = null, $default = null)
     {
-        $config = config(static::configFile());
+        if (is_null($key)) {
+            return config(static::configFile(), []);
+        }
 
-        return func_num_args() ? data_get($config, $key, $default) : $config;
+        if (is_array($key)) {
+            return static::setConfig($key);
+        }
+
+        return static::getConfig($key, $default);
+    }
+
+    /**
+     * Get the config value for the given key.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    public static function getConfig(string $key, $default = null)
+    {
+        return data_get(static::config(), $key, $default);
     }
 
     /**
      * Set a config value for the given key.
      *
-     * @param  string  $key
-     * @param  mixed   $value
+     * @param  array|string  $key
+     * @param  mixed         $value
      * @return void
      */
-    public static function setConfig(string $key, $value)
+    public static function setConfig($key, $value = null)
     {
-        config([static::configFile().'.'.$key => $value]);
+        $keys = is_array($key) ? $key : [$key => $value];
+
+        // Here, we'll prepend the given keys with the config file that's being used.
+        $keys = collect($keys)->mapWithKeys(function ($value, $key) {
+            return [static::configFile().'.'.$key => $value];
+        })->all();
+
+        config($keys);
     }
 }

--- a/src/MediaLibrary.php
+++ b/src/MediaLibrary.php
@@ -61,6 +61,6 @@ class MediaLibrary
      */
     public static function setConfig(string $key, $value)
     {
-        config([ static::configFile() .'.'. $key => $value ]);
+        config([static::configFile().'.'.$key => $value]);
     }
 }

--- a/src/MediaLibrary.php
+++ b/src/MediaLibrary.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Spatie\MediaLibrary;
+
+class MediaLibrary
+{
+    /**
+     * The config file to use.
+     *
+     * @var string
+     */
+    protected static $config_file = 'medialibrary';
+
+    /**
+     * Get the config file.
+     *
+     * @return string
+     */
+    public static function configFile()
+    {
+        return static::$config_file;
+    }
+
+    /**
+     * Specify the config file to use.
+     *
+     * @param  string  $config_file
+     * @return static
+     */
+    public static function setConfigFile(string $config_file)
+    {
+        $config_file = trim($config_file, ' /');
+        $config_file = rtrim($config_file, '.php');
+        $config_file = str_replace('/', '.', $config_file);
+
+        static::$config_file = $config_file;
+
+        return new static;
+    }
+
+    /**
+     * Get the config array, or a value from it.
+     *
+     * @param  string|null  $key
+     * @param  mixed        $default
+     * @return mixed
+     */
+    public static function config($key = null, $default = null)
+    {
+        $config = config(static::configFile());
+
+        return func_num_args() ? data_get($config, $key, $default) : $config;
+    }
+
+    /**
+     * Set a config value for the given key.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return void
+     */
+    public static function setConfig(string $key, $value)
+    {
+        config([ static::configFile() .'.'. $key => $value ]);
+    }
+}

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -28,7 +28,7 @@ class MediaLibraryServiceProvider extends ServiceProvider
             __DIR__.'/../resources/views' => resource_path('views/vendor/medialibrary'),
         ], 'views');
 
-        $mediaClass = config('medialibrary.media_model');
+        $mediaClass = MediaLibrary::config('media_model');
 
         $mediaClass::observe(new MediaObserver());
 
@@ -37,10 +37,10 @@ class MediaLibraryServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/medialibrary.php', 'medialibrary');
+        $this->mergeConfigFrom(__DIR__.'/../config/medialibrary.php', MediaLibrary::configFile());
 
         $this->app->singleton(MediaRepository::class, function () {
-            $mediaClass = config('medialibrary.media_model');
+            $mediaClass = MediaLibrary::config('media_model');
 
             return new MediaRepository(new $mediaClass);
         });
@@ -51,8 +51,8 @@ class MediaLibraryServiceProvider extends ServiceProvider
 
         $this->app->bind(Filesystem::class, Filesystem::class);
 
-        $this->app->bind(WidthCalculator::class, config('medialibrary.responsive_images.width_calculator'));
-        $this->app->bind(TinyPlaceholderGenerator::class, config('medialibrary.responsive_images.tiny_placeholder_generator'));
+        $this->app->bind(WidthCalculator::class, MediaLibrary::config('responsive_images.width_calculator'));
+        $this->app->bind(TinyPlaceholderGenerator::class, MediaLibrary::config('responsive_images.tiny_placeholder_generator'));
 
         $this->commands([
             'command.medialibrary:regenerate',
@@ -65,8 +65,8 @@ class MediaLibraryServiceProvider extends ServiceProvider
 
     protected function registerDeprecatedConfig()
     {
-        if (! config('medialibrary.disk_name')) {
-            config(['medialibrary.disk_name' => config('medialibrary.default_filesystem')]);
+        if (! MediaLibrary::config('disk_name')) {
+            MediaLibrary::setConfig('disk_name', MediaLibrary::config('default_filesystem'));
         }
     }
 }

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -6,6 +6,7 @@ use DateTimeInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Spatie\MediaLibrary\Helpers\File;
+use Spatie\MediaLibrary\MediaLibrary;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Contracts\Support\Htmlable;
 use Spatie\MediaLibrary\HasMedia\HasMedia;
@@ -78,7 +79,7 @@ class Media extends Model implements Responsable, Htmlable
 
     public function getImageGenerators(): Collection
     {
-        return collect(config('medialibrary.image_generators'));
+        return collect(MediaLibrary::config('image_generators'));
     }
 
     public function getTypeAttribute(): string
@@ -301,7 +302,7 @@ class Media extends Model implements Responsable, Htmlable
         $width = '';
 
         if ($this->hasResponsiveImages($conversion)) {
-            $viewName = config('medialibrary.responsive_images.use_tiny_placeholders')
+            $viewName = MediaLibrary::config('responsive_images.use_tiny_placeholders')
                 ? 'responsiveImageWithPlaceholder'
                 : 'responsiveImage';
 

--- a/src/PathGenerator/PathGeneratorFactory.php
+++ b/src/PathGenerator/PathGeneratorFactory.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\PathGenerator;
 
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Exceptions\InvalidPathGenerator;
 
 class PathGeneratorFactory
@@ -10,7 +11,7 @@ class PathGeneratorFactory
     {
         $pathGeneratorClass = BasePathGenerator::class;
 
-        $customPathClass = config('medialibrary.path_generator');
+        $customPathClass = MediaLibrary::config('path_generator');
 
         if ($customPathClass) {
             $pathGeneratorClass = $customPathClass;

--- a/src/ResponsiveImages/RegisteredResponsiveImages.php
+++ b/src/ResponsiveImages/RegisteredResponsiveImages.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\ResponsiveImages;
 
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Models\Media;
 
 class RegisteredResponsiveImages
@@ -50,7 +51,7 @@ class RegisteredResponsiveImages
             })
             ->implode(', ');
 
-        $shouldAddPlaceholderSvg = config('medialibrary.responsive_images.use_tiny_placeholders')
+        $shouldAddPlaceholderSvg = MediaLibrary::config('responsive_images.use_tiny_placeholders')
             && $this->getPlaceholderSvg();
 
         if ($shouldAddPlaceholderSvg) {

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\UrlGenerator;
 
 use DateTimeInterface;
+use Spatie\MediaLibrary\MediaLibrary;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Contracts\Config\Repository as Config;
 
@@ -33,7 +34,7 @@ class S3UrlGenerator extends BaseUrlGenerator
 
         $url = $this->rawUrlEncodeFilename($url);
 
-        return config('medialibrary.s3.domain').'/'.$url;
+        return MediaLibrary::config('s3.domain').'/'.$url;
     }
 
     /**
@@ -69,6 +70,6 @@ class S3UrlGenerator extends BaseUrlGenerator
      */
     public function getResponsiveImagesDirectoryUrl(): string
     {
-        return config('medialibrary.s3.domain').'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
+        return MediaLibrary::config('s3.domain').'/'.$this->pathGenerator->getPathForResponsiveImages($this->media);
     }
 }

--- a/src/UrlGenerator/UrlGeneratorFactory.php
+++ b/src/UrlGenerator/UrlGeneratorFactory.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\UrlGenerator;
 
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Models\Media;
 use Spatie\MediaLibrary\Exceptions\InvalidUrlGenerator;
 use Spatie\MediaLibrary\Conversion\ConversionCollection;
@@ -11,7 +12,7 @@ class UrlGeneratorFactory
 {
     public static function createForMedia(Media $media, string $conversionName = '') : UrlGenerator
     {
-        $urlGeneratorClass = config('medialibrary.url_generator')
+        $urlGeneratorClass = MediaLibrary::config('url_generator')
             ?: 'Spatie\MediaLibrary\UrlGenerator\\'.ucfirst($media->getDiskDriverName()).'UrlGenerator';
 
         static::guardAgainstInvalidUrlGenerator($urlGeneratorClass);

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Tests\Feature\Models\Media;
 
 use File;
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -38,7 +39,7 @@ class DeleteTest extends TestCase
     /** @test */
     public function it_will_remove_files_when_deleting_a_media_object_with_a_custom_path_generator()
     {
-        config(['medialibrary.path_generator' => TestPathGenerator::class]);
+        MediaLibrary::setConfig('path_generator', TestPathGenerator::class);
 
         $pathGenerator = new TestPathGenerator();
 

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -30,9 +30,9 @@ class ServiceProviderTest extends TestCase
 
         $config_file = 'medialibrary_custom';
 
-        $app['config']->set($config_file, array_merge([
-            'disk_name' => 'custom_disk',
-        ], $app['config']->get($config_file, [])));
+        $disk_name = 'custom_disk';
+
+        $app['config']->set($config_file, compact('disk_name'));
 
         $provider = new MediaLibraryServiceProvider($app);
 
@@ -40,6 +40,6 @@ class ServiceProviderTest extends TestCase
 
         MediaLibrary::setConfigFile($config_file);
 
-        $this->assertEquals('custom_disk', MediaLibrary::config('disk_name'));
+        $this->assertEquals($disk_name, MediaLibrary::config('disk_name'));
     }
 }

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -13,8 +13,8 @@ class ServiceProviderTest extends TestCase
     {
         $app = app();
 
-        $app['config']->set(MediaLibrary::configFile() . '.disk_name', null);
-        $app['config']->set(MediaLibrary::configFile() . '.default_filesystem', 'test');
+        $app['config']->set(MediaLibrary::configFile().'.disk_name', null);
+        $app['config']->set(MediaLibrary::configFile().'.default_filesystem', 'test');
 
         $provider = new MediaLibraryServiceProvider($app);
 
@@ -31,7 +31,7 @@ class ServiceProviderTest extends TestCase
         $config_file = 'medialibrary_custom';
 
         $app['config']->set($config_file, array_merge([
-            'disk_name' => 'custom_disk'
+            'disk_name' => 'custom_disk',
         ], $app['config']->get($config_file, [])));
 
         $provider = new MediaLibraryServiceProvider($app);

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Feature;
 
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 
@@ -12,13 +13,33 @@ class ServiceProviderTest extends TestCase
     {
         $app = app();
 
-        $app['config']->set('medialibrary.disk_name', null);
-        $app['config']->set('medialibrary.default_filesystem', 'test');
+        $app['config']->set(MediaLibrary::configFile() . '.disk_name', null);
+        $app['config']->set(MediaLibrary::configFile() . '.default_filesystem', 'test');
 
         $provider = new MediaLibraryServiceProvider($app);
 
         $provider->register();
 
-        $this->assertEquals(config('medialibrary.default_filesystem'), config('medialibrary.disk_name'));
+        $this->assertEquals(MediaLibrary::config('default_filesystem'), MediaLibrary::config('disk_name'));
+    }
+
+    /** @test */
+    public function it_can_use_a_custom_config_file()
+    {
+        $app = app();
+
+        $config_file = 'medialibrary_custom';
+
+        $app['config']->set($config_file, array_merge([
+            'disk_name' => 'custom_disk'
+        ], $app['config']->get($config_file, [])));
+
+        $provider = new MediaLibraryServiceProvider($app);
+
+        $provider->register();
+
+        MediaLibrary::setConfigFile($config_file);
+
+        $this->assertEquals('custom_disk', MediaLibrary::config('disk_name'));
     }
 }

--- a/tests/Unit/Helpers/ImageFactoryTest.php
+++ b/tests/Unit/Helpers/ImageFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Tests\Unit\Helpers;
 
 use ReflectionClass;
+use Spatie\MediaLibrary\MediaLibrary;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Helpers\ImageFactory;
 
@@ -11,7 +12,7 @@ class ImageFactoryTest extends TestCase
     /** @test */
     public function loading_an_image_uses_the_correct_driver()
     {
-        config(['medialibrary.image_driver' => 'imagick']);
+        MediaLibrary::setConfig('image_driver', 'imagick');
 
         $image = ImageFactory::load($this->getTestJpg());
 


### PR DESCRIPTION
## Changes

**Added** a `Spatie\MediaLibrary\MediaLibrary` helper class to be able to specify a custom config file. This can be useful if you use MediaLibrary in your own package, with its own media configuration.

**Updated** all `config('medialibrary....')` signatures with `MediaLibrary::config('...')`.

**Added** `it_can_use_a_custom_config_file` test in `ServiceProviderTest`.

## Usage

E.g.: In a custom package route group middleware:

`MediaLibrary::setConfigFile('path.to.custom_media_config');`

Then the MediaLibrary package will use your custom config file.

And the end project will still be able to use the default `/config/medialibrary.php` for its own use.

---

Let me know what you think! Would be awesome if this could get merged.

Ps: There were 4 errors and 1 failure when I ran phpunit, but those were already present and are not related to my changes.