### PR TITLE
Update S3 url generator to use media disk

### DIFF
--- a/src/UrlGenerator/S3UrlGenerator.php
+++ b/src/UrlGenerator/S3UrlGenerator.php
@@ -35,7 +35,7 @@ class S3UrlGenerator extends BaseUrlGenerator
 
         $url = $this->versionUrl($url);
 
-        return config('medialibrary.s3.domain').'/'.$url;
+        return config('medialibrary.'.$this->media->disk.'.domain').'/'.$url;
     }
 
     /**
@@ -76,6 +76,6 @@ class S3UrlGenerator extends BaseUrlGenerator
             $url = $root.'/'.$url;
         }
 
-        return config('medialibrary.s3.domain').'/'.$url;
+        return config('medialibrary.'.$this->media->disk.'.domain').'/'.$url;
     }
 }


### PR DESCRIPTION
The S3 Url generator currently assumes the disk that uses the "s3" driver also is called "s3". This is not always the case. In my case: I use a Digital Ocean Space, which also uses the "s3" driver, but the disk is not called "s3" of course. Currently it's not possible to generate a correct url using the standard s3 url generator.