### PR TITLE
Fixed duplicated path prefix for temporary urls

### DIFF
--- a/src/Support/UrlGenerator/DefaultUrlGenerator.php
+++ b/src/Support/UrlGenerator/DefaultUrlGenerator.php
@@ -18,7 +18,7 @@ class DefaultUrlGenerator extends BaseUrlGenerator
 
     public function getTemporaryUrl(DateTimeInterface $expiration, array $options = []): string
     {
-        return $this->getDisk()->temporaryUrl($this->getPath(), $expiration, $options);
+        return $this->getDisk()->temporaryUrl($this->getPathRelativeToRoot(), $expiration, $options);
     }
 
     public function getBaseMediaDirectoryUrl()

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -163,6 +163,32 @@ class S3IntegrationTest extends TestCase
             sha1(file_get_contents($media->getTemporaryUrl(Carbon::now()->addMinutes(5))))
         );
     }
+    
+    /** @test */
+    public function it_retrieves_a_temporary_media_url_from_s3_when_s3_root_not_empty()
+    {
+        config()->set('filesystems.disks.s3_disk.root', 'test-root');
+
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection('default', 's3_disk');
+
+        $this->assertStringContainsString(
+            "/{$this->s3BaseDirectory}/{$media->id}/test.jpg",
+            $media->getTemporaryUrl(Carbon::now()->addMinutes(5))
+        );
+
+        $this->assertStringNotContainsString(
+            '/test-root/test-root',
+            $media->getTemporaryUrl(Carbon::now()->addMinutes(5))
+        );
+
+        $this->assertEquals(
+            sha1(file_get_contents($this->getTestJpg())),
+            sha1(file_get_contents($media->getTemporaryUrl(Carbon::now()->addMinutes(5))))
+        );
+    }
 
     /** @test */
     public function it_can_get_the_temporary_url_to_first_media_in_a_collection()

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -163,7 +163,7 @@ class S3IntegrationTest extends TestCase
             sha1(file_get_contents($media->getTemporaryUrl(Carbon::now()->addMinutes(5))))
         );
     }
-    
+
     /** @test */
     public function it_retrieves_a_temporary_media_url_from_s3_when_s3_root_not_empty()
     {


### PR DESCRIPTION
Hi,

The path prefix (root) gets duplicated for temporary urls when disk root is not empty. This is not a problem with local adapter, or even s3 when the root is empty in the s3 disk config. 

First, when using $media->getTemporaryUrl(...), in `spatie/laravel-medialibrary/src/Support/UrlGenerator/DefaultUrlGenerator.php` we have the prefix added in the `getPath()` function:

```
public function getPath(): string
    {
        ...
        return $pathPrefix.$this->getPathRelativeToRoot();
    }
```

Then `laravel/framework/src/Illuminate/Filesystem/FilesystemAdapter.php` also adds it in:

```
public function getAwsTemporaryUrl($adapter, $path, $expiration, $options)
    {
        ...
        $command = $client->getCommand('GetObject', array_merge([
            'Bucket' => $adapter->getBucket(),
            'Key' => $adapter->getPathPrefix().$path,
        ], $options));
        ...
    }
```

So the getTemporaryUrl() function should use ->getPathRelativeToRoot(), to make sure we get the path without the root prefix in disk config.

```
public function getTemporaryUrl(DateTimeInterface $expiration, array $options = []): string
    {
        return $this->getDisk()->temporaryUrl($this->getPathRelativeToRoot(), $expiration, $options);
    }
```
