### PR TITLE
fix wrong documentation for new fallback methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `laravel-medialibrary` will be documented in this file
 
 ## 7.7.0 - 2019-07-27
 
-- add `useFallbackMediaUrl` and `useFallbackMediaPath` to media collections
+- add `useFallbackUrl` and `useFallbackPath` to media collections
 
 ## 7.6.9 - 2019-07-22
 
@@ -100,7 +100,7 @@ All notable changes to `laravel-medialibrary` will be documented in this file
 - fix for multiple files with the same filename in one ZIP archive
 - fix `markAsConversionGenerated`: disable model events when saving extra properties in Media::updated event
 
-## 7.3.9 - 2018-06-16 
+## 7.3.9 - 2018-06-16
 
 **do not use - broken**
 

--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -25,7 +25,7 @@ public function registerMediaCollections()
 
 ## Defining a fallback url or path
 
-If your media collection does not contain any items, calling `getFirstMediaUrl` or `getFirstMediaPath` will return `null`. You can change this by setting a fallback url and/or path using `useFallbackMediaUrl` and `useFallbackMediaPath`.
+If your media collection does not contain any items, calling `getFirstMediaUrl` or `getFirstMediaPath` will return `null`. You can change this by setting a fallback url and/or path using `useFallbackUrl` and `useFallbackPath`.
 
 ```php
 use Spatie\MediaLibrary\File;
@@ -34,8 +34,8 @@ public function registerMediaCollections()
 {
     $this
         ->addMediaCollection('avatars')
-        ->useFallbackMediaUrl('/images/anonymous-user.jpg')
-        ->useFallbackMediaPath(public_path('/images/anonymous-user.jpg'));
+        ->useFallbackUrl('/images/anonymous-user.jpg')
+        ->useFallbackPath(public_path('/images/anonymous-user.jpg'));
 }
 ```
 


### PR DESCRIPTION
The methods names were wrongly documented, noticed it when I tried to use them and received an exception that the methods were undefined.