### PR TITLE
Scope trim_trailing_whitespace setting change to blade files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,10 +9,11 @@ indent_size = 4
 indent_style = space
 end_of_line = lf
 insert_final_newline = true
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 
 [*.blade.php]
 insert_final_newline = false
+trim_trailing_whitespace = false
 
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
Is `trim_trailing_whitespace = false` even necessary for Blade files?