### PR TITLE
Fixed width calculator

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -2,31 +2,31 @@
 
 return [
 
-	/*
+    /*
      * The disk on which to store added files and derived images by default. Choose
      * one or more of the disks you've configured in config/filesystems.php.
      */
-	'disk_name' => env('MEDIA_DISK', 'public'),
+    'disk_name' => env('MEDIA_DISK', 'public'),
 
-	/*
+    /*
      * The maximum file size of an item in bytes.
      * Adding a larger file will result in an exception.
      */
-	'max_file_size' => 1024 * 1024 * 10,
+    'max_file_size' => 1024 * 1024 * 10,
 
-	/*
+    /*
      * This queue will be used to generate derived and responsive images.
      * Leave empty to use the default queue.
      */
-	'queue_name' => '',
+    'queue_name' => '',
 
-	/*
+    /*
      * The fully qualified class name of the media model.
      */
-	'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
+    'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
 
-	'remote' => [
-		/*
+    'remote' => [
+        /*
          * Any extra headers that should be included when uploading media to
          * a remote disk. Even though supported headers may vary between
          * different drivers, a sensible default has been provided.
@@ -34,45 +34,45 @@ return [
          * Supported by S3: CacheControl, Expires, StorageClass,
          * ServerSideEncryption, Metadata, ACL, ContentEncoding
          */
-		'extra_headers' => [
-			'CacheControl' => 'max-age=604800',
-		],
-	],
+        'extra_headers' => [
+            'CacheControl' => 'max-age=604800',
+        ],
+    ],
 
-	'responsive_images' => [
+    'responsive_images' => [
 
-		/*
+        /*
          * This class is responsible for calculating the target widths of the responsive
          * images. By default we optimize for filesize and create variations that each are 20%
          * smaller than the previous one. More info in the documentation.
          *
          * https://docs.spatie.be/laravel-medialibrary/v8/advanced-usage/generating-responsive-images
          */
-		'width_calculator' => Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator::class,
+        'width_calculator' => Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator::class,
 
-		/*
+        /*
          * By default rendering media to a responsive image will add some javascript and a tiny placeholder.
          * This ensures that the browser can already determine the correct layout.
          */
-		'use_tiny_placeholders' => true,
+        'use_tiny_placeholders' => true,
 
-		/*
+        /*
          * This class will generate the tiny placeholder used for progressive image loading. By default
          * the medialibrary will use a tiny blurred jpg image.
          */
-		'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
+        'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
 
-		/*
+        /*
          * Used by FixedWidthCalculator. Generates responsive images from these breakpoints.
-		 * If empty, it fallbacks to FileSizeOptimizedWidthCalculator.
-		 *
-		 * Eg. [200, 600, 1200]
-		 *
+         * If empty, it fallbacks to FileSizeOptimizedWidthCalculator.
+         *
+         * Eg. [200, 600, 1200]
+         *
          */
-		'breakpoints' => [],
-	],
+        'breakpoints' => [],
+    ],
 
-	/*
+    /*
      * When converting Media instances to response the medialibrary will add
      * a `loading` attribute to the `img` tag. Here you can set the default
      * value of that attribute.
@@ -81,103 +81,103 @@ return [
      *
      * More info: https://css-tricks.com/native-lazy-loading/
      */
-	'default_loading_attribute_value' => null,
+    'default_loading_attribute_value' => null,
 
-	/*
+    /*
      * This is the class that is responsible for naming conversion files. By default,
      * it will use the filename of the original and concatenate the conversion name to it.
      */
-	'conversion_file_namer' => Spatie\MediaLibrary\Conversions\DefaultConversionFileNamer::class,
+    'conversion_file_namer' => Spatie\MediaLibrary\Conversions\DefaultConversionFileNamer::class,
 
-	/*
+    /*
      * The class that contains the strategy for determining a media file's path.
      */
-	'path_generator' => Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class,
+    'path_generator' => Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class,
 
-	/*
+    /*
      * When urls to files get generated, this class will be called. Use the default
      * if your files are stored locally above the site root or on s3.
      */
-	'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
+    'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
 
-	/*
+    /*
      * Whether to activate versioning when urls to files get generated.
      * When activated, this attaches a ?v=xx query string to the URL.
      */
-	'version_urls' => false,
+    'version_urls' => false,
 
-	/*
+    /*
      * The media library will try to optimize all converted images by removing
      * metadata and applying a little bit of compression. These are
      * the optimizers that will be used by default.
      */
-	'image_optimizers' => [
-		Spatie\ImageOptimizer\Optimizers\Jpegoptim::class => [
-			'--strip-all', // this strips out all text information such as comments and EXIF data
-			'--all-progressive', // this will make sure the resulting image is a progressive one
-		],
-		Spatie\ImageOptimizer\Optimizers\Pngquant::class => [
-			'--force', // required parameter for this package
-		],
-		Spatie\ImageOptimizer\Optimizers\Optipng::class => [
-			'-i0', // this will result in a non-interlaced, progressive scanned image
-			'-o2', // this set the optimization level to two (multiple IDAT compression trials)
-			'-quiet', // required parameter for this package
-		],
-		Spatie\ImageOptimizer\Optimizers\Svgo::class => [
-			'--disable=cleanupIDs', // disabling because it is known to cause troubles
-		],
-		Spatie\ImageOptimizer\Optimizers\Gifsicle::class => [
-			'-b', // required parameter for this package
-			'-O3', // this produces the slowest but best results
-		],
-	],
+    'image_optimizers' => [
+        Spatie\ImageOptimizer\Optimizers\Jpegoptim::class => [
+            '--strip-all', // this strips out all text information such as comments and EXIF data
+            '--all-progressive', // this will make sure the resulting image is a progressive one
+        ],
+        Spatie\ImageOptimizer\Optimizers\Pngquant::class => [
+            '--force', // required parameter for this package
+        ],
+        Spatie\ImageOptimizer\Optimizers\Optipng::class => [
+            '-i0', // this will result in a non-interlaced, progressive scanned image
+            '-o2', // this set the optimization level to two (multiple IDAT compression trials)
+            '-quiet', // required parameter for this package
+        ],
+        Spatie\ImageOptimizer\Optimizers\Svgo::class => [
+            '--disable=cleanupIDs', // disabling because it is known to cause troubles
+        ],
+        Spatie\ImageOptimizer\Optimizers\Gifsicle::class => [
+            '-b', // required parameter for this package
+            '-O3', // this produces the slowest but best results
+        ],
+    ],
 
-	/*
+    /*
      * These generators will be used to create an image of media files.
      */
-	'image_generators' => [
-		Spatie\MediaLibrary\Conversions\ImageGenerators\Image::class,
-		Spatie\MediaLibrary\Conversions\ImageGenerators\Webp::class,
-		Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf::class,
-		Spatie\MediaLibrary\Conversions\ImageGenerators\Svg::class,
-		Spatie\MediaLibrary\Conversions\ImageGenerators\Video::class,
-	],
+    'image_generators' => [
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Image::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Webp::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Svg::class,
+        Spatie\MediaLibrary\Conversions\ImageGenerators\Video::class,
+    ],
 
-	/*
+    /*
      * The engine that should perform the image conversions.
      * Should be either `gd` or `imagick`.
      */
-	'image_driver' => env('IMAGE_DRIVER', 'gd'),
+    'image_driver' => env('IMAGE_DRIVER', 'gd'),
 
-	/*
+    /*
      * FFMPEG & FFProbe binaries paths, only used if you try to generate video
      * thumbnails and have installed the php-ffmpeg/php-ffmpeg composer
      * dependency.
      */
-	'ffmpeg_path' => env('FFMPEG_PATH', '/usr/bin/ffmpeg'),
-	'ffprobe_path' => env('FFPROBE_PATH', '/usr/bin/ffprobe'),
+    'ffmpeg_path' => env('FFMPEG_PATH', '/usr/bin/ffmpeg'),
+    'ffprobe_path' => env('FFPROBE_PATH', '/usr/bin/ffprobe'),
 
-	/*
+    /*
      * The path where to store temporary files while performing image conversions.
      * If set to null, storage_path('media-library/temp') will be used.
      */
-	'temporary_directory_path' => null,
+    'temporary_directory_path' => null,
 
-	/*
+    /*
      * Here you can override the class names of the jobs used by this package. Make sure
      * your custom jobs extend the ones provided by the package.
      */
-	'jobs' => [
-		'perform_conversions' => Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
-		'generate_responsive_images' => Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
-	],
+    'jobs' => [
+        'perform_conversions' => Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
+        'generate_responsive_images' => Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
+    ],
 
-	/*
+    /*
      * When using the addMediaFromUrl method you may want to replace the default downloader.
      * This is particularly useful when the url of the image is behind a firewall and
      * need to add additional flags, possibly using curl.
      */
-	'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
+    'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
 
 ];

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -2,31 +2,31 @@
 
 return [
 
-    /*
+	/*
      * The disk on which to store added files and derived images by default. Choose
      * one or more of the disks you've configured in config/filesystems.php.
      */
-    'disk_name' => env('MEDIA_DISK', 'public'),
+	'disk_name' => env('MEDIA_DISK', 'public'),
 
-    /*
+	/*
      * The maximum file size of an item in bytes.
      * Adding a larger file will result in an exception.
      */
-    'max_file_size' => 1024 * 1024 * 10,
+	'max_file_size' => 1024 * 1024 * 10,
 
-    /*
+	/*
      * This queue will be used to generate derived and responsive images.
      * Leave empty to use the default queue.
      */
-    'queue_name' => '',
+	'queue_name' => '',
 
-    /*
+	/*
      * The fully qualified class name of the media model.
      */
-    'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
+	'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
 
-    'remote' => [
-        /*
+	'remote' => [
+		/*
          * Any extra headers that should be included when uploading media to
          * a remote disk. Even though supported headers may vary between
          * different drivers, a sensible default has been provided.
@@ -34,36 +34,45 @@ return [
          * Supported by S3: CacheControl, Expires, StorageClass,
          * ServerSideEncryption, Metadata, ACL, ContentEncoding
          */
-        'extra_headers' => [
-            'CacheControl' => 'max-age=604800',
-        ],
-    ],
+		'extra_headers' => [
+			'CacheControl' => 'max-age=604800',
+		],
+	],
 
-    'responsive_images' => [
+	'responsive_images' => [
 
-        /*
+		/*
          * This class is responsible for calculating the target widths of the responsive
          * images. By default we optimize for filesize and create variations that each are 20%
          * smaller than the previous one. More info in the documentation.
          *
          * https://docs.spatie.be/laravel-medialibrary/v8/advanced-usage/generating-responsive-images
          */
-        'width_calculator' => Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator::class,
+		'width_calculator' => Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator::class,
 
-        /*
+		/*
          * By default rendering media to a responsive image will add some javascript and a tiny placeholder.
          * This ensures that the browser can already determine the correct layout.
          */
-        'use_tiny_placeholders' => true,
+		'use_tiny_placeholders' => true,
 
-        /*
+		/*
          * This class will generate the tiny placeholder used for progressive image loading. By default
          * the medialibrary will use a tiny blurred jpg image.
          */
-        'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
-    ],
+		'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
 
-    /*
+		/*
+         * Used by FixedWidthCalculator. Generates responsive images from these breakpoints.
+		 * If empty, it fallbacks to FileSizeOptimizedWidthCalculator.
+		 *
+		 * Eg. [200, 600, 1200]
+		 *
+         */
+		'breakpoints' => [],
+	],
+
+	/*
      * When converting Media instances to response the medialibrary will add
      * a `loading` attribute to the `img` tag. Here you can set the default
      * value of that attribute.
@@ -72,103 +81,103 @@ return [
      *
      * More info: https://css-tricks.com/native-lazy-loading/
      */
-    'default_loading_attribute_value' => null,
+	'default_loading_attribute_value' => null,
 
-    /*
+	/*
      * This is the class that is responsible for naming conversion files. By default,
      * it will use the filename of the original and concatenate the conversion name to it.
      */
-    'conversion_file_namer' => Spatie\MediaLibrary\Conversions\DefaultConversionFileNamer::class,
+	'conversion_file_namer' => Spatie\MediaLibrary\Conversions\DefaultConversionFileNamer::class,
 
-    /*
+	/*
      * The class that contains the strategy for determining a media file's path.
      */
-    'path_generator' => Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class,
+	'path_generator' => Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class,
 
-    /*
+	/*
      * When urls to files get generated, this class will be called. Use the default
      * if your files are stored locally above the site root or on s3.
      */
-    'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
+	'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
 
-    /*
+	/*
      * Whether to activate versioning when urls to files get generated.
      * When activated, this attaches a ?v=xx query string to the URL.
      */
-    'version_urls' => false,
+	'version_urls' => false,
 
-    /*
+	/*
      * The media library will try to optimize all converted images by removing
      * metadata and applying a little bit of compression. These are
      * the optimizers that will be used by default.
      */
-    'image_optimizers' => [
-        Spatie\ImageOptimizer\Optimizers\Jpegoptim::class => [
-            '--strip-all', // this strips out all text information such as comments and EXIF data
-            '--all-progressive', // this will make sure the resulting image is a progressive one
-        ],
-        Spatie\ImageOptimizer\Optimizers\Pngquant::class => [
-            '--force', // required parameter for this package
-        ],
-        Spatie\ImageOptimizer\Optimizers\Optipng::class => [
-            '-i0', // this will result in a non-interlaced, progressive scanned image
-            '-o2', // this set the optimization level to two (multiple IDAT compression trials)
-            '-quiet', // required parameter for this package
-        ],
-        Spatie\ImageOptimizer\Optimizers\Svgo::class => [
-            '--disable=cleanupIDs', // disabling because it is known to cause troubles
-        ],
-        Spatie\ImageOptimizer\Optimizers\Gifsicle::class => [
-            '-b', // required parameter for this package
-            '-O3', // this produces the slowest but best results
-        ],
-    ],
+	'image_optimizers' => [
+		Spatie\ImageOptimizer\Optimizers\Jpegoptim::class => [
+			'--strip-all', // this strips out all text information such as comments and EXIF data
+			'--all-progressive', // this will make sure the resulting image is a progressive one
+		],
+		Spatie\ImageOptimizer\Optimizers\Pngquant::class => [
+			'--force', // required parameter for this package
+		],
+		Spatie\ImageOptimizer\Optimizers\Optipng::class => [
+			'-i0', // this will result in a non-interlaced, progressive scanned image
+			'-o2', // this set the optimization level to two (multiple IDAT compression trials)
+			'-quiet', // required parameter for this package
+		],
+		Spatie\ImageOptimizer\Optimizers\Svgo::class => [
+			'--disable=cleanupIDs', // disabling because it is known to cause troubles
+		],
+		Spatie\ImageOptimizer\Optimizers\Gifsicle::class => [
+			'-b', // required parameter for this package
+			'-O3', // this produces the slowest but best results
+		],
+	],
 
-    /*
+	/*
      * These generators will be used to create an image of media files.
      */
-    'image_generators' => [
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Image::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Webp::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Svg::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Video::class,
-    ],
+	'image_generators' => [
+		Spatie\MediaLibrary\Conversions\ImageGenerators\Image::class,
+		Spatie\MediaLibrary\Conversions\ImageGenerators\Webp::class,
+		Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf::class,
+		Spatie\MediaLibrary\Conversions\ImageGenerators\Svg::class,
+		Spatie\MediaLibrary\Conversions\ImageGenerators\Video::class,
+	],
 
-    /*
+	/*
      * The engine that should perform the image conversions.
      * Should be either `gd` or `imagick`.
      */
-    'image_driver' => env('IMAGE_DRIVER', 'gd'),
+	'image_driver' => env('IMAGE_DRIVER', 'gd'),
 
-    /*
+	/*
      * FFMPEG & FFProbe binaries paths, only used if you try to generate video
      * thumbnails and have installed the php-ffmpeg/php-ffmpeg composer
      * dependency.
      */
-    'ffmpeg_path' => env('FFMPEG_PATH', '/usr/bin/ffmpeg'),
-    'ffprobe_path' => env('FFPROBE_PATH', '/usr/bin/ffprobe'),
+	'ffmpeg_path' => env('FFMPEG_PATH', '/usr/bin/ffmpeg'),
+	'ffprobe_path' => env('FFPROBE_PATH', '/usr/bin/ffprobe'),
 
-    /*
+	/*
      * The path where to store temporary files while performing image conversions.
      * If set to null, storage_path('media-library/temp') will be used.
      */
-    'temporary_directory_path' => null,
+	'temporary_directory_path' => null,
 
-    /*
+	/*
      * Here you can override the class names of the jobs used by this package. Make sure
      * your custom jobs extend the ones provided by the package.
      */
-    'jobs' => [
-        'perform_conversions' => Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
-        'generate_responsive_images' => Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
-    ],
+	'jobs' => [
+		'perform_conversions' => Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
+		'generate_responsive_images' => Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
+	],
 
-    /*
+	/*
      * When using the addMediaFromUrl method you may want to replace the default downloader.
      * This is particularly useful when the url of the image is behind a firewall and
      * need to add additional flags, possibly using curl.
      */
-    'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
+	'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
 
 ];

--- a/src/ResponsiveImages/WidthCalculator/FixedWidthCalculator.php
+++ b/src/ResponsiveImages/WidthCalculator/FixedWidthCalculator.php
@@ -6,12 +6,12 @@ use Illuminate\Support\Collection;
 
 class FixedWidthCalculator extends FileSizeOptimizedWidthCalculator
 {
-	public function calculateWidths(int $fileSize, int $width, int $height): Collection
-	{
-		$breakpoints = config('media-library.responsive_images.breakpoints');
+    public function calculateWidths(int $fileSize, int $width, int $height): Collection
+    {
+        $breakpoints = config('media-library.responsive_images.breakpoints');
 
-		return empty($breakpoints) ? parent::calculateWidths($fileSize, $width, $height) : collect($breakpoints)->filter(function ($value, $key) use ($width) {
-			return $value < $width;
-		});
-	}
+        return empty($breakpoints) ? parent::calculateWidths($fileSize, $width, $height) : collect($breakpoints)->filter(function ($value, $key) use ($width) {
+            return $value < $width;
+        });
+    }
 }

--- a/src/ResponsiveImages/WidthCalculator/FixedWidthCalculator.php
+++ b/src/ResponsiveImages/WidthCalculator/FixedWidthCalculator.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\MediaLibrary\ResponsiveImages\WidthCalculator;
+
+use Illuminate\Support\Collection;
+
+class FixedWidthCalculator extends FileSizeOptimizedWidthCalculator
+{
+	public function calculateWidths(int $fileSize, int $width, int $height): Collection
+	{
+		$breakpoints = config('media-library.responsive_images.breakpoints');
+
+		return empty($breakpoints) ? parent::calculateWidths($fileSize, $width, $height) : collect($breakpoints)->filter(function ($value, $key) use ($width) {
+			return $value < $width;
+		});
+	}
+}


### PR DESCRIPTION
Introducing the new WidthCalculator => `FixedWidthCalculator`. Sometimes we just need responsive images for fixed breakpoints (eg. 200, 600, 1200 px). It adds one extra config option to set the breakpoints. In addition, if you choose to use this width calculator and the breakpoints array is empty, it fallbacks to good old `FileSizeOptimizedWidthCalculator`. Also, if you set the breakpoint too high for some smaller images, it just won't use that breakpoint (it filters the breakpoints array where the actual picture width is smaller).

PS. If you're interested in this kind of thing I'm sure I can add tests and docs updates...