### PR TITLE
Fix absolute references to media.id

### DIFF
--- a/src/Commands/CleanCommand.php
+++ b/src/Commands/CleanCommand.php
@@ -171,8 +171,11 @@ class CleanCommand extends Command
         if (is_null(config("filesystems.disks.{$diskName}"))) {
             throw FileCannotBeAdded::diskDoesNotExist($diskName);
         }
+        $mediaClass = config('medialibrary.media_model');
+        $mediaInstance = new $mediaClass();
+        $keyName = $mediaInstance->getKeyName();
 
-        $mediaIds = collect($this->mediaRepository->all()->pluck('id')->toArray());
+        $mediaIds = collect($this->mediaRepository->all()->pluck($keyName)->toArray());
 
         collect($this->fileSystem->disk($diskName)->directories())
             ->filter(function (string $directory) {

--- a/src/Commands/RegenerateCommand.php
+++ b/src/Commands/RegenerateCommand.php
@@ -58,7 +58,7 @@ class RegenerateCommand extends Command
                     $this->option('only-missing')
                 );
             } catch (Exception $exception) {
-                $this->errorMessages[$media->id] = $exception->getMessage();
+                $this->errorMessages[$media->getKey()] = $exception->getMessage();
             }
 
             $progressBar->advance();

--- a/src/Exceptions/MediaCannotBeDeleted.php
+++ b/src/Exceptions/MediaCannotBeDeleted.php
@@ -12,6 +12,6 @@ class MediaCannotBeDeleted extends Exception
     {
         $modelClass = get_class($model);
 
-        return new static("Media with id `{$mediaId}` cannot be deleted because it does not exist or does not belong to model {$modelClass} with id {$model->id}");
+        return new static("Media with id `{$mediaId}` cannot be deleted because it does not exist or does not belong to model {$modelClass} with id {$model->getKey()}");
     }
 }

--- a/src/MediaRepository.php
+++ b/src/MediaRepository.php
@@ -63,7 +63,7 @@ class MediaRepository
 
     public function getByIds(array $ids): DbCollection
     {
-        return $this->model->whereIn('id', $ids)->get();
+        return $this->model->whereIn($this->model->getKeyName(), $ids)->get();
     }
 
     public function getByModelTypeAndCollectionName(string $modelType, string $collectionName): DbCollection


### PR DESCRIPTION
Numerous parts of the library break when the media model's primary key is not named id. I did not address the tests.