### PR TITLE
Add the ability to pass options to ZipStream.

### DIFF
--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -13,7 +13,7 @@ class MediaStream implements Responsable
 {
     protected string $zipName;
     
-    protected ?ArchiveOptions $zipOptions = null;
+    protected ArchiveOptions $zipOptions;
 
     protected Collection $mediaItems;
 

--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -17,18 +17,23 @@ class MediaStream implements Responsable
 
     protected Collection $mediaItems;
 
-    public static function create(string $zipName, ?ArchiveOptions $zipOptions = null)
+    public static function create(string $zipName)
     {
-        return new static($zipName, $zipOptions);
+        return new static($zipName);
     }
 
-    public function __construct(string $zipName, ?ArchiveOptions $zipOptions = null)
+    public function __construct(string $zipName)
     {
         $this->zipName = $zipName;
-        
-        $this->zipOptions = $zipOptions;
 
         $this->mediaItems = collect();
+    }
+    
+    public function useOptions(ArchiveOptions $zipOptions)
+    {
+        $this->zipOptions = $zipOptions;
+        
+        return $this;
     }
 
     public function addMedia(...$mediaItems): self

--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -13,7 +13,7 @@ class MediaStream implements Responsable
 {
     protected string $zipName;
     
-    protected ?ArchiveOptions $zipOptions;
+    protected ?ArchiveOptions $zipOptions = null;
 
     protected Collection $mediaItems;
 

--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -6,22 +6,27 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use ZipStream\Option\Archive as ArchiveOptions;
 use ZipStream\ZipStream;
 
 class MediaStream implements Responsable
 {
     protected string $zipName;
+    
+    protected ArchiveOptions $zipOptions;
 
     protected Collection $mediaItems;
 
-    public static function create(string $zipName)
+    public static function create(string $zipName, ?ArchiveOptions $zipOptions = null)
     {
-        return new static($zipName);
+        return new static($zipName, $zipOptions);
     }
 
-    public function __construct(string $zipName)
+    public function __construct(string $zipName, ?ArchiveOptions $zipOptions = null)
     {
         $this->zipName = $zipName;
+        
+        $this->zipOptions = $zipOptions;
 
         $this->mediaItems = collect();
     }
@@ -66,7 +71,7 @@ class MediaStream implements Responsable
 
     public function getZipStream(): ZipStream
     {
-        $zip = new ZipStream($this->zipName);
+        $zip = new ZipStream($this->zipName, $this->zipOptions);
 
         $this->getZipStreamContents()->each(function (array $mediaInZip) use ($zip) {
             $stream = $mediaInZip['media']->stream();

--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -13,7 +13,7 @@ class MediaStream implements Responsable
 {
     protected string $zipName;
     
-    protected ArchiveOptions $zipOptions;
+    protected ?ArchiveOptions $zipOptions;
 
     protected Collection $mediaItems;
 

--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -13,7 +13,7 @@ class MediaStream implements Responsable
 {
     protected string $zipName;
     
-    protected ArchiveOptions $zipOptions;
+    protected ?ArchiveOptions $zipOptions = null;
 
     protected Collection $mediaItems;
 


### PR DESCRIPTION
Example of use:

```php
<?php

namespace App\Http\Controllers\Products;

use App\Models\Product;
use Spatie\MediaLibrary\Support\MediaStream;
use App\Http\Controllers\Controller;
use ZipStream\Option\Archive as ArchiveOptions;

class DownloadProductAttachmentsController extends Controller
{
    public function __invoke(Product $product)
    {
        $downloads = $product->getMedia('attachments');

        $zipOptions = new ArchiveOptions;

        $zipOptions->setZeroHeader(true);

        return MediaStream::create(str_slug($product->name).'.zip', $zipOptions)->addMedia($downloads);
   }
}
```