### PR TITLE
SVG to PNG Conversion Loses Transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,6 @@ To learn how to upgrade, take a look in UPGRADING.md
 ## 7.19.3 - 2020-03-09
 
 - fix responsive images extension (#1752)
-- use native file copy (#1758)
 
 ## 7.19.2 - 2020-03-04
 

--- a/src/Conversions/ImageGenerators/Svg.php
+++ b/src/Conversions/ImageGenerators/Svg.php
@@ -11,12 +11,12 @@ class Svg extends ImageGenerator
 {
     public function convert(string $file, Conversion $conversion = null): string
     {
-        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
+        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.'.$conversion->getResultExtension();
 
         $image = new Imagick();
-        $image->readImage($file);
         $image->setBackgroundColor(new ImagickPixel('none'));
-        $image->setImageFormat('jpg');
+        $image->readImage($file);
+        $image->setImageFormat($conversion->getResultExtension());
 
         file_put_contents($imageFile, $image);
 


### PR DESCRIPTION
I found that PNG conversions were being created with white backgrounds.

Seems you must set the background color before reading the file, otherwise your transparent background is not respected.

I've simply changed the lines around in the Image Generator, and set it to use the result extension as the Imagick file type.