### PR TITLE
Allow image_driver config to be set via .env

### DIFF
--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -129,7 +129,7 @@ return [
      * The engine that should perform the image conversions.
      * Should be either `gd` or `imagick`.
      */
-    'image_driver' => 'gd',
+    'image_driver' => env('IMAGE_DRIVER', 'gd'),
 
     /*
      * FFMPEG & FFProbe binaries paths, only used if you try to generate video


### PR DESCRIPTION
This small change will allow the `image_driver` config option to be set via an `IMAGE_DRIVER` env variable. This is useful in cases where `gd` is available locally but `imagick` is used in production.

This change has no breaking-changes as the default is still `gd`.