### PR TITLE
Add support for getLastMedia() convenience-method

### DIFF
--- a/docs/basic-usage/retrieving-media.md
+++ b/docs/basic-usage/retrieving-media.md
@@ -29,6 +29,13 @@ $media = $yourModel->getFirstMedia();
 $url = $yourModel->getFirstMediaUrl();
 ```
 
+There is also a shorthand for retrieving the latest media that has been added to a collection:
+
+```php
+$media = $yourModel->getLatestMedia('collection');
+$url = $yourModel->getLatestMediaUrl();
+```
+
 An instance of `Media` also has a name, by default its filename:
 
 ```php

--- a/docs/basic-usage/retrieving-media.md
+++ b/docs/basic-usage/retrieving-media.md
@@ -32,8 +32,8 @@ $url = $yourModel->getFirstMediaUrl();
 There is also a shorthand for retrieving the latest media that has been added to a collection:
 
 ```php
-$media = $yourModel->getLatestMedia('collection');
-$url = $yourModel->getLatestMediaUrl();
+$media = $yourModel->getLastMedia('collection');
+$url = $yourModel->getLastMediaUrl();
 ```
 
 An instance of `Media` also has a name, by default its filename:

--- a/docs/converting-images/retrieving-converted-images.md
+++ b/docs/converting-images/retrieving-converted-images.md
@@ -19,9 +19,9 @@ $urlToFirstListImage = $yourModel->getFirstMediaUrl('images', 'thumb');
 $urlToFirstTemporaryListImage = $yourModel->getFirstTemporaryUrl(Carbon::now()->addMinutes(5), 'images', 'thumb');
 $fullPathToFirstListImage = $yourModel->getFirstMediaPath('images', 'thumb');
 
-$urlToLatestListImage = $yourModel->getLatestMediaUrl('images', 'thumb');
-$urlToLatestTemporaryListImage = $yourModel->getLatestTemporaryUrl(Carbon::now()->addMinutes(5), 'images', 'thumb');
-$fullPathToLatestListImage = $yourModel->getLatestMediaPath('images', 'thumb');
+$urlToLatestListImage = $yourModel->getLastMediaUrl('images', 'thumb');
+$urlToLatestTemporaryListImage = $yourModel->getLastTemporaryUrl(Carbon::now()->addMinutes(5), 'images', 'thumb');
+$fullPathToLatestListImage = $yourModel->getLastMediaPath('images', 'thumb');
 ```
 
 If a conversion is queued, a file may not exist yet on the generated url. You can check if the conversion has been created using the `hasGeneratedConversion`-method on a media item.

--- a/docs/converting-images/retrieving-converted-images.md
+++ b/docs/converting-images/retrieving-converted-images.md
@@ -12,12 +12,16 @@ $mediaItems[0]->getPath('thumb'); // Absolute path on its disk
 $mediaItems[0]->getTemporaryUrl(Carbon::now()->addMinutes(5), 'thumb'); // Temporary S3 url
 ```
 
-Because retrieving an url for the first media item in a collection is such a common scenario, the `getFirstMediaUrl` convenience-method is provided. The first parameter is the name of the collection, the second is the name of a conversion. There's also a `getFirstMediaPath`-variant that returns the absolute path on its disk and a `getFirstTemporaryURL`-variant which returns an temporary S3 url.
+Because retrieving an url for the first media item in a collection is such a common scenario, the `getFirstMediaUrl` convenience-method is provided. The first parameter is the name of the collection, the second is the name of a conversion. There's also a `getFirstMediaPath`-variant that returns the absolute path on its disk and a `getFirstTemporaryURL`-variant which returns an temporary S3 url. There are also corresponding variants for retrieving the latest media.
 
 ```php
 $urlToFirstListImage = $yourModel->getFirstMediaUrl('images', 'thumb');
 $urlToFirstTemporaryListImage = $yourModel->getFirstTemporaryUrl(Carbon::now()->addMinutes(5), 'images', 'thumb');
 $fullPathToFirstListImage = $yourModel->getFirstMediaPath('images', 'thumb');
+
+$urlToLatestListImage = $yourModel->getLatestMediaUrl('images', 'thumb');
+$urlToLatestTemporaryListImage = $yourModel->getLatestTemporaryUrl(Carbon::now()->addMinutes(5), 'images', 'thumb');
+$fullPathToLatestListImage = $yourModel->getLatestMediaPath('images', 'thumb');
 ```
 
 If a conversion is queued, a file may not exist yet on the generated url. You can check if the conversion has been created using the `hasGeneratedConversion`-method on a media item.

--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -35,7 +35,7 @@ This returns a collection of `MediaCollection` objects.
 
 ## Defining a fallback URL or path
 
-If your media collection does not contain any items, calling `getFirstMediaUrl` or `getFirstMediaPath` will return `null`. You can change this by setting a fallback url and/or path using `useFallbackUrl` and `useFallbackPath`.
+If your media collection does not contain any items, calling `getFirstMediaUrl`, `getFirstMediaPath`, `getLatestMediaUrl` or `getLatestMediaPath` will return `null`. You can change this by setting a fallback url and/or path using `useFallbackUrl` and `useFallbackPath`.
 
 ```php
 use Spatie\MediaLibrary\MediaCollections\File;

--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -35,7 +35,7 @@ This returns a collection of `MediaCollection` objects.
 
 ## Defining a fallback URL or path
 
-If your media collection does not contain any items, calling `getFirstMediaUrl`, `getFirstMediaPath`, `getLatestMediaUrl` or `getLatestMediaPath` will return `null`. You can change this by setting a fallback url and/or path using `useFallbackUrl` and `useFallbackPath`.
+If your media collection does not contain any items, calling `getFirstMediaUrl`, `getFirstMediaPath`, `getLastMediaUrl` or `getLastMediaPath` will return `null`. You can change this by setting a fallback url and/or path using `useFallbackUrl` and `useFallbackPath`.
 
 ```php
 use Spatie\MediaLibrary\MediaCollections\File;

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -252,6 +252,13 @@ trait InteractsWithMedia
         return $media->first();
     }
 
+    public function getLatestMedia(string $collectionName = 'default', $filters = []): ?Media
+    {
+        $media = $this->getMedia($collectionName, $filters);
+
+        return $media->last();
+    }
+
     /*
      * Get the url of the image for the given conversionName
      * for first media for the given collectionName.
@@ -260,6 +267,22 @@ trait InteractsWithMedia
     public function getFirstMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
     {
         $media = $this->getFirstMedia($collectionName);
+
+        if (!$media) {
+            return $this->getFallbackMediaUrl($collectionName) ?: '';
+        }
+
+        return $media->getUrl($conversionName);
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for latest media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getLatestMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        $media = $this->getLatestMedia($collectionName);
 
         if (!$media) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
@@ -280,6 +303,26 @@ trait InteractsWithMedia
         string $conversionName = ''
     ): string {
         $media = $this->getFirstMedia($collectionName);
+
+        if (!$media) {
+            return $this->getFallbackMediaUrl($collectionName) ?: '';
+        }
+
+        return $media->getTemporaryUrl($expiration, $conversionName);
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for latest media for the given collectionName.
+     *
+     * If no profile is given, return the source's url.
+     */
+    public function getLatestTemporaryUrl(
+        DateTimeInterface $expiration,
+        string $collectionName = 'default',
+        string $conversionName = ''
+    ): string {
+        $media = $this->getLatestMedia($collectionName);
 
         if (!$media) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
@@ -321,6 +364,22 @@ trait InteractsWithMedia
     public function getFirstMediaPath(string $collectionName = 'default', string $conversionName = ''): string
     {
         $media = $this->getFirstMedia($collectionName);
+
+        if (!$media) {
+            return $this->getFallbackMediaPath($collectionName) ?: '';
+        }
+
+        return $media->getPath($conversionName);
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for latest media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getLatestMediaPath(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        $media = $this->getLatestMedia($collectionName);
 
         if (!$media) {
             return $this->getFallbackMediaPath($collectionName) ?: '';

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -252,7 +252,7 @@ trait InteractsWithMedia
         return $media->first();
     }
 
-    public function getLatestMedia(string $collectionName = 'default', $filters = []): ?Media
+    public function getLastMedia(string $collectionName = 'default', $filters = []): ?Media
     {
         $media = $this->getMedia($collectionName, $filters);
 
@@ -280,9 +280,9 @@ trait InteractsWithMedia
      * for latest media for the given collectionName.
      * If no profile is given, return the source's url.
      */
-    public function getLatestMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
+    public function getLastMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
     {
-        $media = $this->getLatestMedia($collectionName);
+        $media = $this->getLastMedia($collectionName);
 
         if (!$media) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
@@ -317,12 +317,12 @@ trait InteractsWithMedia
      *
      * If no profile is given, return the source's url.
      */
-    public function getLatestTemporaryUrl(
+    public function getLastTemporaryUrl(
         DateTimeInterface $expiration,
         string $collectionName = 'default',
         string $conversionName = ''
     ): string {
-        $media = $this->getLatestMedia($collectionName);
+        $media = $this->getLastMedia($collectionName);
 
         if (!$media) {
             return $this->getFallbackMediaUrl($collectionName) ?: '';
@@ -377,9 +377,9 @@ trait InteractsWithMedia
      * for latest media for the given collectionName.
      * If no profile is given, return the source's url.
      */
-    public function getLatestMediaPath(string $collectionName = 'default', string $conversionName = ''): string
+    public function getLastMediaPath(string $collectionName = 'default', string $conversionName = ''): string
     {
-        $media = $this->getLatestMedia($collectionName);
+        $media = $this->getLastMedia($collectionName);
 
         if (!$media) {
             return $this->getFallbackMediaPath($collectionName) ?: '';

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -175,7 +175,7 @@ class GetMediaTest extends TestCase
         $media->name = 'second';
         $media->save();
 
-        $this->assertEquals('second', $this->testModel->getLatestMedia('images')->name);
+        $this->assertEquals('second', $this->testModel->getLastMedia('images')->name);
     }
 
     /** @test */
@@ -226,7 +226,7 @@ class GetMediaTest extends TestCase
         $media->name = 'third';
         $media->save();
 
-        $this->assertEquals('second', $this->testModel->getLatestMedia('images', ['extra_property' => 'no'])->name);
+        $this->assertEquals('second', $this->testModel->getLastMedia('images', ['extra_property' => 'no'])->name);
     }
 
     /** @test */
@@ -278,7 +278,7 @@ class GetMediaTest extends TestCase
         $media->name = 'third';
         $media->save();
 
-        $latestMedia = $this->testModel->getLatestMedia('images',
+        $latestMedia = $this->testModel->getLastMedia('images',
             fn (Media $media) => isset($media->custom_properties['extra_property'])
         );
 
@@ -294,7 +294,7 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_returns_null_when_getting_latest_media_for_an_empty_collection()
     {
-        $this->assertNull($this->testModel->getLatestMedia());
+        $this->assertNull($this->testModel->getLastMedia());
     }
 
     /** @test */
@@ -318,7 +318,7 @@ class GetMediaTest extends TestCase
         $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
         $secondMedia->save();
 
-        $this->assertEquals($secondMedia->getUrl(), $this->testModel->getLatestMediaUrl('images'));
+        $this->assertEquals($secondMedia->getUrl(), $this->testModel->getLastMediaUrl('images'));
     }
 
     /** @test */
@@ -342,7 +342,7 @@ class GetMediaTest extends TestCase
         $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
         $secondMedia->save();
 
-        $this->assertEquals($secondMedia->getPath(), $this->testModel->getLatestMediaPath('images'));
+        $this->assertEquals($secondMedia->getPath(), $this->testModel->getLastMediaPath('images'));
     }
 
     /** @test */
@@ -354,7 +354,7 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_can_get_the_default_path_to_the_latest_media_in_a_collection()
     {
-        $this->assertEquals('/default.jpg', $this->testModel->getLatestMediaPath('avatar'));
+        $this->assertEquals('/default.jpg', $this->testModel->getLastMediaPath('avatar'));
     }
 
     /** @test */
@@ -366,7 +366,7 @@ class GetMediaTest extends TestCase
     /** @test */
     public function it_can_get_the_default_url_to_the_latest_media_in_a_collection()
     {
-        $this->assertEquals('/default.jpg', $this->testModel->getLatestMediaUrl('avatar'));
+        $this->assertEquals('/default.jpg', $this->testModel->getLastMediaUrl('avatar'));
     }
 
     /** @test */

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -165,6 +165,20 @@ class GetMediaTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_latest_media_from_a_collection()
+    {
+        $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $media->name = 'first';
+        $media->save();
+
+        $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $media->name = 'second';
+        $media->save();
+
+        $this->assertEquals('second', $this->testModel->getLatestMedia('images')->name);
+    }
+
+    /** @test */
     public function it_can_get_the_first_media_from_a_collection_using_a_filter()
     {
         $media = $this->testModel
@@ -183,6 +197,36 @@ class GetMediaTest extends TestCase
         $media->save();
 
         $this->assertEquals('first', $this->testModel->getFirstMedia('images', ['extra_property' => 'yes'])->name);
+    }
+
+    /** @test */
+    public function it_can_get_the_latest_media_from_a_collection_using_a_filter()
+    {
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->withCustomProperties(['extra_property' => 'no'])
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+        $media->name = 'first';
+        $media->save();
+
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->withCustomProperties(['extra_property' => 'no'])
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+        $media->name = 'second';
+        $media->save();
+
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->withCustomProperties(['extra_property' => 'yes'])
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+        $media->name = 'third';
+        $media->save();
+
+        $this->assertEquals('second', $this->testModel->getLatestMedia('images', ['extra_property' => 'no'])->name);
     }
 
     /** @test */
@@ -208,9 +252,49 @@ class GetMediaTest extends TestCase
         $this->assertEquals('first', $firstMedia->name);
     }
 
-    public function it_returns_false_when_getting_first_media_for_an_empty_collection()
+    /** @test */
+    public function it_can_get_the_latest_media_from_a_collection_using_a_filter_callback()
     {
-        $this->assertFalse($this->testModel->getFirstMedia());
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->withCustomProperties(['extra_property' => 'yes'])
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+        $media->name = 'first';
+        $media->save();
+
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->withCustomProperties(['extra_property' => 'yes'])
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+        $media->name = 'second';
+        $media->save();
+
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+        $media->name = 'third';
+        $media->save();
+
+        $latestMedia = $this->testModel->getLatestMedia('images',
+            fn (Media $media) => isset($media->custom_properties['extra_property'])
+        );
+
+        $this->assertEquals('second', $latestMedia->name);
+    }
+
+    /** @test */
+    public function it_returns_null_when_getting_first_media_for_an_empty_collection()
+    {
+        $this->assertNull($this->testModel->getFirstMedia());
+    }
+
+    /** @test */
+    public function it_returns_null_when_getting_latest_media_for_an_empty_collection()
+    {
+        $this->assertNull($this->testModel->getLatestMedia());
     }
 
     /** @test */
@@ -226,6 +310,18 @@ class GetMediaTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_url_to_latest_media_in_a_collection()
+    {
+        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $firstMedia->save();
+
+        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $secondMedia->save();
+
+        $this->assertEquals($secondMedia->getUrl(), $this->testModel->getLatestMediaUrl('images'));
+    }
+
+    /** @test */
     public function it_can_get_the_path_to_first_media_in_a_collection()
     {
         $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
@@ -238,15 +334,39 @@ class GetMediaTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_path_to_latest_media_in_a_collection()
+    {
+        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $firstMedia->save();
+
+        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+        $secondMedia->save();
+
+        $this->assertEquals($secondMedia->getPath(), $this->testModel->getLatestMediaPath('images'));
+    }
+
+    /** @test */
     public function it_can_get_the_default_path_to_the_first_media_in_a_collection()
     {
         $this->assertEquals('/default.jpg', $this->testModel->getFirstMediaPath('avatar'));
     }
 
     /** @test */
+    public function it_can_get_the_default_path_to_the_latest_media_in_a_collection()
+    {
+        $this->assertEquals('/default.jpg', $this->testModel->getLatestMediaPath('avatar'));
+    }
+
+    /** @test */
     public function it_can_get_the_default_url_to_the_first_media_in_a_collection()
     {
         $this->assertEquals('/default.jpg', $this->testModel->getFirstMediaUrl('avatar'));
+    }
+
+    /** @test */
+    public function it_can_get_the_default_url_to_the_latest_media_in_a_collection()
+    {
+        $this->assertEquals('/default.jpg', $this->testModel->getLatestMediaUrl('avatar'));
     }
 
     /** @test */


### PR DESCRIPTION
With this pull request a new convenience-method ~`getLatestMedia()`~ `getLastMedia()` is introduced which returns the latest added media of a collection. This can be useful if a collection is used to store multiple versions of a file and the newest should be returned, for example.

The associated functions `getLastMediaUrl()`, `getLastMediaPath()` and `getLastTemporaryUrl()` were also implemented – the test cases and documentation were adapted accordingly.

**Edit:** Since collections can be re-ordered manually, I renamed `getLatestMedia()` to `getLastMedia()` because this is less opinionated.