### PR TITLE
fix `img` doesnt work with null 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ phpunit.xml
 .env
 .phpunit.result.cache
 .php_cs.cache
+.history

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -250,11 +250,11 @@ trait InteractsWithMedia
         return app(MediaRepository::class)->getCollection($this, $collectionName, $filters);
     }
 
-    public function getFirstMedia(string $collectionName = 'default', $filters = []): ?Media
+    public function getFirstMedia(string $collectionName = 'default', $filters = []): ?object
     {
         $media = $this->getMedia($collectionName, $filters);
 
-        return $media->first();
+        return optional($media->first());
     }
 
     /*
@@ -266,7 +266,7 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (!$media) {
+        if (!$media->first()) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 
@@ -287,7 +287,7 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (!$media) {
+        if (!$media->first()) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 
@@ -328,7 +328,7 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (!$media) {
+        if (!$media->first()) {
             return $this->getFallbackMediaPath($collectionName) ?: '';
         }
 

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -3,26 +3,27 @@
 namespace Spatie\MediaLibrary;
 
 use DateTimeInterface;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Http\File;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Optional;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\MediaLibrary\Conversions\Conversion;
-use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenCleared;
-use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidBase64Data;
-use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidUrl;
-use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeDeleted;
-use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeUpdated;
-use Spatie\MediaLibrary\MediaCollections\Exceptions\MimeTypeNotAllowed;
-use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
 use Spatie\MediaLibrary\MediaCollections\FileAdder;
-use Spatie\MediaLibrary\MediaCollections\FileAdderFactory;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\MediaCollections\MediaCollection;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\MediaCollections\FileAdderFactory;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidUrl;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidBase64Data;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\MimeTypeNotAllowed;
+use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenCleared;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeDeleted;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeUpdated;
 
 trait InteractsWithMedia
 {
@@ -154,7 +155,6 @@ trait InteractsWithMedia
             ->usingFileName($filename);
     }
 
-
     /**
      * Add a file to the media library that contains the given string.
      *
@@ -250,7 +250,7 @@ trait InteractsWithMedia
         return app(MediaRepository::class)->getCollection($this, $collectionName, $filters);
     }
 
-    public function getFirstMedia(string $collectionName = 'default', $filters = []): ?object
+    public function getFirstMedia(string $collectionName = 'default', $filters = []): Optional
     {
         $media = $this->getMedia($collectionName, $filters);
 
@@ -266,7 +266,7 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (!$media->first()) {
+        if (!$media->value) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 
@@ -287,7 +287,7 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (!$media->first()) {
+        if (!$media->value) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 
@@ -328,7 +328,7 @@ trait InteractsWithMedia
     {
         $media = $this->getFirstMedia($collectionName);
 
-        if (!$media->first()) {
+        if (!$media->value) {
             return $this->getFallbackMediaPath($collectionName) ?: '';
         }
 
@@ -454,7 +454,7 @@ trait InteractsWithMedia
 
         $media = $this->media->find($mediaId);
 
-        if (!$media) {
+        if (!$media->value) {
             throw MediaCannotBeDeleted::doesNotBelongToModel($mediaId, $this);
         }
 

--- a/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
@@ -60,7 +60,7 @@ class DeleteMediaTest extends TestCase
 
         $this->testModelWithoutMediaConversions->clearMediaCollectionExcept('images', $excludedMedia);
 
-        $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[0], $excludedMedia);
+        $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[0], $excludedMedia->value);
         $this->assertCount(1, $this->testModelWithoutMediaConversions->getMedia('images'));
     }
 

--- a/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
@@ -72,7 +72,7 @@ class DeleteMediaTest extends TestCase
 
         $this->addMedia($testModel);
 
-        $this->assertInstanceOf(TestCustomMediaModel::class, $testModel->getFirstMedia());
+        $this->assertInstanceOf(TestCustomMediaModel::class, $testModel->getFirstMedia()->value);
 
         $ids = $testModel->getMedia('images')->pluck('id');
 

--- a/tests/ResponsiveImages/RegisteredResponsiveImagesTest.php
+++ b/tests/ResponsiveImages/RegisteredResponsiveImagesTest.php
@@ -32,7 +32,7 @@ class RegisteredResponsiveImagesTest extends TestCase
             ->withResponsiveImages()
             ->toMediaCollection();
 
-        $media = $this->testModel->getFirstMedia();
+        $media = $this->testModel->getFirstMedia()->value;
 
         $responsiveImages = $media->responsive_images;
 


### PR DESCRIPTION
a partial fix for https://github.com/spatie/laravel-medialibrary/issues/2035

for now to use any of https://github.com/spatie/laravel-medialibrary/blob/master/src/MediaCollections/HtmlableMedia.php methods like `lazy, attributes, etc..` you will have to use optional in your blade file ex.

```blade
{{ optional($item->getFirstMedia('cover')->img('', ['class' => 'extra class']))->lazy() }}
```

also reflected the new change to the other methods that depend on the `getFirstMedia` 

