### PR TITLE
Changed freads to fgets as per issue #812

### DIFF
--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -122,7 +122,7 @@ class Filesystem
         $targetFileStream = fopen($targetFile, 'a');
 
         while (! feof($stream)) {
-            $chunk = fread($stream, 1024);
+            $chunk = fgets($stream, 1024);
             fwrite($targetFileStream, $chunk);
         }
 


### PR DESCRIPTION
This fixes the bug on Windows that prevents png resizing when using s3 driver