### PR TITLE
Change increments to bigIncrements in migrations

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -12,7 +12,7 @@ class CreateMediaTable extends Migration
     public function up()
     {
         Schema::create('media', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->morphs('model');
             $table->string('collection_name');
             $table->string('name');


### PR DESCRIPTION
In Laravel 5.8, id are bigIncrements by default in migrations so might be good to follow the conventions.