### PR TITLE
Add url versioning based on media updated_at

### DIFF
--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -77,6 +77,12 @@ return [
     'url_generator' => null,
 
     /*
+     * Whether to activate versioning when urls to files get generated.
+     * When activated, this attaches a ?v=xx query string to the URL.
+     */
+    'versioning' => false,
+
+    /*
      * The class that contains the strategy for determining a media file's path.
      */
     'path_generator' => null,

--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -80,7 +80,7 @@ return [
      * Whether to activate versioning when urls to files get generated.
      * When activated, this attaches a ?v=xx query string to the URL.
      */
-    'versioning' => false,
+    'version_urls' => false,
 
     /*
      * The class that contains the strategy for determining a media file's path.

--- a/docs/basic-usage/retrieving-media.md
+++ b/docs/basic-usage/retrieving-media.md
@@ -20,6 +20,8 @@ $fullPathOnDisk = $mediaItems[0]->getPath();
 $temporaryS3Url = $mediaItems[0]->getTemporaryUrl(Carbon::now()->addMinutes(5));
 ```
 
+If you want to retrieve versioned media urls you can enable versioning by setting the `versioning` config to `true` in your `medialibrary.php` config file.
+
 Since retrieving the first media and the url for the first media for an object is such a common scenario, the `getFirstMedia` and `getFirstMediaUrl` convenience-methods are also provided:
 
 ```php

--- a/docs/basic-usage/retrieving-media.md
+++ b/docs/basic-usage/retrieving-media.md
@@ -20,7 +20,7 @@ $fullPathOnDisk = $mediaItems[0]->getPath();
 $temporaryS3Url = $mediaItems[0]->getTemporaryUrl(Carbon::now()->addMinutes(5));
 ```
 
-If you want to retrieve versioned media urls you can enable versioning by setting the `versioning` config to `true` in your `medialibrary.php` config file.
+If you want to retrieve versioned media urls, for example when needing cache busting, you can enable versioning by setting the `version_urls` config value to `true` in your `medialibrary.php` config file. The `getUrl()` and `getFullUrl()` functions will return the url with a version string based on the `updated_at` column of the media model.
 
 Since retrieving the first media and the url for the first media for an object is such a common scenario, the `getFirstMedia` and `getFirstMediaUrl` convenience-methods are also provided:
 

--- a/src/UrlGenerator/BaseUrlGenerator.php
+++ b/src/UrlGenerator/BaseUrlGenerator.php
@@ -86,7 +86,7 @@ abstract class BaseUrlGenerator implements UrlGenerator
 
     public function versionUrl(string $path = ''): string
     {
-        if (!$this->config->get('medialibrary.versioning', false)) {
+        if (! $this->config->get('medialibrary.versioning', false)) {
             return $path;
         }
 

--- a/src/UrlGenerator/BaseUrlGenerator.php
+++ b/src/UrlGenerator/BaseUrlGenerator.php
@@ -86,7 +86,7 @@ abstract class BaseUrlGenerator implements UrlGenerator
 
     public function versionUrl(string $path = ''): string
     {
-        if (! $this->config->get('medialibrary.versioning', false)) {
+        if (! $this->config->get('medialibrary.version_urls')) {
             return $path;
         }
 

--- a/src/UrlGenerator/BaseUrlGenerator.php
+++ b/src/UrlGenerator/BaseUrlGenerator.php
@@ -83,4 +83,13 @@ abstract class BaseUrlGenerator implements UrlGenerator
     {
         return pathinfo($path, PATHINFO_DIRNAME).'/'.rawurlencode(pathinfo($path, PATHINFO_BASENAME));
     }
+
+    public function versionUrl(string $path = ''): string
+    {
+        if (!$this->config->get('medialibrary.versioning', false)) {
+            return $path;
+        }
+
+        return "{$path}?v={$this->media->updated_at->timestamp}";
+    }
 }

--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -23,6 +23,8 @@ class LocalUrlGenerator extends BaseUrlGenerator
 
         $url = $this->rawUrlEncodeFilename($url);
 
+        $url = $this->versionUrl($url);
+
         return $url;
     }
 

--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -33,6 +33,8 @@ class S3UrlGenerator extends BaseUrlGenerator
 
         $url = $this->rawUrlEncodeFilename($url);
 
+        $url = $this->versionUrl($url);
+
         return config('medialibrary.s3.domain').'/'.$url;
     }
 

--- a/tests/Unit/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/Unit/UrlGenerator/BaseUrlGeneratorTest.php
@@ -82,13 +82,13 @@ class BaseUrlGeneratorTest extends TestCase
     /** @test * */
     public function it_appends_a_version_string_when_versioning_is_enabled()
     {
-        config()->set('medialibrary.versioning', true);
+        config()->set('medialibrary.version_urls', true);
 
         $url = '/media/'.$this->media->id.'/conversions/test-'.$this->conversion->getName().'.jpg?v='.$this->media->updated_at->timestamp;
 
         $this->assertEquals($url, $this->urlGenerator->getUrl());
 
-        config()->set('medialibrary.versioning', false);
+        config()->set('medialibrary.version_urls', false);
 
         $url = '/media/'.$this->media->id.'/conversions/test-'.$this->conversion->getName().'.jpg';
 

--- a/tests/Unit/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/Unit/UrlGenerator/BaseUrlGeneratorTest.php
@@ -78,4 +78,20 @@ class BaseUrlGeneratorTest extends TestCase
 
         $this->assertEquals($pathRelativeToRoot, $this->urlGenerator->getPathRelativeToRoot());
     }
+
+    /** @test * */
+    public function it_appends_a_version_string_when_versioning_is_enabled()
+    {
+        config()->set('medialibrary.versioning', true);
+
+        $url = '/media/'.$this->media->id.'/conversions/test-'.$this->conversion->getName().'.jpg?v='.$this->media->updated_at->timestamp;
+
+        $this->assertEquals($url, $this->urlGenerator->getUrl());
+
+        config()->set('medialibrary.versioning', false);
+
+        $url = '/media/'.$this->media->id.'/conversions/test-'.$this->conversion->getName().'.jpg';
+
+        $this->assertEquals($url, $this->urlGenerator->getUrl());
+    }
 }


### PR DESCRIPTION
- This adds a config key `medialibrary.versioning`
- When set to `true`, adds the `updated_at` timestamp of the media model to the image url