### PR TITLE
MediaStream without rewind

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "illuminate/pipeline": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
     "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
     "league/flysystem": "^1.0.8",
-    "maennchen/zipstream-php": "^0.4|^1.0",
+    "maennchen/zipstream-php": "^1.0",
     "spatie/image": "^1.4.0",
     "spatie/pdf-to-image": "^1.2",
     "spatie/temporary-directory": "^1.1",

--- a/src/MediaStream.php
+++ b/src/MediaStream.php
@@ -6,7 +6,6 @@ use ZipStream\ZipStream;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Models\Media;
 use Illuminate\Contracts\Support\Responsable;
-use ZipStream\Option\Archive as ArchiveOptions;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class MediaStream implements Responsable
@@ -73,10 +72,16 @@ class MediaStream implements Responsable
 
     public function getZipStream(): ZipStream
     {
-        $options = new ArchiveOptions();
-        // Stream files without rewind.
-        $options->setZeroHeader(true);
-        $zip = new ZipStream($this->zipName, $options);
+        // For ZipStream-PHP versions above 1.0
+        // improve performance using options
+        if (class_exists('\ZipStream\Option\Archive')) {
+            $options = new \ZipStream\Option\Archive();
+            // Stream files without rewind.
+            $options->setZeroHeader(true);
+            $zip = new ZipStream($this->zipName, $options);
+        } else {
+            $zip = new ZipStream($this->zipName);
+        }
 
         $this->getZipStreamContents()->each(function (array $mediaInZip) use ($zip) {
             $stream = $mediaInZip['media']->stream();

--- a/src/MediaStream.php
+++ b/src/MediaStream.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\MediaLibrary;
 
+
+use ZipStream\Option\Archive;
 use ZipStream\ZipStream;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Models\Media;
@@ -72,16 +74,7 @@ class MediaStream implements Responsable
 
     public function getZipStream(): ZipStream
     {
-        // For ZipStream-PHP versions above 1.0
-        // improve performance using options
-        if (class_exists('\ZipStream\Option\Archive')) {
-            $options = new \ZipStream\Option\Archive();
-            // Stream files without rewind.
-            $options->setZeroHeader(true);
-            $zip = new ZipStream($this->zipName, $options);
-        } else {
-            $zip = new ZipStream($this->zipName);
-        }
+        $zip = new ZipStream($this->zipName, tap(new Archive())->setZeroHeader(true));
 
         $this->getZipStreamContents()->each(function (array $mediaInZip) use ($zip) {
             $stream = $mediaInZip['media']->stream();

--- a/src/MediaStream.php
+++ b/src/MediaStream.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary;
 
+use ZipStream\Option\Archive as ArchiveOptions;
 use ZipStream\ZipStream;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Models\Media;
@@ -72,7 +73,10 @@ class MediaStream implements Responsable
 
     public function getZipStream(): ZipStream
     {
-        $zip = new ZipStream($this->zipName);
+        $options = new ArchiveOptions();
+        // Stream files without rewind.
+        $options->setZeroHeader(true);
+        $zip = new ZipStream($this->zipName, $options);
 
         $this->getZipStreamContents()->each(function (array $mediaInZip) use ($zip) {
             $stream = $mediaInZip['media']->stream();

--- a/src/MediaStream.php
+++ b/src/MediaStream.php
@@ -2,12 +2,12 @@
 
 namespace Spatie\MediaLibrary;
 
-use ZipStream\Option\Archive as ArchiveOptions;
-use ZipStream\ZipStream;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Models\Media;
-use Illuminate\Contracts\Support\Responsable;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use ZipStream\Option\Archive as ArchiveOptions;
+use ZipStream\ZipStream;
 
 class MediaStream implements Responsable
 {

--- a/src/MediaStream.php
+++ b/src/MediaStream.php
@@ -2,9 +2,8 @@
 
 namespace Spatie\MediaLibrary;
 
-
-use ZipStream\Option\Archive;
 use ZipStream\ZipStream;
+use ZipStream\Option\Archive;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Models\Media;
 use Illuminate\Contracts\Support\Responsable;

--- a/src/MediaStream.php
+++ b/src/MediaStream.php
@@ -2,12 +2,12 @@
 
 namespace Spatie\MediaLibrary;
 
-use Illuminate\Contracts\Support\Responsable;
+use ZipStream\ZipStream;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Models\Media;
-use Symfony\Component\HttpFoundation\StreamedResponse;
+use Illuminate\Contracts\Support\Responsable;
 use ZipStream\Option\Archive as ArchiveOptions;
-use ZipStream\ZipStream;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class MediaStream implements Responsable
 {

--- a/tests/Feature/MediaStreamTest.php
+++ b/tests/Feature/MediaStreamTest.php
@@ -76,25 +76,4 @@ class MediaStreamTest extends TestCase
 
         $this->assertEquals(2, $zipStreamResponse->getMediaItems()->count());
     }
-
-    protected function assertFileExistsInZip($zipPath, $filename)
-    {
-        $this->assertTrue($this->fileExistsInZip($zipPath, $filename), "Failed to assert that {$zipPath} contains a file name {$filename}");
-    }
-
-    protected function assertFileDoesntExistsInZip($zipPath, $filename)
-    {
-        $this->assertFalse($this->fileExistsInZip($zipPath, $filename), "Failed to assert that {$zipPath} doesn't contain a file name {$filename}");
-    }
-
-    protected function fileExistsInZip($zipPath, $filename): bool
-    {
-        $zip = new ZipArchive();
-
-        if ($zip->open($zipPath) === true) {
-            return $zip->locateName($filename, ZipArchive::FL_NODIR) !== false;
-        }
-
-        return false;
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,7 @@ use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithMorphMap;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithResponsiveImages;
 use Spatie\MediaLibrary\Tests\Support\TestModels\TestModelWithoutMediaConversions;
+use ZipArchive;
 
 abstract class TestCase extends Orchestra
 {
@@ -266,5 +267,27 @@ abstract class TestCase extends Orchestra
         Carbon::setTestNow($newNow);
 
         return $this;
+    }
+
+
+    protected function assertFileExistsInZip($zipPath, $filename)
+    {
+        $this->assertTrue($this->fileExistsInZip($zipPath, $filename), "Failed to assert that {$zipPath} contains a file name {$filename}");
+    }
+
+    protected function assertFileDoesntExistsInZip($zipPath, $filename)
+    {
+        $this->assertFalse($this->fileExistsInZip($zipPath, $filename), "Failed to assert that {$zipPath} doesn't contain a file name {$filename}");
+    }
+
+    protected function fileExistsInZip($zipPath, $filename): bool
+    {
+        $zip = new ZipArchive();
+
+        if ($zip->open($zipPath) === true) {
+            return $zip->locateName($filename, ZipArchive::FL_NODIR) !== false;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Hi Spatie,
Thank you for your wonderful packages.

I did use ZipStream-PHP package recently and had difficulties with streaming data. Apparently the file contents get read twice because the crc is required upfront. This can be avoided by setting the zero header option in the archive. The ZIP format specification allows the crc to be added after the file contents, which is what happens.
I saw you use this package as well and wanted to give you a hint in order to make your package better.

This should not impact any behavior, so I'm not sure if I can write any test to demonstrate this working.