### PR TITLE
Set conversion disk when adding media from remote

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -224,10 +224,9 @@ class FileAdder
         $media->file_name = $this->fileName;
 
         $media->disk = $this->determineDiskName($diskName, $collectionName);
-
-        if (is_null(config("filesystems.disks.{$media->disk}"))) {
-            throw DiskDoesNotExist::create($media->disk);
-        }
+        $this->ensureDiskExists($media->disk);
+        $media->conversions_disk = $this->determineConversionsDiskName($media->disk, $collectionName);
+        $this->ensureDiskExists($media->conversions_disk);
 
         $media->collection_name = $collectionName;
 


### PR DESCRIPTION
This seems to be a bug in v8.

When adding a file from s3, eg:
```php
$newImage = $event
    ->addMediaFromDisk('my/filename.jpg', 'uploads')
    ->toMediaCollection('main_image');
```

the `conversions_disk` is not being set, and thus the jobs that execute the conversions, fail.