### PR TITLE
Add ext-exif to prevent composer from stuck.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     ],
     "require": {
         "php": "^7.4",
+        "ext-exif": "*",
         "ext-fileinfo": "*",
         "ext-json": "*",
         "illuminate/bus": "^6.18|^7.0",


### PR DESCRIPTION
Composer sometimes will stuck without any useful message about the inactive extension when install using composer install or composer update. Only can be trace when using composer require method.