### PR TITLE
Added option to set a limit for MediaCollections

### DIFF
--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -95,9 +95,9 @@ You can still specify the disk name manually when adding media. In this example 
 $yourModel->addMedia($pathToFile)->toMediaCollection('big-files', 'alternative-disk');
 ```
 
-## Single file collections
+## Limited collections & single file collections
 
-If you want a collection to hold only one file you can use `singleFile` on the collection. A good use case for this would be an avatar collection on a `User` model. In most cases you'd want to have a user to only have one `avatar`.
+If you want a collection to hold only `n` file(s) you can use `onlyKeepLatests(n)` on the collection. A good use case for this would be an avatar collection on a `User` model. In most cases you'd want to have a user to only have one `avatar`. Whenever you add a file and the collection exceeds the limit, Medialibrary will delete the oldest files first and keep the latest file(s).
 
 ```php
 // in your model
@@ -106,9 +106,11 @@ public function registerMediaCollections()
 {
     $this
         ->addMediaCollection('avatar')
-        ->singleFile();
+        ->onlyKeepLatests(1);
 }
 ```
+
+You can also use the shorthand to `singleFile()` which is an alternative to `onlyKeepLatest(1)`.
 
 The first time you add a file to the collection it will be stored as usual.
 

--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -95,9 +95,9 @@ You can still specify the disk name manually when adding media. In this example 
 $yourModel->addMedia($pathToFile)->toMediaCollection('big-files', 'alternative-disk');
 ```
 
-## Limited collections & single file collections
+## Single file collections
 
-If you want a collection to hold only `n` file(s) you can use `onlyKeepLatests(n)` on the collection. A good use case for this would be an avatar collection on a `User` model. In most cases you'd want to have a user to only have one `avatar`. Whenever you add a file and the collection exceeds the limit, Medialibrary will delete the oldest files first and keep the latest file(s).
+If you want a collection to hold only one file you can use `singleFile` on the collection. A good use case for this would be an avatar collection on a `User` model. In most cases you'd want to have a user to only have one `avatar`.
 
 ```php
 // in your model
@@ -106,11 +106,9 @@ public function registerMediaCollections()
 {
     $this
         ->addMediaCollection('avatar')
-        ->onlyKeepLatests(1);
+        ->singleFile();
 }
 ```
-
-You can also use `singleFile()` which is an alternative to `onlyKeepLatest(1)`.
 
 The first time you add a file to the collection it will be stored as usual.
 
@@ -127,6 +125,35 @@ When adding another file to a single file collection the first one will be delet
 $yourModel->addMedia($anotherPathToImage)->toMediaCollection('avatar');
 $yourModel->getMedia('avatar')->count(); // returns 1
 $yourModel->getFirstMediaUrl('avatar'); // will return an url to the `$anotherPathToImage` file
+```
+
+## Limited file collections
+
+Whenever you want to limit the amount of files inside a collection you can use the `onlyKeepLatests(n)` method. Whenever you add a file to a collection and exceed the given limit, Medialibrary will delete the oldest file(s) and keep the collection size at `n`.
+
+```php
+// in your model
+
+public function registerMediaCollections()
+{
+    $this
+        ->addMediaCollection('limited-collection')
+        ->onlyKeepLatests(3);
+}
+```
+
+For the first 3 files, nothing strange happens. The files get added to the collection and the collection now holds all 3 files. Whenever you decide to add a 4th file, Medialibrary deletes the first file and keeps the latest 3.
+
+```php
+$yourModel->addMedia($firstFile)->toMediaCollection('limited-collection');
+$yourModel->getMedia('avatar')->count(); // returns 1
+$yourModel->addMedia($secondFile)->toMediaCollection('limited-collection');
+$yourModel->getMedia('avatar')->count(); // returns 2
+$yourModel->addMedia($thirdFile)->toMediaCollection('limited-collection');
+$yourModel->getMedia('avatar')->count(); // returns 3
+$yourModel->addMedia($fourthFile)->toMediaCollection('limited-collection');
+$yourModel->getMedia('avatar')->count(); // returns 3
+$yourModel->getFirstMediaUrl('avatar'); // will return an url to the `$secondFile` file
 ```
 
 ## Registering media conversions

--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -110,7 +110,7 @@ public function registerMediaCollections()
 }
 ```
 
-You can also use the shorthand to `singleFile()` which is an alternative to `onlyKeepLatest(1)`.
+You can also use `singleFile()` which is an alternative to `onlyKeepLatest(1)`.
 
 The first time you add a file to the collection it will be stored as usual.
 

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -328,7 +328,7 @@ class FileAdder
         if ($collectionSizeLimit = optional($this->getMediaCollection($media->collection_name))->collectionSizeLimit) {
             $collectionMedia = $this->subject->fresh()->getMedia($media->collection_name);
 
-            if($collectionMedia->count() > $collectionSizeLimit) {
+            if ($collectionMedia->count() > $collectionSizeLimit) {
                 $model->clearMediaCollectionExcept($media->collection_name, $collectionMedia->reverse()->take($collectionSizeLimit));
             }
         }

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -325,8 +325,12 @@ class FileAdder
             dispatch($job);
         }
 
-        if (optional($this->getMediaCollection($media->collection_name))->singleFile) {
-            $model->clearMediaCollectionExcept($media->collection_name, $media);
+        if ($collectionSizeLimit = optional($this->getMediaCollection($media->collection_name))->collectionSizeLimit) {
+            $collectionMedia = $this->subject->fresh()->getMedia($media->collection_name);
+
+            if($collectionMedia->count() > $collectionSizeLimit) {
+                $model->clearMediaCollectionExcept($media->collection_name, $collectionMedia->reverse()->take($collectionSizeLimit));
+            }
         }
     }
 

--- a/src/MediaCollection/MediaCollection.php
+++ b/src/MediaCollection/MediaCollection.php
@@ -20,7 +20,7 @@ class MediaCollection
     /** @var callable */
     public $acceptsFile;
 
-    /** @var integer */
+    /** @var int */
     public $collectionSizeLimit = false;
 
     /** @var string */

--- a/src/MediaCollection/MediaCollection.php
+++ b/src/MediaCollection/MediaCollection.php
@@ -21,7 +21,7 @@ class MediaCollection
     public $acceptsFile;
 
     /** @var bool */
-    public $singleFile = false;
+    public $collectionSizeLimit = false;
 
     /** @var string */
     public $fallbackUrl = '';
@@ -62,7 +62,12 @@ class MediaCollection
 
     public function singleFile(): self
     {
-        $this->singleFile = true;
+        return $this->onlyKeepLatest(1);
+    }
+
+    public function onlyKeepLatest(int $int): self
+    {
+        $this->collectionSizeLimit = $int;
 
         return $this;
     }

--- a/src/MediaCollection/MediaCollection.php
+++ b/src/MediaCollection/MediaCollection.php
@@ -20,7 +20,7 @@ class MediaCollection
     /** @var callable */
     public $acceptsFile;
 
-    /** @var bool */
+    /** @var integer */
     public $collectionSizeLimit = false;
 
     /** @var string */

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -172,7 +172,30 @@ class MediaCollectionTest extends TestCase
 
         $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
         $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
         $this->assertCount(1, $model->getMedia('images'));
+    }
+
+    /** @test */
+    public function if_the_only_keeps_latest_method_is_specified_it_will_delete_all_other_media_and_will_only_keep_the_latest_n_ones()
+    {
+        $testModel = new class extends TestModelWithConversion {
+            public function registerMediaCollections()
+            {
+                $this
+                    ->addMediaCollection('images')
+                    ->onlyKeepLatest(3);
+            }
+        };
+
+        $model = $testModel::create(['name' => 'testmodel']);
+
+        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+        $this->assertCount(3, $model->getMedia('images'));
     }
 }

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -191,11 +191,14 @@ class MediaCollectionTest extends TestCase
 
         $model = $testModel::create(['name' => 'testmodel']);
 
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $firstFile = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
         $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
         $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
         $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
+        $this->assertFalse($model->getMedia('images')->contains(function($model) use($firstFile) {
+            return $model->is($firstFile);
+        }));
         $this->assertCount(3, $model->getMedia('images'));
     }
 }

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -196,7 +196,7 @@ class MediaCollectionTest extends TestCase
         $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
         $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
-        $this->assertFalse($model->getMedia('images')->contains(function($model) use($firstFile) {
+        $this->assertFalse($model->getMedia('images')->contains(function ($model) use ($firstFile) {
             return $model->is($firstFile);
         }));
         $this->assertCount(3, $model->getMedia('images'));


### PR DESCRIPTION
As requested here: https://github.com/spatie/laravel-medialibrary/issues/1524

This pull-request adds the `onlyKeepLatest(n)` method for MediaCollections, where the existing `singleFile()` method uses the new method under the hood. Whenever adding a new file to the collection exceeds the set limit, Medialibrary will delete the oldest file(s) and only keep the latest `n`.

The tests involved passed, I did however got 2 failures that involved Ghostscript and some of the tests skipped. As far as I can tell none of these tests involve the parts I've been working on.

And as request, the docs have been editted as well. 