### PR TITLE
Updated tags of the publshed assets for more package specific naming conventions

### DIFF
--- a/docs/advanced-usage/rendering-media.md
+++ b/docs/advanced-usage/rendering-media.md
@@ -40,7 +40,7 @@ Lazy loading this one: {{ $media()->lazy() }}
 You can customize the rendered output even further by publishing the `views` with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="views"
+php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="media-library-views"
 ```
 
 The following files will be published in the `resources/views/vendor/media-library` directory:

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -14,7 +14,7 @@ The package will automatically register a service provider.
 You need to publish and run the migration:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="migrations"
+php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="media-library-migrations"
 php artisan migrate
 ```
 
@@ -33,7 +33,7 @@ public function down()
 Publishing the config file is optional:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="config"
+php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="media-library-config"
 ```
 
 This is the default content of the config file:

--- a/docs/responsive-images/customizing-the-rendered-html.md
+++ b/docs/responsive-images/customizing-the-rendered-html.md
@@ -6,7 +6,7 @@ weight: 3
 Whenever you use a `$media` instance as output in a Blade view the medialibrary will generate a `img` tag with the necessary `src`, `srcset` and `alt` attributes. You can customize the rendered output by publishing the `views` with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="views"
+php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="media-library-views"
 ```
 
 The following files will be published in the `resources/views/vendor/media-library` directory:

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -40,19 +40,23 @@ class MediaLibraryServiceProvider extends ServiceProvider
 
     protected function registerPublishables(): void
     {
+        if (! $this->app->runningInConsole()) {
+            return;
+        }
+
         $this->publishes([
             __DIR__.'/../config/media-library.php' => config_path('media-library.php'),
-        ], 'config');
+        ], 'media-library-config');
 
         if (! class_exists('CreateMediaTable')) {
             $this->publishes([
                 __DIR__.'/../database/migrations/create_media_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_media_table.php'),
-            ], 'migrations');
+            ], 'media-library-migrations');
         }
 
         $this->publishes([
             __DIR__.'/../resources/views' => resource_path('views/vendor/media-library'),
-        ], 'views');
+        ], 'media-library-views');
     }
 
     protected function registerCommands(): void


### PR DESCRIPTION
To have more granular control for end user to publish only migrations or config etc from this package.