### PR TITLE
Close #1712 - Save Media Files in ZIP Subfolders

### DIFF
--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -86,7 +86,7 @@ class MediaStream implements Responsable
     protected function getZipStreamContents(): Collection
     {
         return $this->mediaItems->map(fn (Media $media, $mediaItemIndex) => [
-            'fileNameInZip' => $this->getFileNameWithSuffix($this->mediaItems, $mediaItemIndex),
+            'fileNameInZip' => $this->getZipFileNamePrefix($this->mediaItems, $mediaItemIndex) . $this->getFileNameWithSuffix($this->mediaItems, $mediaItemIndex),
             'media' => $media,
         ]);
     }
@@ -115,5 +115,10 @@ class MediaStream implements Responsable
         $fileNameWithoutExtension = pathinfo($fileName, PATHINFO_FILENAME);
 
         return "{$fileNameWithoutExtension} ({$fileNameCount}).{$extension}";
+    }
+
+    protected function getZipFileNamePrefix(Collection $mediaItems, int $currentIndex): string
+    {
+        return $mediaItems[$currentIndex]->hasCustomProperty('zip_filename_prefix') ? $mediaItems[$currentIndex]->getCustomProperty('zip_filename_prefix') : "";
     }
 }

--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -86,7 +86,7 @@ class MediaStream implements Responsable
     protected function getZipStreamContents(): Collection
     {
         return $this->mediaItems->map(fn (Media $media, $mediaItemIndex) => [
-            'fileNameInZip' => $this->getZipFileNamePrefix($this->mediaItems, $mediaItemIndex) . $this->getFileNameWithSuffix($this->mediaItems, $mediaItemIndex),
+            'fileNameInZip' => $this->getZipFileNamePrefix($this->mediaItems, $mediaItemIndex).$this->getFileNameWithSuffix($this->mediaItems, $mediaItemIndex),
             'media' => $media,
         ]);
     }
@@ -119,6 +119,6 @@ class MediaStream implements Responsable
 
     protected function getZipFileNamePrefix(Collection $mediaItems, int $currentIndex): string
     {
-        return $mediaItems[$currentIndex]->hasCustomProperty('zip_filename_prefix') ? $mediaItems[$currentIndex]->getCustomProperty('zip_filename_prefix') : "";
+        return $mediaItems[$currentIndex]->hasCustomProperty('zip_filename_prefix') ? $mediaItems[$currentIndex]->getCustomProperty('zip_filename_prefix') : '';
     }
 }

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -22,9 +22,6 @@ class MediaStreamTest extends TestCase
                 ->preservingOriginal()
                 ->toMediaCollection();
         }
-
-
-
     }
 
     /** @test */
@@ -89,7 +86,6 @@ class MediaStreamTest extends TestCase
             ])
             ->toMediaCollection();
 
-
         $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
 
         ob_start();
@@ -103,8 +99,6 @@ class MediaStreamTest extends TestCase
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
 
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (3).jpg');
-
-        $this->assertEquals(2,2);
     }
 
 
@@ -119,7 +113,6 @@ class MediaStreamTest extends TestCase
             ])
             ->toMediaCollection();
 
-
         $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
 
         ob_start();
@@ -131,7 +124,5 @@ class MediaStreamTest extends TestCase
         file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'just_a_string_prefix test (3).jpg');
-
-        $this->assertEquals(2,2);
     }
 }

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -101,7 +101,6 @@ class MediaStreamTest extends TestCase
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (3).jpg');
     }
 
-
     /** @test */
     public function media_with_zip_file_prefix_property_saved_with_correct_prefix()
     {

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -22,6 +22,9 @@ class MediaStreamTest extends TestCase
                 ->preservingOriginal()
                 ->toMediaCollection();
         }
+
+
+
     }
 
     /** @test */
@@ -73,5 +76,62 @@ class MediaStreamTest extends TestCase
             ->addMedia([Media::find(1), Media::find(2)]);
 
         $this->assertEquals(2, $zipStreamResponse->getMediaItems()->count());
+    }
+
+    /** @test */
+    public function media_with_zip_file_folder_prefix_property_saved_in_correct_zip_folder()
+    {
+        $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->withCustomProperties([
+                'zip_filename_prefix' => 'folder/subfolder/',
+            ])
+            ->toMediaCollection();
+
+
+        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+        ob_start();
+        @$zipStreamResponse->toResponse(request())->sendContent();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $temporaryDirectory = (new TemporaryDirectory())->create();
+        file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (3).jpg');
+
+        $this->assertEquals(2,2);
+    }
+
+
+    /** @test */
+    public function media_with_zip_file_prefix_property_saved_with_correct_prefix()
+    {
+        $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->withCustomProperties([
+                'zip_filename_prefix' => 'just_a_string_prefix ',
+            ])
+            ->toMediaCollection();
+
+
+        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+        ob_start();
+        @$zipStreamResponse->toResponse(request())->sendContent();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $temporaryDirectory = (new TemporaryDirectory())->create();
+        file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'just_a_string_prefix test (3).jpg');
+
+        $this->assertEquals(2,2);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -251,7 +251,13 @@ abstract class TestCase extends Orchestra
             "Failed to assert that {$zipPath} contains a file name {$filename}"
         );
     }
-
+    protected function assertFileExistsInZipRecognizeFolder(string $zipPath, string $filename)
+    {
+        $this->assertTrue(
+            $this->fileExistsInZipRecognizeFolder($zipPath, $filename),
+            "Failed to assert that {$zipPath} contains a file name {$filename} by recognizing folders"
+        );
+    }
     protected function assertFileDoesntExistsInZip(string $zipPath, string $filename)
     {
         $this->assertFalse(
@@ -266,6 +272,17 @@ abstract class TestCase extends Orchestra
 
         if ($zip->open($zipPath) === true) {
             return $zip->locateName($filename, ZipArchive::FL_NODIR) !== false;
+        }
+
+        return false;
+    }
+
+    protected function fileExistsInZipRecognizeFolder($zipPath, $filename): bool
+    {
+        $zip = new ZipArchive();
+
+        if ($zip->open($zipPath) === true) {
+            return $zip->locateName($filename) !== false;
         }
 
         return false;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -251,6 +251,7 @@ abstract class TestCase extends Orchestra
             "Failed to assert that {$zipPath} contains a file name {$filename}"
         );
     }
+
     protected function assertFileExistsInZipRecognizeFolder(string $zipPath, string $filename)
     {
         $this->assertTrue(
@@ -258,6 +259,7 @@ abstract class TestCase extends Orchestra
             "Failed to assert that {$zipPath} contains a file name {$filename} by recognizing folders"
         );
     }
+
     protected function assertFileDoesntExistsInZip(string $zipPath, string $filename)
     {
         $this->assertFalse(


### PR DESCRIPTION
Completion of the feature for custom property "zip_file_prefix" to store a media file in a specific ZIP Folder.

Just add a custom property named 'zip_filename_prefix' to a media model and the media will be saved to the specific Subfolder in the ZIP File.