### PR TITLE
Fixes #1258 when the file doesn't have extension

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -330,7 +330,7 @@ class Media extends Model implements Responsable, Htmlable
     {
         $temporaryDirectory = TemporaryDirectory::create();
 
-        $temporaryFile = $temporaryDirectory->path($this->file_name);
+        $temporaryFile = $temporaryDirectory->path('/') . DIRECTORY_SEPARATOR . $this->file_name;
 
         app(Filesystem::class)->copyFromMediaLibrary($this, $temporaryFile);
 

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -330,7 +330,7 @@ class Media extends Model implements Responsable, Htmlable
     {
         $temporaryDirectory = TemporaryDirectory::create();
 
-        $temporaryFile = $temporaryDirectory->path('/') . DIRECTORY_SEPARATOR . $this->file_name;
+        $temporaryFile = $temporaryDirectory->path('/').DIRECTORY_SEPARATOR.$this->file_name;
 
         app(Filesystem::class)->copyFromMediaLibrary($this, $temporaryFile);
 

--- a/tests/Feature/Media/CopyTest.php
+++ b/tests/Feature/Media/CopyTest.php
@@ -37,4 +37,41 @@ class CopyTest extends TestCase
         $this->assertEquals($movedMedia->name, 'custom-name');
         $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
     }
+
+    /** @test */
+    public function it_can_copy_file_without_extension()
+    {
+        if(!file_exists(storage_path('medialibrary/temp'))){
+            mkdir(storage_path('medialibrary/temp'), 0777, true);
+        }
+
+        config(['medialibrary.temporary_directory_path' => realpath(storage_path('medialibrary/temp'))]);
+
+        /** @var TestModel $model */
+        $model = TestModel::create(['name' => 'test']);
+
+        /** @var \Spatie\MediaLibrary\Models\Media $media */
+        $media = $model
+            ->addMedia($this->getTestImageWithoutExtension())
+            ->usingName('custom-name')
+            ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
+            ->toMediaCollection();
+
+        $this->assertFileExists($this->getMediaDirectory($media->id.'/image'));
+
+        $anotherModel = TestModel::create(['name' => 'another-test']);
+
+        $movedMedia = $media->copy($anotherModel, 'images');
+
+        $movedMedia->refresh();
+
+        $this->assertCount(1, $model->getMedia('default'));
+        $this->assertFileExists($this->getMediaDirectory($media->id.'/image'));
+
+        $this->assertCount(1, $anotherModel->getMedia('images'));
+        $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/image'));
+        $this->assertEquals($movedMedia->model->id, $anotherModel->id);
+        $this->assertEquals($movedMedia->name, 'custom-name');
+        $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+    }
 }

--- a/tests/Feature/Media/CopyTest.php
+++ b/tests/Feature/Media/CopyTest.php
@@ -41,7 +41,7 @@ class CopyTest extends TestCase
     /** @test */
     public function it_can_copy_file_without_extension()
     {
-        if(!file_exists(storage_path('medialibrary/temp'))){
+        if (! file_exists(storage_path('medialibrary/temp'))) {
             mkdir(storage_path('medialibrary/temp'), 0777, true);
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -203,6 +203,11 @@ abstract class TestCase extends Orchestra
         return $this->getTestFilesDirectory('test.mp4');
     }
 
+    public function getTestImageWithoutExtension()
+    {
+        return $this->getTestFilesDirectory('image');
+    }
+
     private function setUpMorphMap()
     {
         Relation::morphMap([


### PR DESCRIPTION
The temporary directory cannot identify if it is a file path, when the file doesn't have extension, and it creates a directory with the file's name.

It was tricky to reproduce the issue with tests: 
If the temporary directory path contained `../`, the bug didn't appear, because the isFilePath returned true even for files without extension. I've added the absolute path of the temporary directory to the config `medialibrary.temporary_directory_path`, this way I was able to reproduce the issue.