### PR TITLE
Added getMedia('*') to retrieving all media with any collection_name

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -505,8 +505,11 @@ trait InteractsWithMedia
             ? $this->media
             : collect($this->unAttachedMediaLibraryItems)->pluck('media');
 
+        if ($collectionName !== '*')
+            $collection = $collection
+                ->filter(fn(Media $mediaItem) => $mediaItem->collection_name === $collectionName);
+
         return $collection
-            ->filter(fn(Media $mediaItem) => $mediaItem->collection_name === $collectionName)
             ->sortBy('order_column')
             ->values();
     }


### PR DESCRIPTION
how can I delete model's media with any collection type.

getMedia() returns all media with default value. but I need all media with any collection type

I offer you to add this feature: getMedia("*")