### PR TITLE
Allow for attributes when copying a media item

### DIFF
--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -248,7 +248,7 @@ class Media extends Model implements Responsable, Htmlable
         return $newMedia;
     }
 
-    public function copy(HasMedia $model, $collectionName = 'default', string $diskName = ''): self
+    public function copy(HasMedia $model, $collectionName = 'default', string $diskName = '', array $attributes = []): self
     {
         $temporaryDirectory = TemporaryDirectory::create();
 
@@ -263,6 +263,7 @@ class Media extends Model implements Responsable, Htmlable
             ->addMedia($temporaryFile)
             ->usingName($this->name)
             ->withCustomProperties($this->custom_properties)
+            ->withAttributes($attributes)
             ->toMediaCollection($collectionName, $diskName);
 
         $temporaryDirectory->delete();


### PR DESCRIPTION
The issue I am trying to solve right now is that when you create a media item `withAttributes()`:

```php
auth()->user()
    ->addMediaFromDisk($image, $this->diskName())
    ->preservingOriginal()
    ->withAttributes([
        'team_id' => $teamId,
    ])
    ->toMediaCollection();
```

and down the road you want to "duplicate"/copy this item, I could usually use the following API:

```php
$media->copy(auth()->user());
```

The problem that arises is that the media item was created *with* custom attributes, which will throw an error when `copy`-ing the item because those attributes are disregarded, similar to this error:

`SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '...' for column 'team_id' at row 1`

This PR adds the ability to add custom attributes when copying media.

