### PR TITLE
Allow "setName()" accept mixed values

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -44,7 +44,8 @@ class FileAdder
 
     protected string $fileName = '';
 
-    protected string $mediaName = '';
+    /** @var string|mixed */
+    protected $mediaName = '';
 
     protected string $diskName = '';
 
@@ -123,12 +124,12 @@ class FileAdder
         return $this;
     }
 
-    public function usingName(string $name): self
+    public function usingName($name): self
     {
         return $this->setName($name);
     }
 
-    public function setName(string $name): self
+    public function setName($name): self
     {
         $this->mediaName = $name;
 


### PR DESCRIPTION
In some situations, it is nice to have the "name" field accept something other than "string".
Example:
When used together with `spatie/laravel-translatable` we can set `name` DB field to JSON but, because `setName()` method does not accept array, it is not possible to set multiple translations when adding media like this:
``` php
$model->addMediaFromUrl('https://example.com/image.jpg')
        ->setName([
              'en' => 'Name in English',
              'de' => 'Name auf Deutsch'
        ])
        ->toMediaCollection('images');
```