### PR TITLE
Correctly use the media item's disk when removing responsive images

### DIFF
--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -157,7 +157,7 @@ class Filesystem
     {
         $responsiveImagesDirectory = $this->getResponsiveImagesDirectory($media);
 
-        $allFilePaths = $this->filesystem->allFiles($responsiveImagesDirectory);
+        $allFilePaths = $this->filesystem->disk($media->disk)->allFiles($responsiveImagesDirectory);
 
         $responsiveImagePaths = array_filter(
             $allFilePaths,
@@ -166,7 +166,7 @@ class Filesystem
             }
         );
 
-        $this->filesystem->delete($responsiveImagePaths);
+        $this->filesystem->disk($media->disk)->delete($responsiveImagePaths);
     }
 
     public function syncFileNames(Media $media)


### PR DESCRIPTION
Howdy @freekmurze and Spatie crew 👋 

I have a media collection setup that uses responsive images and also uses the non-default disk. I noticed that processing responsive images was always failing for this collection, and I tracked it down to the `removeResponsiveImages` method not specifying which disk to use. I noticed all the other methods call the filesystem's `disk` method, so I'm adding that here as well. It fixes the issue I encountered.

Thanks!