### PR TITLE
Zipstream Dependency - optionally allow later version of zipstream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "illuminate/pipeline": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
     "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
     "league/flysystem": "^1.0.8",
-    "maennchen/zipstream-php": "~0.4",
+    "maennchen/zipstream-php": "^0.4|^1.0",
     "spatie/image": "^1.4.0",
     "spatie/pdf-to-image": "^1.2",
     "spatie/temporary-directory": "^1.1"


### PR DESCRIPTION
This PR just allows the library to be more flexible with its zipstream dependency.

Current constraint is fixed to pre-release version which is now over a year out of date.

Since this library uses just the basic features of the ZipStream class, the usage is compatible with both 0.x versions and 1.x versions, adding either as a dependency allows users to specify either in their local `composer.json` file.

All tests pass with either version installed, currently tested 0.5.2 and 1.1 which are the latest versions on both constraints.