### PR TITLE
Add hyphenated separator to default sanitizer

### DIFF
--- a/docs/basic-usage/retrieving-media.md
+++ b/docs/basic-usage/retrieving-media.md
@@ -69,7 +69,7 @@ You can sanitize the filename using a callable:
 $yourModel
    ->addMedia($pathToFile)
    ->sanitizingFileName(function($fileName) {
-      return strtolower(str_replace(['#', '/', '\\', ' '], '-', $fileName));
+      return strtolower(str_replace(['#', '/', '\\', ' - ', ' '], '-', $fileName));
    })
    ->toMediaCollection();
 ```

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -343,7 +343,7 @@ class FileAdder
 
     public function defaultSanitizer(string $fileName): string
     {
-        return str_replace(['#', '/', '\\', ' '], '-', $fileName);
+        return str_replace(['#', '/', '\\', ' - ', ' '], '-', $fileName);
     }
 
     public function sanitizingFileName(callable $fileNameSanitizer): self

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -418,6 +418,18 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function it_will_remove_hyphenated_separators_from_the_file_name()
+    {
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->usingFileName('other - test.jpg')
+            ->toMediaCollection();
+
+        $this->assertEquals('test', $media->name);
+        $this->assertFileExists($this->getMediaDirectory($media->id.'/other-test.jpg'));
+    }
+
+    /** @test */
     public function it_will_sanitize_the_file_name_using_callable()
     {
         $media = $this->testModel


### PR DESCRIPTION
I've been adding a lot of media files today and came across a minor annoyance. If you have a filename that has a hyphenated separator " - " (space hyphen space) you end up with an odd filename due to the way the default sanitizer works. " - " becomes "---", when really it should become a single hyphen "-". For example:

Filename: `A9 - Bird (Quail).pdf`
Sanitized: `A9---Bird-(Quail).pdf`
Should Be: `A9-Bird-(Quail).pdf`

Filename: `Templates - Vehicles - Truck.pdf`
Sanitized: `Templates---Vehicles---Truck.pdf`
Should Be: `Templates-Vehicles-Truck.pdf`

This PR simply adds " - " to the array of strings that are replaced by a single hyphen in the default sanitizer. I also updated the sanitizer example in the docs and added a supporting test.

Thanks!