### PR TITLE
Resolve duplication of migration file on republishing

### DIFF
--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -21,7 +21,7 @@ class MediaLibraryServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->publishes([
-            __DIR__ . '/../database/migrations/create_media_table.php.stub' => $this->getMigrationFileName($filesystem),
+            __DIR__.'/../database/migrations/create_media_table.php.stub' => $this->getMigrationFileName($filesystem),
         ], 'migrations');
 
         $this->publishes([


### PR DESCRIPTION
Resolves duplication of migration file when republishing the vendor "migrations" tag. Fixes #739 

Copied this method from laravel-permission:

https://github.com/spatie/laravel-permission/blob/master/src/PermissionServiceProvider.php#L23