### PR TITLE
Allow the modal to be over ridden

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -218,7 +218,7 @@ class Filesystem
         $oldFileName = $media->getOriginal('file_name');
 
         $mediaDirectory = $this->getMediaDirectory($media);
-(
+
         $oldFile = "{$mediaDirectory}/{$oldFileName}";
         $newFile = "{$mediaDirectory}/{$newFileName}";
 

--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -218,7 +218,7 @@ class Filesystem
         $oldFileName = $media->getOriginal('file_name');
 
         $mediaDirectory = $this->getMediaDirectory($media);
-
+(
         $oldFile = "{$mediaDirectory}/{$oldFileName}";
         $newFile = "{$mediaDirectory}/{$newFileName}";
 
@@ -227,7 +227,7 @@ class Filesystem
 
     protected function renameConversionFiles(Media $media): void
     {
-        $mediaWithOldFileName = Media::find($media->id);
+        $mediaWithOldFileName = config('media-library.media_model')::find($media->id);
         $mediaWithOldFileName->file_name = $mediaWithOldFileName->getOriginal('file_name');
 
         $conversionDirectory = $this->getConversionDirectory($media);


### PR DESCRIPTION
This file assumes the file has not been over ridden / extended. This allows the package to work when the Media model is over ridden.