### PR TITLE
fix #1258

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -329,8 +329,9 @@ class Media extends Model implements Responsable, Htmlable
     public function copy(HasMedia $model, $collectionName = 'default'): self
     {
         $temporaryDirectory = TemporaryDirectory::create();
+        $temporaryDirectory->create();
 
-        $temporaryFile = $temporaryDirectory->path($this->file_name);
+        $temporaryFile = $temporaryDirectory->path() . DIRECTORY_SEPARATOR . $this->file_name;
 
         app(Filesystem::class)->copyFromMediaLibrary($this, $temporaryFile);
 


### PR DESCRIPTION
Hello,

Basicly instead of letting `TemporaryDirectory::path()` create the temporary directory I manually call `TemporaryDirectory::create()` and use `TemporaryDirectory::path()` without argument to build `$temporaryFile`. 

I didn't write any test because I don't think it's needed. 