### PR TITLE
Fix: Revert slash because of Vapor errors (Issue #1868)

### DIFF
--- a/src/Support/UrlGenerator/DefaultUrlGenerator.php
+++ b/src/Support/UrlGenerator/DefaultUrlGenerator.php
@@ -23,7 +23,7 @@ class DefaultUrlGenerator extends BaseUrlGenerator
 
     public function getBaseMediaDirectoryUrl()
     {
-        return $this->getDisk()->url('');
+        return $this->getDisk()->url('/');
     }
 
     public function getPath(): string


### PR DESCRIPTION
Revert the slash in `return $this->getDisk()->url('/');` that was removed in version 8.2.2.

His is because of errors in Vapor as described in issue [#1868](https://github.com/spatie/laravel-medialibrary/issues/1868).