### PR TITLE
Allow ZipStream 2.0 (backport from v8)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "illuminate/pipeline": "~5.8.35|^6.0|^7.0",
     "illuminate/support": "~5.8.35|^6.0|^7.0",
     "league/flysystem": "^1.0.8",
-    "maennchen/zipstream-php": "^1.0",
+    "maennchen/zipstream-php": "^1.0|^2.0",
     "spatie/image": "^1.4.0",
     "spatie/pdf-to-image": "^2.0",
     "spatie/temporary-directory": "^1.1",


### PR DESCRIPTION
I'm running into dependency constraints as other packages require ZipStream 2.0. Unfortunately we can't use PHP 7.4 yet (latest minus one policy...), so we can't install v8. I was hoping we can backport #1812 to v7 so we're able to install those other dependencies as well.