### PR TITLE
Update docs to reflect v8 removal of down()

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -18,6 +18,18 @@ php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServicePr
 php artisan migrate
 ```
 
+If you use Artisan's `migrate:rollback` or `migrate:refresh` commands you should edit the migration to include a down method:
+
+```php
+/**
+ * Reverse the migrations.
+ */
+public function down()
+{
+    Schema::dropIfExists('media');
+}
+```
+
 Publishing the config file is optional:
 
 ```bash


### PR DESCRIPTION
Removal of the `down()` migration method in v8 breaks migration when using core command `php artisan migrate:refresh` or `php artisan migrate:rollback` then re-applying migrations (error as the table already exists).

I understand the removal is intentional as Spatie don't use these (see @freekmurze 's [comment](https://github.com/spatie/laravel-medialibrary/commit/1f4dabfb84a2f4cb795ed075e7a75a2daebfa549#r37984857) ) but I believe it would be useful to warn users in the documentation as this caught me out recently.