### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to `laravel-medialibrary` will be documented in this file
 ## 7.19.3 - 2020-03-09
 
 - fix responsive images extension (#1752)
-- use native file copy (#1758)
 
 ## 7.19.2 - 2020-03-04
 


### PR DESCRIPTION
Not exactly sure how you'd like to address this or if it matters. Native file copy wasn't added to v7, though technically it could be. Happy to back port it, if v7 is still being supported, 