### PR TITLE
Fixed namespace in upgrade docs

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,7 +7,7 @@ Because there are many breaking changes an upgrade is not that easy. There are m
 - internally the media library has been restructured an nearly all namespaces have changed. Class names remained the same. In your application code hunt to any usages of classes that start with `Spatie\MediaLibrary`. Take a look in the source code of medialibrary what the new namespace of the class is and use that. 
 - rename `config/medialibrary.php` to `config/media-library.php`
 - all medialibrary commands have been renamed from `medialibrary:xxx` to `media-library:xxx`. Make sure to update all media library commands in your console kernel.
-- the `Spatie\MediaLibrary\HasMedia\HasMediaTrait` has been renamed to `Spatie\MediaLibrary\HasMedia\InteractsWithMedia`. Make sure to update this in all models that use media.
+- the `Spatie\MediaLibrary\HasMedia\HasMediaTrait` has been renamed to `Spatie\MediaLibrary\InteractsWithMedia`. Make sure to update this in all models that use media.
 - Add a `conversions_disk` field to the `media` table (you'll find the definition in the migrations file of the package) and for each row copy the value of `disk` to `conversions_disk`.
 - Add a `uuid` field to the `media` table and fill each row with a unique value, preferably a `uuid`
 - Url generation has been vastly simplified. You should set the `url_generator` in the `media-library` config file to `Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class`. It will be able to handle most disks.


### PR DESCRIPTION
There was a wrong namespace in the upgrade docs:
`Spatie\MediaLibrary\HasMedia\InteractsWithMedia` should be `Spatie\MediaLibrary\InteractsWithMedia` instead.