### PR TITLE
add support to include `ResponsiveImages` based on condition

### DIFF
--- a/docs/responsive-images/getting-started-with-responsive-images.md
+++ b/docs/responsive-images/getting-started-with-responsive-images.md
@@ -71,8 +71,8 @@ When adding an images to the media library simply use the `withResponsiveImages`
 $yourModel
    ->addMedia($yourImageFile)
    ->withResponsiveImages()
-   // or if you want to add if based on condition then use
-   ->withResponsiveImagesIf($condition) // accepts "function or boolean"
+   // or if you want to add it based on a condition then use
+   ->withResponsiveImagesIf($condition) // accepts "closure or boolean"
    ->toMediaCollection();
 ```
 

--- a/docs/responsive-images/getting-started-with-responsive-images.md
+++ b/docs/responsive-images/getting-started-with-responsive-images.md
@@ -71,6 +71,8 @@ When adding an images to the media library simply use the `withResponsiveImages`
 $yourModel
    ->addMedia($yourImageFile)
    ->withResponsiveImages()
+   // or if you want to add if based on condition then use
+   ->withResponsiveImagesIf($condition) // accepts "function or boolean"
    ->toMediaCollection();
 ```
 

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -187,6 +187,13 @@ class FileAdder
         return $this;
     }
 
+    public function withResponsiveImagesIf($condition): self
+    {
+        $this->generateResponsiveImages = (bool) (is_callable($condition) ? $condition() : $condition);
+
+        return $this;
+    }
+
     public function addCustomHeaders(array $customRemoteHeaders): self
     {
         $this->customHeaders = $customRemoteHeaders;
@@ -248,8 +255,6 @@ class FileAdder
 
         return $media;
     }
-
-
 
     public function toMediaCollection(string $collectionName = 'default', string $diskName = ''): Media
     {

--- a/src/MediaCollections/MediaCollection.php
+++ b/src/MediaCollections/MediaCollection.php
@@ -123,11 +123,7 @@ class MediaCollection
 
     public function withResponsiveImagesIf($condition): self
     {
-        if (is_callable($condition)) {
-            $this->generateResponsiveImages = $condition();
-        } else {
-            $this->generateResponsiveImages = $condition;
-        }
+        $this->generateResponsiveImages = (bool) (is_callable($condition) ? $condition() : $condition);
 
         return $this;
     }

--- a/src/MediaCollections/MediaCollection.php
+++ b/src/MediaCollections/MediaCollection.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\MediaLibrary\MediaCollections;
 
-use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
+use Illuminate\Support\Traits\Macroable;
 
 class MediaCollection
 {
@@ -114,9 +114,20 @@ class MediaCollection
         return $this;
     }
 
-    public function withResponsiveImages($add = true): self
+    public function withResponsiveImages(): self
     {
-        $this->generateResponsiveImages = $add;
+        $this->generateResponsiveImages = true;
+
+        return $this;
+    }
+
+    public function withResponsiveImagesIf($condition): self
+    {
+        if (is_callable($condition)) {
+            $this->generateResponsiveImages = $condition();
+        } else {
+            $this->generateResponsiveImages = $condition;
+        }
 
         return $this;
     }

--- a/src/MediaCollections/MediaCollection.php
+++ b/src/MediaCollections/MediaCollection.php
@@ -114,9 +114,9 @@ class MediaCollection
         return $this;
     }
 
-    public function withResponsiveImages(): self
+    public function withResponsiveImages($add = true): self
     {
-        $this->generateResponsiveImages = true;
+        $this->generateResponsiveImages = $add;
 
         return $this;
     }

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -202,6 +202,33 @@ class MediaCollectionTest extends TestCase
         $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));
     }
 
+    /** @test * */
+    public function it_can_generate_responsive_images_on_condition()
+    {
+        $testModel = new class extends TestModelWithConversion {
+            public function registerMediaCollections(): void
+            {
+                $this
+                    ->addMediaCollection('images')
+                    ->withResponsiveImagesIf(true);
+            }
+        };
+
+        $model = $testModel::create(['name' => 'testmodel']);
+
+        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+        $media = $model->getMedia('images')->first();
+
+        $this->assertEquals([
+            'http://localhost/media/1/responsive-images/test___media_library_original_340_280.jpg',
+            'http://localhost/media/1/responsive-images/test___media_library_original_284_233.jpg',
+            'http://localhost/media/1/responsive-images/test___media_library_original_237_195.jpg',
+        ], $media->getResponsiveImageUrls());
+
+        $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));
+    }
+
     /** @test */
     public function if_the_single_file_method_is_specified_it_will_delete_all_other_media_and_will_only_keep_the_new_one()
     {

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -26,7 +26,7 @@ class ResponsiveImageGeneratorTest extends TestCase
     {
         $this->testModel
                 ->addMedia($this->getTestJpg())
-                ->withResponsiveImagesIf(fn () => 1 == '1')
+                ->withResponsiveImagesIf(fn () => 1 === '1')
                 ->toMediaCollection();
 
         $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_237_195.jpg'));

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -22,6 +22,19 @@ class ResponsiveImageGeneratorTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_responsive_images_on_condition()
+    {
+        $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->withResponsiveImagesIf(fn () => 1 == '1')
+                ->toMediaCollection();
+
+        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_237_195.jpg'));
+        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_284_233.jpg'));
+        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_340_280.jpg'));
+    }
+
+    /** @test */
     public function its_conversions_can_have_responsive_images()
     {
         $this->testModelWithResponsiveImages

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -22,16 +22,27 @@ class ResponsiveImageGeneratorTest extends TestCase
     }
 
     /** @test */
-    public function it_can_generate_responsive_images_on_condition()
+    public function it_will_generate_responsive_images_if_withResponsiveImagesIf_returns_true()
     {
         $this->testModel
                 ->addMedia($this->getTestJpg())
-                ->withResponsiveImagesIf(fn () => 1 === '1')
+                ->withResponsiveImagesIf(fn () => true)
                 ->toMediaCollection();
 
         $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_237_195.jpg'));
         $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_284_233.jpg'));
         $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_340_280.jpg'));
+    }
+    
+        /** @test */
+    public function it_will_not_generate_responsive_images_if_withResponsiveImagesIf_returns_false()
+    {
+        $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->withResponsiveImagesIf(fn () => false)
+                ->toMediaCollection();
+
+        $this->assertFileDoesNotExist($this->getTempDirectory('media/1/responsive-images/test___media_library_original_237_195.jpg'));
     }
 
     /** @test */


### PR DESCRIPTION
allow `withResponsiveImages` to be added based on condition, this is useful if you have multiple media collections with the same characteristics but you need the responsive images for only one ex.

```php
public function registerMediaCollections(): void
{
    $singles = ['cover', 'scan'];

    foreach ($singles as $item) {
        $this->addMediaCollection($item)
            ->useFallbackUrl(asset('images/ph.png'))
            ->useFallbackPath(public_path('images/ph.png'))
            ->withResponsiveImages($item != 'scan')
            ->singleFile();
    }
}
```