### PR TITLE
Add a way to define accepted mime types

### DIFF
--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -68,6 +68,33 @@ This will throw a `Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\FileUnaccept
 $yourModel->addMedia('ugly.ppt')->toMediaCollection('only-jpegs-please');
 ```
 
+## Only allow certain mimetypes in a collection
+
+You can defined an array of accepted Mime types using `acceptsMimeTypes` that will check if a file with a certain Mime type is allowed into the collection. In this example we only accept `image/jpeg` files.
+
+```php
+use Spatie\MediaLibrary\File;
+...
+public function registerMediaCollections()
+{
+    $this
+        ->addMediaCollection('only-jpegs-please')
+        ->acceptsMimeTypes(['image/jpeg']);
+}
+```
+
+This will succeed:
+
+```php
+$yourModel->addMedia('beautiful.jpg')->toMediaCollection('only-jpegs-please');
+```
+
+This will throw a `Spatie\MediaLibrary\Exceptions\FileCannotBeAdded\FileUnacceptableForCollection` exception:
+
+```php
+$yourModel->addMedia('ugly.ppt')->toMediaCollection('only-jpegs-please');
+```
+
 ## Using a specific disk
 
 You can ensure that files added to a collection are automatically added to a certain disk.

--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -355,5 +355,9 @@ class FileAdder
         if (! ($collection->acceptsFile)($file, $this->subject)) {
             throw FileUnacceptableForCollection::create($file, $collection, $this->subject);
         }
+
+        if (! empty($collection->acceptsMimeTypes) && ! in_array($file->mimeType, $collection->acceptsMimeTypes)) {
+            throw FileUnacceptableForCollection::create($file, $collection, $this->subject);
+        }
     }
 }

--- a/src/MediaCollection/MediaCollection.php
+++ b/src/MediaCollection/MediaCollection.php
@@ -21,6 +21,9 @@ class MediaCollection
     /** @var callable */
     public $acceptsFile;
 
+    /** @var array $acceptsMimeTypes */
+    public $acceptsMimeTypes = [];
+
     /** @var int */
     public $collectionSizeLimit = false;
 
@@ -59,6 +62,13 @@ class MediaCollection
     public function acceptsFile(callable $acceptsFile): self
     {
         $this->acceptsFile = $acceptsFile;
+
+        return $this;
+    }
+
+    public function acceptsMimeTypes(array $mimeTypes): self
+    {
+        $this->acceptsMimeTypes = $mimeTypes;
 
         return $this;
     }

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -156,6 +156,27 @@ class MediaCollectionTest extends TestCase
         $model->addMedia($this->getTestPdf())->preservingOriginal()->toMediaCollection('images');
     }
 
+    /** @test * */
+    public function it_can_guard_against_invalid_mimetypes()
+    {
+        $testModel = new class extends TestModelWithConversion {
+            public function registerMediaCollections()
+            {
+                $this
+                    ->addMediaCollection('images')
+                    ->acceptsMimeTypes(['image/jpeg']);
+            }
+        };
+
+        $model = $testModel::create(['name' => 'testmodel']);
+
+        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+        $this->expectException(FileUnacceptableForCollection::class);
+
+        $model->addMedia($this->getTestPdf())->preservingOriginal()->toMediaCollection('images');
+    }
+
     /** @test */
     public function if_the_single_file_method_is_specified_it_will_delete_all_other_media_and_will_only_keep_the_new_one()
     {


### PR DESCRIPTION
- Adds a `acceptsMimeTypes()` function to the media collection
- Checks based on the files mimetype if it's allowed in the collection