### PR TITLE
Patch for queue delay #1896

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -245,11 +245,11 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (! $media) {
+        if (! $media || ! file_get_contents($url = $media->getUrl($conversionName)) ) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 
-        return $media->getUrl($conversionName);
+        return $url;
     }
 
     /*
@@ -265,11 +265,11 @@ trait InteractsWithMedia
     ): string {
         $media = $this->getFirstMedia($collectionName);
 
-        if (! $media) {
+        if (! $media || ! file_get_contents($url = $media->getTemporaryUrl($expiration, $conversionName))) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 
-        return $media->getTemporaryUrl($expiration, $conversionName);
+        return $url;
     }
 
     public function getMediaCollection(string $collectionName = 'default'): ?MediaCollection
@@ -299,11 +299,11 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (! $media) {
+        if (! $media || ! file_exists($url = $media->getPath($conversionName))) {
             return $this->getFallbackMediaPath($collectionName) ?: '';
         }
 
-        return $media->getPath($conversionName);
+        return $url;
     }
 
     /*

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -245,7 +245,7 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (! $media || ! @file_get_contents($url = $media->getUrl($conversionName)) ) {
+        if (! $media || ! @file_get_contents($url = $media->getUrl($conversionName))) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -245,11 +245,11 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (! $media || ! @file_get_contents($url = $media->getUrl($conversionName))) {
+        if (! $media || ! @file_get_contents($media->getPath($conversionName))) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 
-        return $url;
+        return $media->getUrl($conversionName);
     }
 
     /*

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -245,7 +245,7 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (! $media || ! file_get_contents($url = $media->getUrl($conversionName)) ) {
+        if (! $media || ! @file_get_contents($url = $media->getUrl($conversionName)) ) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 
@@ -265,7 +265,7 @@ trait InteractsWithMedia
     ): string {
         $media = $this->getFirstMedia($collectionName);
 
-        if (! $media || ! file_get_contents($url = $media->getTemporaryUrl($expiration, $conversionName))) {
+        if (! $media || ! @file_get_contents($url = $media->getTemporaryUrl($expiration, $conversionName))) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 


### PR DESCRIPTION
> I want create PR for some small feature improvement on `InteractsWithMedia` trait.
> 
> On both `getFirstMediaUrl` and `getFirstMediaPath` method, trait checks,
> 
> if there is some record on DB return it's URL
> if there is not any record found on DB return defined fallback URL.
> 
> So there is one point, if img conversion is queued and queue is not completed work yet.
> At this time `getFirstMediaUrl` will return correct IMG url, but there is not such img exists yet. Because queue is not saved it yet.
> 
> Event queue is working normally there is **1sec delay** happenes when queue saves is as file. So user seeing just missing IMG with correct URL:
> 
> ![image](https://user-images.githubusercontent.com/54883542/82751480-96f6d400-9dc8-11ea-8f2f-302cd4fa9572.png)
> 
> After 1second just refresing page and img will be there. Because queue saved it now.
> 
> ![image](https://user-images.githubusercontent.com/54883542/82751506-be4da100-9dc8-11ea-87ca-e655544b588d.png)
> 
> We need to add additional `file_exists()` check for `getFirstMediaPath()` and `file_get_contents()` check for `getFirstMediaUrl()` .
> 
> If DB record exists but that IMG URL is not exists yet, return fallback IMG URL.
> 
> Also this changes applied to related methods where uses `getFallbackMediaUrl` and `getFallbackMediaPath`.
> 
> **NOTE:**
> 
> I added `file_get_contents` with `@` to don't throw 404 error. It will just return false if note exists.



Main issue is #1896