### PR TITLE
Add suggestion to clear config cache before installing

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -3,13 +3,14 @@ title: Installation & setup
 weight: 4
 ---
 
-MediaLibrary can be installed via composer:
+MediaLibrary can be installed via composer. Before installing make sure you have not cached the configuration:
 
 ```bash
+php artisan config:clear
 composer require "spatie/laravel-medialibrary:^8.0.0"
 ```
 
-The package will automatically register a service provider.
+The package will automatically register a service provider. You can cache the configuration afterwards.
 
 You need to publish and run the migration:
 


### PR DESCRIPTION
If Laravel configuration is cached before the installation, running `composer require spatie/laravel-medialibrary` locks your app into broken state.

The reason are these lines in the `boot` method of service provider:

```
$mediaClass = config('media-library.media_model');
$mediaClass::observe(new MediaObserver());
```

As the config was cached `$mediaClass` is `null` and the app crashes with error `Class name must be a valid object or a string`. As the app doesn't boot anymore, one can't event do `php artisan config:clear` anymore.

I believe this could be fixed in a variety of ways and I don't know the code base well enough to suggest a solution. But I believe that for now a warning should be in place because people are really running into this a lot: https://github.com/spatie/laravel-medialibrary/issues?q=Class+name+must+be+a+valid+object+or+a+string