### PR TITLE
Fix for default lazy="auto" value

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -68,17 +68,17 @@ return [
      * a `loading` attribute to the `img` tag. Here you can set the default
      * value of that attribute.
      *
-     * Possible values: 'auto', 'lazy' and 'eager,
+     * Possible values: 'lazy', 'eager', 'auto' or null if you don't want to set any loading instruction.
      *
      * More info: https://css-tricks.com/native-lazy-loading/
      */
-    'default_loading_attribute_value' => 'auto',
+    'default_loading_attribute_value' => null,
 
     /*
      * This is the class that is responsible for naming conversion files. By default,
      * it will use the filename of the original and concatenate the conversion name to it.
      */
-    'conversion_file_namer' => \Spatie\MediaLibrary\Conversions\DefaultConversionFileNamer::class,
+    'conversion_file_namer' => Spatie\MediaLibrary\Conversions\DefaultConversionFileNamer::class,
 
     /*
      * The class that contains the strategy for determining a media file's path.
@@ -160,7 +160,7 @@ return [
      * your custom jobs extend the ones provided by the package.
      */
     'jobs' => [
-        'perform_conversions' => \Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
-        'generate_responsive_images' => \Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
+        'perform_conversions' => Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
+        'generate_responsive_images' => Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
     ],
 ];

--- a/docs/api/defining-conversions.md
+++ b/docs/api/defining-conversions.md
@@ -50,7 +50,7 @@ public function nonQueued(): self
 
 ### useLoadingAttributeValue
 
-This is the value that, when this conversation is converted to html, will be used in the `loading` attribute. The loading attribute is a standardised attribute that controls lazy loading behaviour of the browser. Possible values are `lazy`, `eager` and `auto`.
+This is the value that, when this conversation is converted to html, will be used in the `loading` attribute. The loading attribute is a standardised attribute that controls lazy loading behaviour of the browser. Possible values are `lazy`, `eager`, `auto` or null if you don't want to set any loading instruction.
 
 You can learn more on native lazy loading [in this post on css-tricks](https://css-tricks.com/native-lazy-loading/).
 

--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -1,1 +1,1 @@
-<img{!! $attributeString !!} loading="{{ $loadingAttributeValue }}" src="{{ $media->getUrl($conversion) }}" alt="{{ $media->name }}">
+<img{!! $attributeString !!}@if($loadingAttributeValue) loading="{{ $loadingAttributeValue }}"@endif src="{{ $media->getUrl($conversion) }}" alt="{{ $media->name }}">

--- a/resources/views/responsiveImage.blade.php
+++ b/resources/views/responsiveImage.blade.php
@@ -1,1 +1,1 @@
-<img{!! $attributeString !!} loading="{{ $loadingAttributeValue }}" srcset="{{ $media->getSrcset($conversion) }}" src="{{ $media->getUrl($conversion) }}" width="{{ $width }}">
+<img{!! $attributeString !!}@if($loadingAttributeValue) loading="{{ $loadingAttributeValue }}"@endif srcset="{{ $media->getSrcset($conversion) }}" src="{{ $media->getUrl($conversion) }}" width="{{ $width }}">

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -25,7 +25,7 @@ class Conversion
 
     protected bool $generateResponsiveImages = false;
 
-    protected string $loadingAttributeValue;
+    protected ?string $loadingAttributeValue;
 
     protected int $pdfPageNumber = 1;
 
@@ -228,7 +228,7 @@ class Conversion
         return $this;
     }
 
-    public function getLoadingAttributeValue(): string
+    public function getLoadingAttributeValue(): ?string
     {
         return $this->loadingAttributeValue;
     }

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -26,7 +26,7 @@ class ToHtmlTest extends TestCase
     public function it_can_render_itself_as_an_image()
     {
         $this->assertEquals(
-            '<img loading="auto" src="/media/1/test.jpg" alt="test">',
+            '<img src="/media/1/test.jpg" alt="test">',
             $this->firstMedia()->img(),
         );
     }
@@ -35,7 +35,7 @@ class ToHtmlTest extends TestCase
     public function it_can_render_a_conversion_of_itself_as_an_image()
     {
         $this->assertEquals(
-            '<img loading="auto" src="/media/1/conversions/test-thumb.jpg" alt="test">',
+            '<img src="/media/1/conversions/test-thumb.jpg" alt="test">',
             $this->firstMedia()->img('thumb')
         );
     }
@@ -44,7 +44,7 @@ class ToHtmlTest extends TestCase
     public function it_can_render_extra_attributes()
     {
         $this->assertEquals(
-            '<img class="my-class" id="my-id" loading="auto" src="/media/1/conversions/test-thumb.jpg" alt="test">',
+            '<img class="my-class" id="my-id" src="/media/1/conversions/test-thumb.jpg" alt="test">',
             $this->firstMedia()->img('thumb', ['class' => 'my-class', 'id' => 'my-id']),
         );
     }
@@ -57,7 +57,7 @@ class ToHtmlTest extends TestCase
         $renderedView = $this->renderView('media', compact('media'));
 
         $this->assertEquals(
-            '<img loading="auto" src="/media/1/test.jpg" alt="test"> <img loading="auto" src="/media/1/conversions/test-thumb.jpg" alt="test">',
+            '<img src="/media/1/test.jpg" alt="test"> <img src="/media/1/conversions/test-thumb.jpg" alt="test">',
             $renderedView,
         );
     }
@@ -111,7 +111,7 @@ class ToHtmlTest extends TestCase
 
         $imgTag = $media->refresh()->img();
 
-        $this->assertEquals('<img loading="auto" srcset="http://localhost/media/2/responsive-images/test___media_library_original_340_280.jpg 340w, http://localhost/media/2/responsive-images/test___media_library_original_284_233.jpg 284w, http://localhost/media/2/responsive-images/test___media_library_original_237_195.jpg 237w" src="/media/2/test.jpg" width="340">', $imgTag);
+        $this->assertEquals('<img srcset="http://localhost/media/2/responsive-images/test___media_library_original_340_280.jpg 340w, http://localhost/media/2/responsive-images/test___media_library_original_284_233.jpg 284w, http://localhost/media/2/responsive-images/test___media_library_original_237_195.jpg 237w" src="/media/2/test.jpg" width="340">', $imgTag);
     }
 
     /** @test */
@@ -122,7 +122,7 @@ class ToHtmlTest extends TestCase
             ->toMediaCollection();
 
         $originalImgTag = $media->refresh()->img();
-        $this->assertEquals('<img loading="auto" src="/media/2/test.jpg" alt="test">', $originalImgTag);
+        $this->assertEquals('<img src="/media/2/test.jpg" alt="test">', $originalImgTag);
 
         $lazyConversionImageTag = $media->refresh()->img('lazy-conversion');
         $this->assertEquals('<img loading="lazy" src="/media/2/conversions/test-lazy-conversion.jpg" alt="test">', $lazyConversionImageTag);
@@ -144,7 +144,7 @@ class ToHtmlTest extends TestCase
     public function it_can_set_extra_attributes()
     {
         $this->assertEquals(
-            '<img extra="value" loading="auto" src="/media/1/test.jpg" alt="test">',
+            '<img extra="value" src="/media/1/test.jpg" alt="test">',
             (string) $this->firstMedia()->img()->attributes(['extra' => 'value'])
         );
     }


### PR DESCRIPTION
As discussed here https://github.com/spatie/laravel-medialibrary/issues/2079, here is my proposal to replace the default `default_loading_attribute_value` by `null` instead of `auto`, as this last value is not mentioned in W3C specifications and is breaking the W3C Markup Validation Service.

Setting `null` allow to set no `loading` HTML attribute by default (same as the expected behavior for `auto`).