### PR TITLE
Add config to maintain files on model deletion

### DIFF
--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -17,7 +17,7 @@ return [
     /*
      * If set to false, files will remain on the disk when Media model is deleted. 
      */
-    'remove_file_on_delete' => true,
+    'remove_files_on_delete' => true,
 
     /*
      * This queue will be used to generate derived and responsive images.

--- a/config/medialibrary.php
+++ b/config/medialibrary.php
@@ -13,6 +13,11 @@ return [
      * Adding a larger file will result in an exception.
      */
     'max_file_size' => 1024 * 1024 * 10,
+    
+    /*
+     * If set to false, files will remain on the disk when Media model is deleted. 
+     */
+    'remove_file_on_delete' => true,
 
     /*
      * This queue will be used to generate derived and responsive images.

--- a/src/MediaObserver.php
+++ b/src/MediaObserver.php
@@ -52,8 +52,10 @@ class MediaObserver
                 return;
             }
         }
-
-        app(Filesystem::class)->removeAllFiles($media);
+        
+        if(config('medialibrary.remove_files_on_delete')) {
+            app(Filesystem::class)->removeAllFiles($media);
+        }
     }
 
     private function isLaravel7OrHigher(): bool

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -53,7 +53,7 @@ class DeleteTest extends TestCase
     }
     
     /** @test */
-    public function it_will_not_delete_files_from_disk_if_when_remove_files_on_delete_is_false()
+    public function it_will_not_delete_files_from_disk_if_remove_files_on_delete_config_is_false()
     {
         config(['medialibrary.path_generator' => TestPathGenerator::class]);
         config()->set('medialibrary.remove_files_on_delete', false);

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -51,6 +51,24 @@ class DeleteTest extends TestCase
 
         $this->assertFalse(File::isDirectory($this->getTempDirectory($path)));
     }
+    
+    /** @test */
+    public function it_will_not_delete_files_from_disk_if_when_remove_files_on_delete_is_false()
+    {
+        config(['medialibrary.path_generator' => TestPathGenerator::class]);
+        config()->set('medialibrary.remove_files_on_delete', false);
+
+        $pathGenerator = new TestPathGenerator();
+
+        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+        $path = $pathGenerator->getPath($media);
+
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+
+        $this->testModel->delete();
+
+        $this->assertTrue(File::isDirectory($this->getTempDirectory($path)));
+    }
 
     /**
      * @test


### PR DESCRIPTION
I've added a config value `remove_files_on_delete` that, when set to false, will prevent the MediaObserver deleted observer from removing media files from the disk. (Default = true, which maintains current functionality)

My use case: 
I have built a content management system which uses the media library to upload image files associated with posts. Sometimes the image URLs are hard-coded into the content of the site, but admin users still wish to disassociate the media from the post to which they originally uploaded it. This setting allows that disassociation while maintaining the existing files. 