### PR TITLE
Update UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,6 +24,7 @@ Media::cursor()->each(
 - spatie/pdf-to-image is now a suggestion dependency. Make sure to install it, if you want to create thumbnails for PDFs or SVGs
 - `registerMediaConversions` and `registerMediaCollections` should now use the  `void` return type.
 - if the `path_generator` key in the `media-library` config file was set to `null`, change the value to `Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class`
+- if the `url_generator` key in the `media-library` config file was set to `null`, change the value to `Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class`
 - the `rawUrlEncodeFilename` method on `BaseUrlGenerator` has been removed. Remove all calls in your own code to this method.
 - `getConversionFile` on `Conversion` now accepts a `Media` instance instead of a `string`. In normal circumstance you wouldn't have used this function directly.
 


### PR DESCRIPTION
When upgrading I got the following issue:

`TypeError: Argument 1 passed to Spatie\MediaLibrary\Support\UrlGenerator\UrlGeneratorFactory::guardAgainstInvalidUrlGenerator() must be of the type string, null given`

This fixes the issue, I'm assuming this was missed in the upgrade guide given the type hinting