### PR TITLE
Add Macroable trait to Media Collection

### DIFF
--- a/src/MediaCollection/MediaCollection.php
+++ b/src/MediaCollection/MediaCollection.php
@@ -2,8 +2,12 @@
 
 namespace Spatie\MediaLibrary\MediaCollection;
 
+use Illuminate\Support\Traits\Macroable;
+
 class MediaCollection
 {
+    use Macroable;
+
     /** @var string */
     public $name = '';
 


### PR DESCRIPTION
This would be be really useful non breaking change that for me would mean I can tweak some of the logic like the disk selection with a simple macro rather than extending multiple files or having a lot of duplicated code for interacting with the Media Collection's disk use.