### PR TITLE
Allow model a chance to provide a media base path

### DIFF
--- a/src/Support/PathGenerator/DefaultPathGenerator.php
+++ b/src/Support/PathGenerator/DefaultPathGenerator.php
@@ -39,7 +39,7 @@ class DefaultPathGenerator implements PathGenerator
         // method for retrieving its media. Because
         // the developer's time is precious, and
         // this may save him from having to
-        // implement the inteface in
+        // implement the interface in
         // most basic use cases!
         if (method_exists($media->model, 'getMediaBasePath')) {
             return $media->model->getMediaBasePath($media);

--- a/src/Support/PathGenerator/DefaultPathGenerator.php
+++ b/src/Support/PathGenerator/DefaultPathGenerator.php
@@ -35,6 +35,16 @@ class DefaultPathGenerator implements PathGenerator
      */
     protected function getBasePath(Media $media): string
     {
+        // First we will check if our model  has its own
+        // method for retrieving its media. Because
+        // the developer's time is precious, and
+        // this may save him from having to
+        // implement the inteface in
+        // most basic use cases!
+        if (method_exists($media->model, 'getMediaBasePath')) {
+            return $media->model->getMediaBasePath($media);
+        }
+
         return $media->getKey();
     }
 }


### PR DESCRIPTION
Small change to allow developer to add mediaBasePath() method to a  [prepared model](https://docs.spatie.be/laravel-medialibrary/v8/basic-usage/preparing-your-model/) without having to implement the Spatie\MediaLibrary\Support\PathGenerator\PathGenerator  interface, or even publish the config file!

```php
    protected function getBasePath(Media $media): string
    {
        // First we will check if our model  has its own
        // method for retrieving its media. Because
        // the developer's time is precious, and
        // this may save him from having to
        // implement the interface!
        if (method_exists($media->model, 'getMediaBasePath')) {
            return $media->model->getMediaBasePath($media);
        }

        return $media->getKey();
    }
```