### PR TITLE
Custom manipulations get applied to all relevant conversions with the same name

### DIFF
--- a/src/Conversion/Conversion.php
+++ b/src/Conversion/Conversion.php
@@ -162,11 +162,11 @@ class Conversion
      * Returns the collection names on which this conversion must be performed.
      * Assumes 'default' when none is present.
      *
-     * @return Array
+     * @return array
      */
     public function getPerformOnCollections()
     {
-        if (!count($this->performOnCollections)) {
+        if (! count($this->performOnCollections)) {
             return ['default'];
         }
 

--- a/src/Conversion/Conversion.php
+++ b/src/Conversion/Conversion.php
@@ -158,6 +158,21 @@ class Conversion
         return $this;
     }
 
+    /**
+     * Returns the collection names on which this conversion must be performed.
+     * Assumes 'default' when none is present.
+     *
+     * @return Array
+     */
+    public function getPerformOnCollections()
+    {
+        if (!count($this->performOnCollections)) {
+            return ['default'];
+        }
+
+        return $this->performOnCollections;
+    }
+
     /*
      * Determine if this conversion should be performed on the given
      * collection.

--- a/src/Conversion/ConversionCollection.php
+++ b/src/Conversion/ConversionCollection.php
@@ -127,9 +127,13 @@ class ConversionCollection extends Collection
      */
     protected function addManipulationToConversion(Manipulations $manipulations, string $conversionName)
     {
-        optional($this->first(function (Conversion $conversion) use ($conversionName) {
-            return $conversion->getName() === $conversionName;
-        }))->addAsFirstManipulations($manipulations);
+        optional($this->filter(
+            function ($conversion) use ($conversionName) {
+                return
+                    in_array($this->media->collection_name, $conversion->getPerformOnCollections())
+                    && $conversion->getName() === $conversionName;
+            }
+        )->first())->addAsFirstManipulations($manipulations);
 
         if ($conversionName === '*') {
             $this->each->addAsFirstManipulations(clone $manipulations);

--- a/tests/Unit/Conversion/ConversionCollectionTest.php
+++ b/tests/Unit/Conversion/ConversionCollectionTest.php
@@ -16,12 +16,22 @@ class ConversionCollectionTest extends TestCase
 
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
             ->toMediaCollection();
 
         $media->manipulations = ['thumb' => ['filter' => 'greyscale', 'height' => 10]];
         $media->save();
 
+        $secondMedia = $this->testModelWithConversion
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection();
+
+        $secondMedia->manipulations = ['thumb' => ['filter' => 'greyscale', 'height' => 20]];
+        $secondMedia->save();
+
         $this->media = $media->fresh();
+        $this->secondMedia = $media->fresh();
     }
 
     /** @test */
@@ -80,5 +90,27 @@ class ConversionCollectionTest extends TestCase
             'width' => 50,
             'format' => 'jpg',
         ]], $manipulationSequence);
+    }
+
+    /** @test */
+    public function it_will_apply_the_manipulation_on_the_equally_named_conversion_of_every_model()
+    {
+        $mediaItems = [$this->media, $this->secondMedia];
+        $manipulations = [];
+
+        foreach ($mediaItems as $mediaItem) {
+            $conversionCollection = ConversionCollection::createForMedia($mediaItem);
+           
+            $conversion = $conversionCollection->getConversions()[0];
+
+            $manipulationSequence = $conversion
+                ->getManipulations()
+                ->getManipulationSequence()
+                ->toArray();
+
+            array_push($manipulations, $manipulationSequence);
+        }
+
+        $this->assertEquals($manipulations[0], $manipulations[1]);
     }
 }

--- a/tests/Unit/Conversion/ConversionCollectionTest.php
+++ b/tests/Unit/Conversion/ConversionCollectionTest.php
@@ -100,9 +100,9 @@ class ConversionCollectionTest extends TestCase
 
         foreach ($mediaItems as $mediaItem) {
             $conversionCollection = ConversionCollection::createForMedia($mediaItem);
-           
-            $conversion = $conversionCollection->getConversions()[0];
 
+            $conversion = $conversionCollection->getConversions()[0];
+            
             $manipulationSequence = $conversion
                 ->getManipulations()
                 ->getManipulationSequence()

--- a/tests/Unit/Conversion/ConversionCollectionTest.php
+++ b/tests/Unit/Conversion/ConversionCollectionTest.php
@@ -102,7 +102,7 @@ class ConversionCollectionTest extends TestCase
             $conversionCollection = ConversionCollection::createForMedia($mediaItem);
 
             $conversion = $conversionCollection->getConversions()[0];
-            
+
             $manipulationSequence = $conversion
                 ->getManipulations()
                 ->getManipulationSequence()


### PR DESCRIPTION
Fixed a bug where custom manipulations on a conversion get ignored after the first Media item, when manipulations are applied to multiple Media items with the same conversion name.

See issue #1506 