### PR TITLE
Fix file deletion problem

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -176,6 +176,10 @@ class Filesystem
     public function removeAllFiles(Media $media): void
     {
         $mediaDirectory = $this->getMediaDirectory($media);
+        
+        if ($media->disk !== $media->conversions_disk) {
+            $this->filesystem->disk($media->disk)->deleteDirectory($mediaDirectory);
+        }
 
         $conversionsDirectory = $this->getMediaDirectory($media, 'conversions');
 

--- a/tests/Feature/FileAdder/ConversionsDiskTest.php
+++ b/tests/Feature/FileAdder/ConversionsDiskTest.php
@@ -60,6 +60,9 @@ class ConversionsDiskTest extends TestCase
         $media->delete();
 
         $this->assertFileDoesNotExist($media->getPath('thumb'));
+
+        $originalFilePath = $media->getPath();
+        $this->assertFileDoesNotExist($originalFilePath);
     }
 
     /** @test */


### PR DESCRIPTION
When you delete a media item from a media collection the original file and its directory won't be deleted if you use a different disk for storing the conversions, only the files and directories used on the conversion disk will be deleted.

I noticed this when working with a single file collection where I use a private directory for the original uploaded file and a public directory for the conversions. 

My solution is to add a dedicated **deleteDirectory** call for the original file path if a different disk is being used for the conversions.  I've added a simple assertion test to make sure the original file is being deleted when this is the case.