### PR TITLE
Add page number support for Pdf image generator

### DIFF
--- a/docs/converting-other-file-types/using-image-generators.md
+++ b/docs/converting-other-file-types/using-image-generators.md
@@ -24,6 +24,17 @@ The media library includes image generators for the following file types:
 
 The PDF generator requires [Imagick](http://php.net/manual/en/imagick.setresolution.php) and [Ghostscript](https://www.ghostscript.com/). If you're running into issues with Ghostscript have a look at [issues regarding Ghostscript](https://github.com/spatie/pdf-to-image/blob/master/README.md#issues-regarding-ghostscript).
 
+The pdf image generator allows you to choose at which page of the pdf, the thumbnail should be created using the `pdfPageNumber` on the conversion.
+
+If the `pdfPageNumber` is not set on the conversion, the default value will be the first page of the pdf.
+
+```php
+$this->addMediaConversion('thumb')
+     ->width(368)
+     ->height(232)
+     ->pdfPageNumber(2);
+```
+
 ## SVG
 
 The only requirement to perform a conversion of a SVG file is [Imagick](http://php.net/manual/en/imagick.setresolution.php).

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -27,6 +27,8 @@ class Conversion
 
     protected string $loadingAttributeValue;
 
+    protected int $pdfPageNumber = 1;
+
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -229,5 +231,17 @@ class Conversion
     public function getLoadingAttributeValue(): string
     {
         return $this->loadingAttributeValue;
+    }
+
+    public function pdfPageNumber(int $pageNumber): self
+    {
+        $this->pdfPageNumber = $pageNumber;
+
+        return $this;
+    }
+
+    public function getPdfPageNumber(): int
+    {
+        return $this->pdfPageNumber;
     }
 }

--- a/src/Conversions/ImageGenerators/Pdf.php
+++ b/src/Conversions/ImageGenerators/Pdf.php
@@ -11,7 +11,9 @@ class Pdf extends ImageGenerator
     {
         $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
 
-        (new \Spatie\PdfToImage\Pdf($file))->saveImage($imageFile);
+        $pageNumber = $conversion ? $conversion->getPdfPageNumber() : 1;
+
+        (new \Spatie\PdfToImage\Pdf($file))->setPage($pageNumber)->saveImage($imageFile);
 
         return $imageFile;
     }

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -189,4 +189,12 @@ class ConversionTest extends TestCase
 
         $this->assertArrayNotHasKey('optimize', $manipulations[0]);
     }
+
+    /** @test */
+    public function it_will_use_the_pdf_page_number_parameter_if_it_was_given()
+    {
+        $this->conversion->pdfPageNumber(10);
+
+        $this->assertEquals(10, $this->conversion->getPdfPageNumber());
+    }
 }


### PR DESCRIPTION
We used this package for a project, where we needed to have to generate thumbnails also for the second page of a pdf. 
We saw that the video thumbnail generation is allowing us to set a specified timeframe for the thumbnail.
Based on this we extended the Pdf image generator to accept also the page number from where the thumbnail is generated.

The contribution was made with my colleague:
https://github.com/precubadrian