### PR TITLE
Added option to delete media when parent model is SoftDeleted

### DIFF
--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -24,6 +24,9 @@ use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\MimeTypeNotAllowed;
 
 trait HasMediaTrait
 {
+    /** @var $forceDeleteMediaWhenModelIsSoftDeleted */
+    protected $forceDeleteMediaWhenModelIsSoftDeleted = false;
+
     /** @var Conversion[] */
     public $mediaConversions = [];
 
@@ -44,7 +47,7 @@ trait HasMediaTrait
             }
 
             if (in_array(SoftDeletes::class, class_uses_recursive($entity))) {
-                if (! $entity->forceDeleting) {
+                if (! $entity->forceDeleting && ! $entity->forceDeleteMediaWhenModelIsSoftDeleted) {
                     return;
                 }
             }

--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -34,7 +34,7 @@ trait HasMediaTrait
     protected $deletePreservingMedia = false;
 
     /** @var bool */
-    protected $forceDeleteMediaWhenModelIsSoftDeleted = false;
+    protected $shouldDeleteMediaWhenSoftDeleting = false;
 
     /** @var array */
     protected $unAttachedMediaLibraryItems = [];
@@ -47,7 +47,7 @@ trait HasMediaTrait
             }
 
             if (in_array(SoftDeletes::class, class_uses_recursive($entity))) {
-                if (! $entity->forceDeleting && ! $entity->forceDeleteMediaWhenModelIsSoftDeleted) {
+                if (! $entity->forceDeleting && ! $entity->shouldDeleteMediaWhenSoftDeleting) {
                     return;
                 }
             }

--- a/src/HasMedia/HasMediaTrait.php
+++ b/src/HasMedia/HasMediaTrait.php
@@ -24,9 +24,6 @@ use Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\MimeTypeNotAllowed;
 
 trait HasMediaTrait
 {
-    /** @var $forceDeleteMediaWhenModelIsSoftDeleted */
-    protected $forceDeleteMediaWhenModelIsSoftDeleted = false;
-
     /** @var Conversion[] */
     public $mediaConversions = [];
 
@@ -35,6 +32,9 @@ trait HasMediaTrait
 
     /** @var bool */
     protected $deletePreservingMedia = false;
+
+    /** @var bool */
+    protected $forceDeleteMediaWhenModelIsSoftDeleted = false;
 
     /** @var array */
     protected $unAttachedMediaLibraryItems = [];

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -139,4 +139,27 @@ class DeleteTest extends TestCase
 
         $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
     }
+
+    /** @test */
+    public function it_will_remove_the_file_when_model_uses_softdelete_but_has_media_trait_setting_is_set_to_force_delete_mode()
+    {
+        $testModelClass = new class() extends TestModel {
+            use SoftDeletes;
+
+            protected $forceDeleteMediaWhenModelIsSoftDeleted = true;
+        };
+
+        /** @var TestModel $testModel */
+        $testModel = $testModelClass::find($this->testModel->id);
+
+        $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+
+        $testModel = $testModel->fresh();
+
+        $testModel->delete();
+
+        $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
+    }
 }

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -146,7 +146,7 @@ class DeleteTest extends TestCase
         $testModelClass = new class() extends TestModel {
             use SoftDeletes;
 
-            protected $forceDeleteMediaWhenModelIsSoftDeleted = true;
+            protected $shouldDeleteMediaWhenSoftDeleting = true;
         };
 
         /** @var TestModel $testModel */


### PR DESCRIPTION
Fixes: https://github.com/spatie/laravel-medialibrary/issues/1474

I've added a new property to the `HasMediaTrait` named `$shouldDeleteMediaWhenSoftDeleting`, this property defaults to `false` in which case the Medialibrary works as it does right now.

As soon as `$shouldDeleteMediaWhenSoftDeleting` is set to true and the parent model is set to be softDeleteable, Medialibrary will delete all media belonging to the model anyway.

A use case for this scenario would be a system which holds user data (name, address, avatar, etc.) and you only want to keep the data but not the avatar and other collected media files. By setting `$shouldDeleteMediaWhenSoftDeleting` to true on the `User` model, the files would be deleted at soon as you softDelete the user.