### PR TITLE
Revert use statement with correct path to MediaStream Class

### DIFF
--- a/docs/downloading-media/downloading-multiple-files.md
+++ b/docs/downloading-media/downloading-multiple-files.md
@@ -12,7 +12,7 @@ The provided `MediaStream` class that allows you to respond with a stream. Files
 Here's an example on how it can be used:
 
 ```php
-use Spatie\MediaLibrary\MediaStream;
+use Spatie\MediaLibrary\Support\MediaStream;
 
 class DownloadMediaController
 {


### PR DESCRIPTION
I am an idiot, really sorry about this but a while back I sent a pull request to update this. This needs to be reverted back as it was originally correct. I didn't realize I was on v7 and v8 got a huge change in namespaces. 

Pull request below that needs to be reverted. 
https://github.com/spatie/laravel-medialibrary/pull/1958/commits/bea8f9c3e6a9c7e356e9a3532d9f721dc0a595a1