### PR TITLE
Global queue conversions management

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -21,6 +21,12 @@ return [
     'queue_name' => '',
 
     /*
+     * Choose if your conversions should be generated in queue by default.
+     * Set `false` to have them generated synchronously.
+     */
+    'queue_conversions_by_default' => env('QUEUE_CONVERSIONS_BY_DEFAULT', true),
+
+    /*
      * The fully qualified class name of the media model.
      */
     'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
@@ -58,13 +64,13 @@ return [
 
         /*
          * This class will generate the tiny placeholder used for progressive image loading. By default
-         * the medialibrary will use a tiny blurred jpg image.
+         * the media library will use a tiny blurred jpg image.
          */
         'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
     ],
 
     /*
-     * When converting Media instances to response the medialibrary will add
+     * When converting Media instances to response the media library will add
      * a `loading` attribute to the `img` tag. Here you can set the default
      * value of that attribute.
      *

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -21,8 +21,7 @@ return [
     'queue_name' => '',
 
     /*
-     * Choose if your conversions should be generated in queue by default.
-     * Set `false` to have them generated synchronously.
+     * By default all conversions will be performed on a queue.
      */
     'queue_conversions_by_default' => env('QUEUE_CONVERSIONS_BY_DEFAULT', true),
 

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -109,13 +109,7 @@ $media->getUrl('thumb') // returns ''
 
 ## Queuing conversions
 
-According to your [configuration settings](https://docs.spatie.be/laravel-medialibrary/v8/installation-setup), your conversions may be generated in queue by default or not.
-
-By setting your `queue_conversions_by_default` config value to `true`, conversions will all be added to the queue that you've specified in the `queue_name` config value.
-
-If you want the opposite behavior, then set your `queue_conversions_by_default` config value to `false` to get all your conversions generated synchronously.
-
-In case you need to override the global configuration for a given conversion, use the `queued` or the `nonQueued` method to define the way it should be generated.
+By default, a conversion will be added to the queue that you've [specified in the configuration](https://docs.spatie.be/laravel-medialibrary/v8/installation-setup). If you want your image to be created directly (and not on a queue) use `nonQueued` on a conversion.
 
 ```php
 // in your model
@@ -124,11 +118,22 @@ public function registerMediaConversions(Media $media = null): void
     $this->addMediaConversion('thumb')
             ->width(368)
             ->height(232)
-            //->queued() // will be generated asynchronously in queue
             ->nonQueued(); // will be generated synchronously
 }
 ```
 
+If you have set `queue_conversions_by_default` in the `media-library` config file to `false`, all conversions will all be generated synchronously. If you want to generate a conversion on a queue, while `queue_conversions_by_default` is set to `false`, use the `queued` method.
+
+```php
+// in your model
+public function registerMediaConversions(Media $media = null): void
+{
+    $this->addMediaConversion('thumb')
+            ->width(368)
+            ->height(232)
+            ->queued(); // will be generated on a queue
+}
+```
 
 ## Using model properties in a conversion
 

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -109,7 +109,13 @@ $media->getUrl('thumb') // returns ''
 
 ## Queuing conversions
 
-By default, a conversion will be added to the queue that you've [specified in the configuration](https://docs.spatie.be/laravel-medialibrary/v8/installation-setup). If you want your image to be created directly (and not on a queue) use `nonQueued` on a conversion.
+According to your [configuration settings](https://docs.spatie.be/laravel-medialibrary/v8/installation-setup), your conversions may be generated in queue by default or not.
+
+By setting your `queue_conversions_by_default` config value to `true`, conversions will all be added to the queue that you've specified in the `queue_name` config value.
+
+If you want the opposite behavior, then set your `queue_conversions_by_default` config value to `false` to get all your conversions generated synchronously.
+
+In case you need to override the global configuration for a given conversion, use the `queued` or the `nonQueued` method to define the way it should be generated.
 
 ```php
 // in your model
@@ -118,7 +124,8 @@ public function registerMediaConversions(Media $media = null): void
     $this->addMediaConversion('thumb')
             ->width(368)
             ->height(232)
-            ->nonQueued();
+            //->queued() // will be generated asynchronously in queue
+            ->nonQueued(); // will be generated synchronously
 }
 ```
 

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -118,7 +118,7 @@ public function registerMediaConversions(Media $media = null): void
     $this->addMediaConversion('thumb')
             ->width(368)
             ->height(232)
-            ->nonQueued(); // will be generated synchronously
+            ->nonQueued();
 }
 ```
 
@@ -131,7 +131,7 @@ public function registerMediaConversions(Media $media = null): void
     $this->addMediaConversion('thumb')
             ->width(368)
             ->height(232)
-            ->queued(); // will be generated on a queue
+            ->queued();
 }
 ```
 

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -60,6 +60,12 @@ return [
     'queue_name' => '',
 
     /*
+     * Choose if your conversions should be generated in queue by default.
+     * Set `false` to have them generated synchronously.
+     */
+    'queue_conversions_by_default' => env('QUEUE_CONVERSIONS_BY_DEFAULT', true),
+
+    /*
      * The fully qualified class name of the media model.
      */
     'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
@@ -107,11 +113,11 @@ return [
      * a `loading` attribute to the `img` tag. Here you can set the default
      * value of that attribute.
      *
-     * Possible values: 'auto', 'lazy' and 'eager,
+     * Possible values: 'lazy', 'eager', 'auto' or null if you don't want to set any loading instruction.
      *
      * More info: https://css-tricks.com/native-lazy-loading/
      */
-    'default_loading_attribute_value' => 'auto',
+    'default_loading_attribute_value' => null,
 
     /*
      * This is the class that is responsible for naming conversion files. By default,

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -19,7 +19,7 @@ class Conversion
 
     protected array $performOnCollections = [];
 
-    protected bool $performOnQueue = true;
+    protected bool $performOnQueue;
 
     protected bool $keepOriginalImageFormat = false;
 
@@ -40,6 +40,8 @@ class Conversion
         $this->conversionFileNamer = app(config('media-library.conversion_file_namer'));
 
         $this->loadingAttributeValue = config('media-library.default_loading_attribute_value');
+
+        $this->performOnQueue = config('media-library.queue_conversions_by_default', true);
     }
 
     public static function create(string $name)

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -68,20 +68,37 @@ class ConversionTest extends TestCase
     }
 
     /** @test */
+    public function it_will_be_queued_without_config()
+    {
+        config()->set('media-library.queue_conversions_by_default', null);
+        $this->assertTrue($this->conversion->shouldBeQueued());
+    }
+
+    /** @test */
     public function it_will_be_queued_by_default()
     {
+        config()->set('media-library.queue_conversions_by_default', true);
+        $this->assertTrue($this->conversion->shouldBeQueued());
+    }
+
+    /** @test */
+    public function it_will_be_nonQueued_by_default()
+    {
+        config()->set('media-library.queue_conversions_by_default', false);
         $this->assertTrue($this->conversion->shouldBeQueued());
     }
 
     /** @test */
     public function it_can_be_set_to_queued()
     {
+        config()->set('media-library.queue_conversions_by_default', false);
         $this->assertTrue($this->conversion->queued()->shouldBeQueued());
     }
 
     /** @test */
     public function it_can_be_set_to_nonQueued()
     {
+        config()->set('media-library.queue_conversions_by_default', true);
         $this->assertFalse($this->conversion->nonQueued()->shouldBeQueued());
     }
 

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -38,7 +38,7 @@ class DeleteTest extends TestCase
     /** @test */
     public function it_will_remove_files_when_deleting_a_media_object_with_a_custom_path_generator()
     {
-        config(['medialibrary.path_generator' => TestPathGenerator::class]);
+        config(['media-library.path_generator' => TestPathGenerator::class]);
 
         $pathGenerator = new TestPathGenerator();
 


### PR DESCRIPTION
Following our discussion [here](https://github.com/spatie/laravel-medialibrary/discussions/2088), here is my PR to add an easy way to globally enable/disable queue generation in config.

I've also detected one or two small errors that I have fixed (typos and wrong config call in `tests/Feature/Media/DeleteTest.php`).

Let me know if it's OK for you or if there's something to change.