### PR TITLE
fixing  ftp_rmdir(): Can't remove directory error in #1737 and   #1625

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -185,7 +185,7 @@ class Filesystem
                 try {
                     $this->filesystem->disk($media->disk)->deleteDirectory($directory);
                 } catch (\Exception $e) {
-                    \Log::error($e->getMessage());
+                    report($e->getMessage());
                 }
             });
     }


### PR DESCRIPTION
fixing the error " ftp_rmdir(): Can't remove directory " when using ftp disk . i simply applied #1737 solution and added a try & catch for the deleting function that logs the error instead of throwing it Ï