### PR TITLE
Get registered media collections

### DIFF
--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -23,6 +23,16 @@ public function registerMediaCollections(): void
 }
 ```
 
+## Getting registered media collections
+
+To retrieve all registered media collections on your model you can use the `getRegisteredMediaCollections` method.  
+
+```php
+$mediaCollections = $yourModel->getRegisteredMediaCollections();
+```
+
+This returns a collection of `MediaCollection` objects.
+
 ## Defining a fallback URL or path
 
 If your media collection does not contain any items, calling `getFirstMediaUrl` or `getFirstMediaPath` will return `null`. You can change this by setting a fallback url and/or path using `useFallbackUrl` and `useFallbackPath`.

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -294,6 +294,13 @@ trait InteractsWithMedia
         return $media->getTemporaryUrl($expiration, $conversionName);
     }
 
+    public function getRegisteredMediaCollections(): Collection
+    {
+        $this->registerMediaCollections();
+
+        return collect($this->mediaCollections);
+    }
+
     public function getMediaCollection(string $collectionName = 'default'): ?MediaCollection
     {
         $this->registerMediaCollections();

--- a/tests/MediaCollections/MediaCollectionTest.php
+++ b/tests/MediaCollections/MediaCollectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\Tests\MediaCollections;
 
+use Spatie\MediaLibrary\MediaCollections\MediaCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 
@@ -29,5 +30,17 @@ class MediaCollectionTest extends TestCase
         $totalSize = $mediaCollection->totalSizeInBytes();
 
         $this->assertEquals($mediaItem->size + $anotherMediaItem->size, $totalSize);
+    }
+
+    /** @test */
+    public function it_can_get_registered_media_collections()
+    {
+        // the 'avatar' media collection is registered in
+        // \Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel->registerMediaCollections()
+        $collections = $this->testModel->getRegisteredMediaCollections();
+
+        $this->assertCount(1, $collections);
+        $this->assertInstanceOf(MediaCollection::class, $collections->first());
+        $this->assertEquals('avatar', $collections->first()->name);
     }
 }


### PR DESCRIPTION
I have the need to dynamically retrieve the registered media collections on different models in my project and didn't see any existing functionality to do so. I found issue #1159 where it was requested and decided to implement it. (edit: also issues #312 and #803)

It's a simple change, but it removes the need to manually call `$model->registerMediaCollections()` and then access `$model->mediaCollections` directly (with the added bonus of it returning a `Collection` instead of an `array`).

The supporting test checks that the `avatar` media collection that is registered in the test-wide `TestModel` instance is returned, is the right class, and is the right name.

Feedback/suggestions/ideas are absolutely welcomed. Thanks!