### PR TITLE
Allow ZipStream 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "illuminate/pipeline": "^6.18|^7.0",
         "illuminate/support": "^6.18|^7.0",
         "league/flysystem": "^1.0.64",
-        "maennchen/zipstream-php": "^1.0",
+        "maennchen/zipstream-php": "^1.0|^2.0",
         "spatie/image": "^1.4.0",
         "spatie/temporary-directory": "^1.1",
         "symfony/console": "^4.4|^5.0"


### PR DESCRIPTION
The ZipStream library has a [2.0 release](https://github.com/maennchen/ZipStream-PHP/releases/tag/2.0.0) out which has a breaking change.  From my own use of the library in other applications, I haven't had noted any issues with the change, so I think this should be safe to apply here.