### PR TITLE
Fix custom disk url giving invalid urls

### DIFF
--- a/src/UrlGenerator/LocalUrlGenerator.php
+++ b/src/UrlGenerator/LocalUrlGenerator.php
@@ -96,6 +96,9 @@ class LocalUrlGenerator extends BaseUrlGenerator
      */
     public function getResponsiveImagesDirectoryUrl(): string
     {
-        return url($this->getBaseMediaDirectoryUrl().'/'.$this->pathGenerator->getPathForResponsiveImages($this->media)).'/';
+        $base = Str::finish($this->getBaseMediaDirectoryUrl(), '/');
+        $path = $this->pathGenerator->getPathForResponsiveImages($this->media);
+
+        return Str::finish(url($base.$path), '/');
     }
 }

--- a/tests/Unit/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/Unit/UrlGenerator/BaseUrlGeneratorTest.php
@@ -98,7 +98,7 @@ class BaseUrlGeneratorTest extends TestCase
     /** @test */
     public function it_can_get_the_responsive_images_directory_url()
     {
-        $this->config->set('filesystems.disks.public.url',  'https://localhost/media/');
+        $this->config->set('filesystems.disks.public.url', 'https://localhost/media/');
 
         $this->assertEquals('https://localhost/media/1/responsive-images/', $this->urlGenerator->getResponsiveImagesDirectoryUrl());
 

--- a/tests/Unit/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/Unit/UrlGenerator/BaseUrlGeneratorTest.php
@@ -94,4 +94,16 @@ class BaseUrlGeneratorTest extends TestCase
 
         $this->assertEquals($url, $this->urlGenerator->getUrl());
     }
+
+    /** @test */
+    public function it_can_get_the_responsive_images_directory_url()
+    {
+        $this->config->set('filesystems.disks.public.url',  'https://localhost/media/');
+
+        $this->assertEquals('https://localhost/media/1/responsive-images/', $this->urlGenerator->getResponsiveImagesDirectoryUrl());
+
+        $this->config->set('filesystems.disks.public.url', null);
+
+        $this->assertEquals('http://localhost/media/1/responsive-images/', $this->urlGenerator->getResponsiveImagesDirectoryUrl());
+    }
 }


### PR DESCRIPTION
When using a custom url for your disk the `UrlGenerator` will create a url with double `//`. This PR will prevent that from happening.

Previously, when the disk url was set to `https://localhost/media/` it would generate a url like `https://localhost/media//1/responsive-images//`

This solves #1576 