### PR TITLE
Use native file copy

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -49,7 +49,7 @@ class Filesystem
         $destination = $this->getMediaDirectory($media, $type) . $destinationFileName;
 
         if ($file->getDisk() === $media->disk) {
-            $this->copyFileOnDisk($file->getKey(), $destination, $file->getDisk());
+            $this->copyFileOnDisk($file->getKey(), $destination, $media->disk);
 
             return;
         }
@@ -68,7 +68,7 @@ class Filesystem
         $this->streamFileToDisk(
             $storage->getDriver()->readStream($file->getKey()),
             $destination,
-            $file->getDisk(),
+            $media->disk,
             $headers
         );
     }

--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -44,11 +44,17 @@ class Filesystem
 
     public function copyToMediaLibraryFromRemote(RemoteFile $file, Media $media, ?string $type = null, ?string $targetFileName = null): void
     {
-        $storage = Storage::disk($file->getDisk());
-
         $destinationFileName = $targetFileName ?: $file->getFilename();
 
         $destination = $this->getMediaDirectory($media, $type) . $destinationFileName;
+
+        if ($file->getDisk() === $media->disk) {
+            $this->copyFileOnDisk($file->getKey(), $destination, $file->getDisk());
+
+            return;
+        }
+
+        $storage = Storage::disk($file->getDisk());
 
         $headers = $media->getDiskDriverName() === 'local'
             ? []
@@ -58,11 +64,28 @@ class Filesystem
                 $storage->mimeType($file->getKey())
             );
 
-        $this->filesystem->disk($media->disk)
+
+        $this->streamFileToDisk(
+            $storage->getDriver()->readStream($file->getKey()),
+            $destination,
+            $file->getDisk(),
+            $headers
+        );
+    }
+
+    protected function copyFileOnDisk(string $file, string $destination, string $disk): void
+    {
+        $this->filesystem->disk($disk)
+            ->copy($file, $destination);
+    }
+
+    protected function streamFileToDisk($stream, string $destination, string $disk, array $headers): void
+    {
+        $this->filesystem->disk($disk)
             ->getDriver()->writeStream(
                 $destination,
-                $storage->getDriver()->readStream($file->getKey()),
-                $headers,
+                $stream,
+                $headers
             );
     }
 

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -309,6 +309,20 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function it_can_natively_copy_a_remote_file_from_the_same_disk_to_the_media_library()
+    {
+        Storage::disk('public')->put('tmp/test.jpg', file_get_contents($this->getTestJpg()));
+        $this->assertFileExists($this->getMediaDirectory("tmp/test.jpg"));
+
+        $media = $this->testModel
+            ->addMediaFromDisk('tmp/test.jpg', 'public')
+            ->toMediaCollection();
+
+        $this->assertFileExists($this->getMediaDirectory("{$media->id}/test.jpg"));
+        $this->assertFileNotExists($this->getMediaDirectory("tmp/test.jpg"));
+    }
+
+    /** @test */
     public function it_can_add_a_remote_file_with_a_space_in_the_name_to_the_media_library()
     {
         $url = 'http://spatie.github.io/laravel-medialibrary/tests/Support/testfiles/test%20with%20space.jpg';


### PR DESCRIPTION
If a file and the media destination are on the same disk, use native copy operation instead of streaming.