### PR TITLE
Now using Laravel MediaLibrary's temporary directory during image con…

### DIFF
--- a/src/Support/ImageFactory.php
+++ b/src/Support/ImageFactory.php
@@ -8,6 +8,8 @@ class ImageFactory
 {
     public static function load(string $path): Image
     {
-        return Image::load($path)->useImageDriver(config('media-library.image_driver'));
+        return Image::load($path)
+            ->useImageDriver(config('media-library.image_driver'))
+            ->setTemporaryDirectory(config('media-library.temporary_directory_path'));
     }
 }


### PR DESCRIPTION
…versions.

Hi there,

It seems like the underlying `GlideConversion` is relying on `sys_get_temp_dir()` for its temporary directory instead of `config('media-library.temporary_directory_path')`.