### PR TITLE
Remove docs from export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@
 /.styleci.yml       export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
+/docs               export-ignore


### PR DESCRIPTION
The docs currently add a whopping 2.8 megabytes to the vendor folder, which is not required :)