### PR TITLE
Avoid useless renaming in zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 8.5.0 - 2020-08-06
+
+- add method to get registered media collections (#1976)
+
 ## 8.4.1 - 2020-08-03
 
 - add `addMediaFromString`

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 ## Documentation
 
-
 You'll find the documentation on [https://docs.spatie.be/laravel-medialibrary/v8](https://docs.spatie.be/laravel-medialibrary/v8).
 
 Find yourself stuck using the package? Found a bug? Do you have general questions or suggestions for improving the media library? Feel free to [create an issue on GitHub](https://github.com/spatie/laravel-medialibrary/issues), we'll try to address it as soon as possible.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 ## Documentation
 
+
 You'll find the documentation on [https://docs.spatie.be/laravel-medialibrary/v8](https://docs.spatie.be/laravel-medialibrary/v8).
 
 Find yourself stuck using the package? Found a bug? Do you have general questions or suggestions for improving the media library? Feel free to [create an issue on GitHub](https://github.com/spatie/laravel-medialibrary/issues), we'll try to address it as soon as possible.

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -101,6 +101,36 @@ class MediaStreamTest extends TestCase
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
     }
 
+    public function media_with_zip_file_folder_prefix_property_saved_in_correct_zip_folder_and_correct_suffix()
+    {
+        foreach (range(1, 2) as $i) {
+            $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->preservingOriginal()
+                ->withCustomProperties([
+                    'zip_filename_prefix' => 'folder/subfolder/',
+                ])
+                ->toMediaCollection();
+        }
+
+        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+        ob_start();
+        @$zipStreamResponse->toResponse(request())->sendContent();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $temporaryDirectory = (new TemporaryDirectory())->create();
+        file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test.jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (3).jpg');
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (2).jpg');
+    }
+
     /** @test */
     public function media_with_zip_file_prefix_property_saved_with_correct_prefix()
     {

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -98,7 +98,7 @@ class MediaStreamTest extends TestCase
 
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
 
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (3).jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
     }
 
     /** @test */

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -122,6 +122,6 @@ class MediaStreamTest extends TestCase
         $temporaryDirectory = (new TemporaryDirectory())->create();
         file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'just_a_string_prefix test (3).jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'just_a_string_prefix test.jpg');
     }
 }


### PR DESCRIPTION
Using "zip_filename_prefix" custom property, a zip file can contain files with same name but not in the same directory, so rename it is useless.