### PR TITLE
Fixed duplicated / in paths

### DIFF
--- a/src/Support/UrlGenerator/DefaultUrlGenerator.php
+++ b/src/Support/UrlGenerator/DefaultUrlGenerator.php
@@ -23,7 +23,7 @@ class DefaultUrlGenerator extends BaseUrlGenerator
 
     public function getBaseMediaDirectoryUrl()
     {
-        return $this->getDisk()->url('/');
+        return $this->getDisk()->url('');
     }
 
     public function getPath(): string


### PR DESCRIPTION
Hi,

The / gets duplicated in paths for both local and s3 adapters. If we `dd($this->getDisk()->url('/'));` we'll get something like `"/storage//"`.