### PR TITLE
Unset loaded 'media' relation during updateMedia()

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -352,6 +352,10 @@ trait InteractsWithMedia
                 array_column($newMediaArray, $currentMediaItem->getKeyName()),
             ))
             ->each(fn (Media $media) => $media->delete());
+
+        if ($this->mediaIsPreloaded()) {
+            unset($this->media);
+        }
     }
 
     public function clearMediaCollection(string $collectionName = 'default'): self

--- a/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
@@ -28,6 +28,19 @@ class UpdateMediaTest extends TestCase
     }
 
     /** @test */
+    public function it_removes_a_media_item_with_eager_loaded_relation()
+    {
+        $mediaArray = $this->testModel->media->toArray();
+        unset($mediaArray[0]);
+
+        $this->testModel->load('media');
+        $this->testModel->updateMedia($mediaArray);
+
+        $this->assertCount(1, $this->testModel->media);
+        $this->assertEquals('test2', $this->testModel->getFirstMedia()->name);
+    }
+
+    /** @test */
     public function it_renames_media_items()
     {
         $mediaArray = $this->testModel->media->toArray();


### PR DESCRIPTION
This PR aims to avoid re-saving deleted media when they were previously eagerloaded.

This follows the same logic of relation removal than: [https://github.com/spatie/laravel-medialibrary/commit/2dbd3514008e569d7696d6dfb55c64e633a79bc3](https://github.com/spatie/laravel-medialibrary/commit/2dbd3514008e569d7696d6dfb55c64e633a79bc3)
