### PR TITLE
Allow to change the way the images are being downloaded

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -92,13 +92,6 @@ return [
     'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
 
     /*
-     * When using the addMediaFromUrl method you may want to replace the default downloader.
-     * This is particularly useful when the url of the image is behind a firewall and
-     * need to add additional flags, possibly using curl.
-     */
-    'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
-
-    /*
      * Whether to activate versioning when urls to files get generated.
      * When activated, this attaches a ?v=xx query string to the URL.
      */
@@ -170,4 +163,12 @@ return [
         'perform_conversions' => \Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
         'generate_responsive_images' => \Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
     ],
+
+    /*
+     * When using the addMediaFromUrl method you may want to replace the default downloader.
+     * This is particularly useful when the url of the image is behind a firewall and
+     * need to add additional flags, possibly using curl.
+     */
+    'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
+
 ];

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -92,6 +92,13 @@ return [
     'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
 
     /*
+     * When using the addMediaFromUrl method you may want to replace the default downloader.
+     * This is particularly useful when the url of the image is behind a firewall and
+     * need to add additional flags, possibly using curl.
+     */
+    'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
+
+    /*
      * Whether to activate versioning when urls to files get generated.
      * When activated, this attaches a ?v=xx query string to the URL.
      */

--- a/docs/advanced-usage/using-a-custom-media-downloader.md
+++ b/docs/advanced-usage/using-a-custom-media-downloader.md
@@ -42,9 +42,4 @@ class CustomDownloader {
     }
 
 }
-
-
-
-
 ```
-

--- a/docs/advanced-usage/using-a-custom-media-downloader.md
+++ b/docs/advanced-usage/using-a-custom-media-downloader.md
@@ -39,6 +39,8 @@ class CustomDownloader {
         }
         curl_close($curl);
         fclose($fh);
+
+        return $temporaryFile;
     }
 
 }

--- a/docs/advanced-usage/using-a-custom-media-downloader.md
+++ b/docs/advanced-usage/using-a-custom-media-downloader.md
@@ -1,0 +1,50 @@
+---
+title: Using a custom media downloader
+weight: 6
+---
+
+By default, when using the `addMediaFromUrl` method, the package internally uses `fopen` to download the media. In some cases though, the media can be behind a firewall or you need to attach specific headers to get access.
+
+To do that, you can specify your own Media Downloader. Simply create a class that included a `getTempFile` method.
+
+For example, you may want to use curl as a way to download media.
+
+```php
+use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
+
+class CustomDownloader {
+
+    public function getTempFile($url){
+        $temporaryFile = tempnam(sys_get_temp_dir(), 'media-library');
+        $fh = fopen($temporaryFile, 'w');
+
+        $curl = curl_init($url);
+        $options = [
+            CURLOPT_RETURNTRANSFER  => true,
+            CURLOPT_FAILONERROR     => true,
+            CURLOPT_FILE            => $fh,
+            CURLOPT_TIMEOUT         => 35,
+        ];
+        $headers = [
+            'Content-Type: image/*',
+            'User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:28.0) Gecko/20100101 Firefox/28.0',
+        ];
+        curl_setopt_array($curl, $options);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+
+        if (false === curl_exec($curl)) {
+            curl_close($curl);
+            fclose($fh);
+            throw UnreachableUrl::create($url);
+        }
+        curl_close($curl);
+        fclose($fh);
+    }
+
+}
+
+
+
+
+```
+

--- a/docs/advanced-usage/using-a-custom-media-downloader.md
+++ b/docs/advanced-usage/using-a-custom-media-downloader.md
@@ -5,14 +5,15 @@ weight: 6
 
 By default, when using the `addMediaFromUrl` method, the package internally uses `fopen` to download the media. In some cases though, the media can be behind a firewall or you need to attach specific headers to get access.
 
-To do that, you can specify your own Media Downloader. Simply create a class that included a `getTempFile` method.
+To do that, you can specify your own Media Downloader by creating a class that implements the Downloadder interface. This method must fetch the resource and return the location of the temporary file.
 
-For example, you may want to use curl as a way to download media.
+For example, consider the following example which uses curl with custom headers to fetch the media.
 
 ```php
+use Spatie\MediaLibrary\Downloaders\Downloader;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
 
-class CustomDownloader {
+class CustomDownloader implements Downloader {
 
     public function getTempFile($url){
         $temporaryFile = tempnam(sys_get_temp_dir(), 'media-library');

--- a/src/Downloaders/DefaultDownloader.php
+++ b/src/Downloaders/DefaultDownloader.php
@@ -4,7 +4,7 @@ namespace Spatie\MediaLibrary\Downloaders;
 
 use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
 
-class DefaultDownloader
+class DefaultDownloader implements Downloader
 {
     public function getTempFile(string $url): string
     {

--- a/src/Downloaders/DefaultDownloader.php
+++ b/src/Downloaders/DefaultDownloader.php
@@ -6,6 +6,11 @@ use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
 
 class DefaultDownloader
 {
+    /**
+     * @param $url
+     * @return false|string
+     * @throws UnreachableUrl
+     */
     public function getTempFile($url)
     {
         if (!$stream = @fopen($url, 'r')) {

--- a/src/Downloaders/DefaultDownloader.php
+++ b/src/Downloaders/DefaultDownloader.php
@@ -6,18 +6,14 @@ use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
 
 class DefaultDownloader
 {
-    /**
-     * @param $url
-     * @return false|string
-     * @throws UnreachableUrl
-     */
-    public function getTempFile($url)
+    public function getTempFile(string $url): string
     {
         if (!$stream = @fopen($url, 'r')) {
             throw UnreachableUrl::create($url);
         }
 
         $temporaryFile = tempnam(sys_get_temp_dir(), 'media-library');
+        
         file_put_contents($temporaryFile, $stream);
 
         return $temporaryFile;

--- a/src/Downloaders/DefaultDownloader.php
+++ b/src/Downloaders/DefaultDownloader.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\MediaLibrary\Downloaders;
+
+use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
+
+class DefaultDownloader
+{
+    public function getTempFile($url)
+    {
+        if (!$stream = @fopen($url, 'r')) {
+            throw UnreachableUrl::create($url);
+        }
+
+        $temporaryFile = tempnam(sys_get_temp_dir(), 'media-library');
+        file_put_contents($temporaryFile, $stream);
+
+        return $temporaryFile;
+    }
+}

--- a/src/Downloaders/Downloader.php
+++ b/src/Downloaders/Downloader.php
@@ -4,5 +4,5 @@ namespace Spatie\MediaLibrary\Downloaders;
 
 interface Downloader
 {
-    public function getTempFile($url);
+    public function getTempFile(string $url): string;
 }

--- a/src/Downloaders/Downloader.php
+++ b/src/Downloaders/Downloader.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\MediaLibrary\Downloaders;
+
+interface Downloader
+{
+    public function getTempFile($url);
+}

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -18,7 +18,6 @@ use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidUrl;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeDeleted;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeUpdated;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\MimeTypeNotAllowed;
-use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
 use Spatie\MediaLibrary\MediaCollections\FileAdder;
 use Spatie\MediaLibrary\MediaCollections\FileAdderFactory;
 use Spatie\MediaLibrary\MediaCollections\MediaCollection;

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\Downloaders\DefaultDownloader;
 use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenCleared;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidBase64Data;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidUrl;
@@ -126,13 +127,8 @@ trait InteractsWithMedia
             throw InvalidUrl::doesNotStartWithProtocol($url);
         }
 
-        if (!$stream = @fopen($url, 'r')) {
-            throw UnreachableUrl::create($url);
-        }
-
-        $temporaryFile = tempnam(sys_get_temp_dir(), 'media-library');
-        file_put_contents($temporaryFile, $stream);
-
+        $downloader = config('media-library.media_downloader', DefaultDownloader::class);
+        $temporaryFile = (new $downloader)->getTempFile($url);
         $this->guardAgainstInvalidMimeType($temporaryFile, $allowedMimeTypes);
 
         $filename = basename(parse_url($url, PHP_URL_PATH));


### PR DESCRIPTION
We have a case were the images cannot be downloaded using `fopen` but instead a client should be used. With this changes we will be able to change how the image is downloaded and instead use either curl (with additional headers) or something else.

Let me know if you want me to add an interface there or even another downloader (curl) as an option.

This is backwards compatible.