### PR TITLE
V7: set the media table for now due to medias bug

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -24,6 +24,7 @@ use Spatie\MediaLibrary\UrlGenerator\UrlGeneratorFactory;
 
 class Media extends Model implements Responsable, Htmlable
 {
+    protected $table = 'media';
     use IsSorted,
         CustomMediaProperties;
 


### PR DESCRIPTION
set the media table name explicitly to `media` to avoid failure caused by doctrine/inflictor now using `medias` as the plural

addresses: #1864 