### PR TITLE
Assure Responsive Image Generation Respects Conversion Quality Setting

### DIFF
--- a/docs/responsive-images/getting-started-with-responsive-images.md
+++ b/docs/responsive-images/getting-started-with-responsive-images.md
@@ -121,17 +121,19 @@ class YourModel extends Model implements HasMedia
         $this
             ->addMediaConversion('my-conversion')
             ->greyscale()
+            ->quality(80)
             ->withResponsiveImages();
     }
 }
 ```
 
-To generate the converted greyscale file and the responsive images simply add a file:
+To generate the converted greyscale file with its [quality](https://docs.spatie.be/image/v1/usage/saving-images/#changing-jpeg-quality) reduced, and the responsive images simply add a file:
 
 
 ```php
-$yourModel->addMedia($yourImage)->toMediaCollection();
+$yourModel->addMedia($yourImage)->toMediaCollection('my-conversion');
 ```
+*The conversion's `quality` setting will also be applied to its generated responsive images.*
 
 In a controller you can pass a media object to a view.
 

--- a/docs/responsive-images/getting-started-with-responsive-images.md
+++ b/docs/responsive-images/getting-started-with-responsive-images.md
@@ -127,7 +127,7 @@ class YourModel extends Model implements HasMedia
 }
 ```
 
-To generate the converted greyscale file with its [quality](https://docs.spatie.be/image/v1/usage/saving-images/#changing-jpeg-quality) reduced, and the responsive images simply add a file:
+To generate the converted greyscale file with its [quality](https://docs.spatie.be/image/v1/usage/saving-images/#changing-jpeg-quality) slightly reduced, and the responsive images, simply add a file:
 
 
 ```php

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -71,4 +71,18 @@ class ResponsiveImageTest extends TestCase
 
         $this->assertEquals(280, $responsiveImage->height());
     }
+
+    /** @test */
+    public function responsive_image_generation_respects_the_conversion_quality_setting()
+    {
+        $this->testModelWithResponsiveImages
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection('default');
+
+        $standardQualityResponsiveConversion = $this->getTempDirectory('media/1/responsive-images/test___standardQuality_340_280.jpg');
+        $lowerQualityResponsiveConversion = $this->getTempDirectory('media/1/responsive-images/test___lowerQuality_340_280.jpg');
+
+        $this->assertLessThan(filesize($standardQualityResponsiveConversion), filesize($lowerQualityResponsiveConversion));
+    }
 }

--- a/tests/TestSupport/TestModels/TestModelWithResponsiveImages.php
+++ b/tests/TestSupport/TestModels/TestModelWithResponsiveImages.php
@@ -23,5 +23,14 @@ class TestModelWithResponsiveImages extends TestModel
             ->background('blue')
             ->format(Manipulations::FORMAT_JPG)
             ->withResponsiveImages();
+
+        $this->addMediaConversion('lowerQuality')
+             ->withResponsiveImages()
+             ->quality(60)
+             ->nonQueued();
+
+        $this->addMediaConversion('standardQuality')
+             ->withResponsiveImages()
+             ->nonQueued();
     }
 }


### PR DESCRIPTION
I saw the help wanted tag on [this issue](https://github.com/spatie/laravel-medialibrary/issues/1862), and I wanted to contribute as all of the awesome Spatie packages are such a boon to the Laravel community. 

## Original Issue
The [original issue](https://github.com/spatie/laravel-medialibrary/issues/1862) was that the the responsive image generation process did not respect the quality setting of a conversion. 

## Proposed Solution
This pull request adds a private method to determine if the conversion has a quality setting, and if so, it applies that quality setting to the generated responsive images. 

## Tests
I also created a test for the change to assure it actually worked. I wanted to be more precise, i.e. show that at 60% quality the image would be 60% smaller, but while the numbers are close, they're not exact. So I simply asserted that the lower quality responsive image should have a smaller file size than the standard responsive image. 

## Concerns 
I added two additional conversions in `TestModelWithResponsiveImages`, and I'm hoping this doesn't slow the test suite down too much. I looked for alternative ways to test the changes but all of the current conversions within this class didn't quite unambiguously achieve what the test needed to prove, IMO. 

If any changes are needed or this just isn't the solution you are looking for, don't hesitate to let me know, I will take no offense. And thanks again for all of your amazing packages!