### PR TITLE
Make FileAdder macroable

### DIFF
--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary\FileAdder;
 use Spatie\MediaLibrary\Helpers\File;
 use Spatie\MediaLibrary\Models\Media;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Traits\Macroable;
 use Spatie\MediaLibrary\HasMedia\HasMedia;
 use Spatie\MediaLibrary\File as PendingFile;
 use Spatie\MediaLibrary\Filesystem\Filesystem;
@@ -21,6 +22,8 @@ use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\FileUnacceptableForCollecti
 
 class FileAdder
 {
+    use Macroable;
+
     /** @var \Illuminate\Database\Eloquent\Model subject */
     protected $subject;
 


### PR DESCRIPTION
With this approach, we can add some additional functionality to the FileAdder on the fly.
For example to always set filename using Uuid4, etc.

I always set filename using uuid4, so I've something like this everywhere:
```
$user->addMedia($file)
    ->usingFileName(Uuid::uuid4()->toString() . '.' . $file->guessExtension())
    ->toMediaCollection('files');
```

If the FileAdder is macroable, I can make my code little cleaner.