### PR TITLE
fix: reference to getPath in Model breaks custom url generator

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -74,7 +74,7 @@ class Media extends Model implements Responsable, Htmlable
     {
         $urlGenerator = UrlGeneratorFactory::createForMedia($this, $conversionName);
 
-        return $urlGenerator->getPath();
+        return $urlGenerator->getUrl();
     }
 
     public function getImageGenerators(): Collection


### PR DESCRIPTION
My project which uses v7 has a custom url generator:

```
<?php

namespace App\Helpers;

use DateTimeInterface;
use Spatie\MediaLibrary\Exceptions\UrlCannotBeDetermined;
use Spatie\MediaLibrary\UrlGenerator\BaseUrlGenerator;
use Spatie\MediaLibrary\UrlGenerator\UrlGenerator;
use Illuminate\Support\Str;

class MediaPrivateFileUrlGenerator extends BaseUrlGenerator implements UrlGenerator
{
    /**
     * Get the url for the profile of a media item.
     *
     * @return string
     */
    public function getUrl() : string
    {
        return config('app.url').'/protected-assets/'.$this->getPathRelativeToRoot();
    }
    
    /**
     * Get the temporary url for a media item.
     *
     * @param \DateTimeInterface $expiration
     * @param array $options
     *
     * @return string
     */
    public function getTemporaryUrl(DateTimeInterface $expiration, array $options = []): string
    {
        throw UrlCannotBeDetermined::filesystemDoesNotSupportTemporaryUrls();
    }
    
    /**
     * Get the url to the directory containing responsive images.
     *
     * @return string
     */
    public function getResponsiveImagesDirectoryUrl(): string
    {
        $path = $this->pathGenerator->getPathForResponsiveImages($this->media);

        return Str::finish(url($path), '/');
    }
}
```

and also a custom path generator:
```
<?php 

namespace App\Helpers;

use Spatie\MediaLibrary\Models\Media;
use Spatie\MediaLibrary\PathGenerator\PathGenerator;
use Illuminate\Support\Str;
class MediaCustomPathGenerator implements PathGenerator
{
    public function getPath(Media $media): string
    {
        $model = $media->model;
        $model_slug = Str::slug($model->getTable());
        $model_id = $model->id;
        $media_id = $media->id;
    return "{$model_slug}/{$model_id}/$media_id/";
    }
    
    public function getPathForConversions(Media $media): string
    {
        return Str::slug($media->model->name);
    }

    public function getPathForResponsiveImages(Media $media): string
    {
        return Str::slug($media->model->name);
    }
}
```

When trying to save media, I get an exception saying that getPath is not set on my CustomUrlGenerator. Surely this is a mistake?
```
Call to undefined method App\Helpers\MediaPrivateFileUrlGenerator::getPath() 
at vendor/spatie/laravel-medialibrary/src/Models/Media.php:77)
```