### PR TITLE
Added dependency on the PHP fileinfo extension.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "maennchen/zipstream-php": "~0.4",
     "spatie/image": "^1.4.0",
     "spatie/pdf-to-image": "^1.2",
-    "spatie/temporary-directory": "^1.1"
+    "spatie/temporary-directory": "^1.1",
+    "ext-fileinfo": "*"
   },
   "require-dev": {
     "ext-pdo_sqlite": "*",


### PR DESCRIPTION
Added dependency on the PHP fileinfo extension. This is an extension which is enabled by default, but one of our customers had it disabled.
The dependency is used in (at least) src/Helpers/File.php