### PR TITLE
Backward compatibility for media created before conversions_disk was added

### DIFF
--- a/src/Support/UrlGenerator/BaseUrlGenerator.php
+++ b/src/Support/UrlGenerator/BaseUrlGenerator.php
@@ -57,7 +57,11 @@ abstract class BaseUrlGenerator implements UrlGenerator
 
     protected function getDiskName(): string
     {
-        return $this->conversion === null
+        if ($this->conversion === null) {
+            return $this->media->disk;
+        }
+        
+        return $this->media->conversions_disk === null
             ? $this->media->disk
             : $this->media->conversions_disk;
     }


### PR DESCRIPTION
Hi,

An exception is thrown for media (with conversions) created before the conversions_disk column was added to the media table. The conversions_disk is null for older media.

> Return value of Spatie\MediaLibrary\Support\UrlGenerator\BaseUrlGenerator::getDiskName() must be of the type string, null returned (View: /home/vagrant/my-project/resources/views/vendor/media-library/responsiveImageWithPlaceholder.blade.php) (View: /home/vagrant/my-project/resources/views/vendor/media-library/responsiveImageWithPlaceholder.blade.php) (View: /home/vagrant/my-project/resources/views/vendor/media-library/responsiveImageWithPlaceholder.blade.php)

Unless I'm missing something, the old media conversions disk is always the same as the media disk. This change solves the backward compatibility for me, I hope it helps.

Have a great day!