### PR TITLE
support a custom file namer for responsive images

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Spatie is a webdesign agency in Antwerp, Belgium. You'll find an overview of all
 
 ## Support us
 
-[<img src="https://github-ads.s3.eu-central-1.amazonaws.com/laravel-medialibrary.jpg?t=1" width="419px" />](https://spatie.be/github-ad-click/laravel-medialibrary)
+[<img src="https://github-ads.s3.eu-central-1.amazonaws.com/laravel-medialibrary.jpg?t=2" width="419px" />](https://spatie.be/github-ad-click/laravel-medialibrary)
 
 We invest a lot of resources into creating [best in class open source packages](https://spatie.be/open-source). You can support us by [buying one of our paid products](https://spatie.be/open-source/support-us).
 

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -86,6 +86,12 @@ return [
     'conversion_file_namer' => Spatie\MediaLibrary\Conversions\DefaultConversionFileNamer::class,
 
     /*
+     * This is the class that is responsible for naming files. By default,
+     * it will use the filename of the original and concatenate the conversion name to it.
+     */
+    'file_namer' => Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer::class,
+
+    /*
      * The class that contains the strategy for determining a media file's path.
      */
     'path_generator' => Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class,

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -87,7 +87,7 @@ return [
 
     /*
      * This is the class that is responsible for naming files. By default,
-     * it will use the filename of the original and concatenate the conversion name to it.
+     * it will use the filename of the original.
      */
     'file_namer' => Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer::class,
 

--- a/docs/converting-images/naming-conversion-files.md
+++ b/docs/converting-images/naming-conversion-files.md
@@ -9,7 +9,9 @@ By default, all conversion files will be named in this format:
 {original-file-name-without-extension}-{name-of-the-conversion}.{extension}
 ```
 
-Should you want to name your conversion file using another format, than you can specify the class name of your own `ConversionFileNamer` in the `conversion_file_namer` key of the `media-library.php` config file.
+Should you want to name your conversion file using another format,
+then you can specify the class name of your own `ConversionFileNamer` in the `conversion_file_namer` key
+of the `media-library.php` config file.
 
 The only requirement is that your class extends `Spatie\MediaLibrary\Conversion\ConversionFileNamer`. In your class you should implement the `getFileName` method that returns the name of the file without the extension.
 

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -5,13 +5,14 @@ namespace Spatie\MediaLibrary\Conversions;
 use BadMethodCallException;
 use Spatie\Image\Manipulations;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
 
 /** @mixin \Spatie\Image\Manipulations */
 class Conversion
 {
     protected string $name = '';
 
-    protected ConversionFileNamer $conversionFileNamer;
+    protected FileNamer $fileNamer;
 
     protected float $extractVideoFrameAtSecond = 0;
 
@@ -37,7 +38,7 @@ class Conversion
             ->optimize(config('media-library.image_optimizers'))
             ->format(Manipulations::FORMAT_JPG);
 
-        $this->conversionFileNamer = app(config('media-library.conversion_file_namer'));
+        $this->fileNamer = app(config('media-library.file_namer'));
 
         $this->loadingAttributeValue = config('media-library.default_loading_attribute_value');
 
@@ -217,8 +218,11 @@ class Conversion
 
     public function getConversionFile(Media $media): string
     {
-        $fileName = $this->conversionFileNamer->getFileName($this, $media);
-        $extension = $this->conversionFileNamer->getExtension($this, $media);
+        $fileName = $this->fileNamer->getFileName($media->file_name);
+        $fileName = $this->fileNamer->addConversionToFileName($fileName, $this);
+
+        $fileExtension = $this->fileNamer->getExtension($media->file_name);
+        $extension = $this->getResultExtension($fileExtension) ?: $fileExtension;
 
         return "{$fileName}.{$extension}";
     }

--- a/src/ResponsiveImages/ResponsiveImageGenerator.php
+++ b/src/ResponsiveImages/ResponsiveImageGenerator.php
@@ -93,7 +93,7 @@ class ResponsiveImageGenerator
         int $conversionQuality = self::DEFAULT_CONVERSION_QUALITY
     ): void {
         $extension = $this->fileNamer->getExtension($baseImage);
-        $responsiveImagePath = $this->fileNamer->getTemporarilyFileName($media, $extension);
+        $responsiveImagePath = $this->fileNamer->getTemporaryFileName($media, $extension);
 
         $tempDestination = $temporaryDirectory->path($responsiveImagePath);
 
@@ -105,8 +105,8 @@ class ResponsiveImageGenerator
 
         $responsiveImageHeight = ImageFactory::load($tempDestination)->getHeight();
 
-        // the user can customize the name like he wants, be we expect the last part in a certain format
-        $finalImageFileName = $this->fileNamer->addPropertiesToFileName(
+        // Users can customize the name like they want, but we expect the last part in a certain format
+        $fileName = $this->fileNamer->addPropertiesToFileName(
             $responsiveImagePath,
             $conversionName,
             $targetWidth,
@@ -114,13 +114,13 @@ class ResponsiveImageGenerator
             $extension
         );
 
-        $finalResponsiveImagePath = $temporaryDirectory->path($finalImageFileName);
+        $finalResponsiveImagePath = $temporaryDirectory->path($fileName);
 
         rename($tempDestination, $finalResponsiveImagePath);
 
         $this->filesystem->copyToMediaLibrary($finalResponsiveImagePath, $media, 'responsiveImages');
 
-        ResponsiveImage::register($media, $finalImageFileName, $conversionName);
+        ResponsiveImage::register($media, $fileName, $conversionName);
     }
 
     public function generateTinyJpg(

--- a/src/ResponsiveImages/ResponsiveImageGenerator.php
+++ b/src/ResponsiveImages/ResponsiveImageGenerator.php
@@ -11,6 +11,7 @@ use Spatie\MediaLibrary\ResponsiveImages\Exceptions\InvalidTinyJpg;
 use Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\TinyPlaceholderGenerator;
 use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\WidthCalculator;
 use Spatie\MediaLibrary\Support\File;
+use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
 use Spatie\MediaLibrary\Support\ImageFactory;
 use Spatie\MediaLibrary\Support\TemporaryDirectory;
 use Spatie\TemporaryDirectory\TemporaryDirectory as BaseTemporaryDirectory;
@@ -25,6 +26,8 @@ class ResponsiveImageGenerator
 
     protected const DEFAULT_CONVERSION_QUALITY = 90;
 
+    protected FileNamer $fileNamer;
+
     public function __construct(
         Filesystem $filesystem,
         WidthCalculator $widthCalculator,
@@ -35,6 +38,8 @@ class ResponsiveImageGenerator
         $this->widthCalculator = $widthCalculator;
 
         $this->tinyPlaceholderGenerator = $tinyPlaceholderGenerator;
+
+        $this->fileNamer = app(config('media-library.file_namer'));
     }
 
     public function generateResponsiveImages(Media $media): void
@@ -87,11 +92,8 @@ class ResponsiveImageGenerator
         BaseTemporaryDirectory $temporaryDirectory,
         int $conversionQuality = self::DEFAULT_CONVERSION_QUALITY
     ): void {
-        $responsiveImagePath = $this->appendToFileName(
-            $media->file_name,
-            "___{$conversionName}_{$targetWidth}",
-            $baseImage
-        );
+        $extension = $this->fileNamer->getExtension($baseImage);
+        $responsiveImagePath = $this->fileNamer->getTemporarilyFileName($media, $extension);
 
         $tempDestination = $temporaryDirectory->path($responsiveImagePath);
 
@@ -103,7 +105,14 @@ class ResponsiveImageGenerator
 
         $responsiveImageHeight = ImageFactory::load($tempDestination)->getHeight();
 
-        $finalImageFileName = $this->appendToFileName($responsiveImagePath, "_{$responsiveImageHeight}");
+        // the user can customize the name like he wants, be we expect the last part in a certain format
+        $finalImageFileName = $this->fileNamer->addPropertiesToFileName(
+            $responsiveImagePath,
+            $conversionName,
+            $targetWidth,
+            $responsiveImageHeight,
+            $extension
+        );
 
         $finalResponsiveImagePath = $temporaryDirectory->path($finalImageFileName);
 

--- a/src/Support/FileNamer/DefaultFileNamer.php
+++ b/src/Support/FileNamer/DefaultFileNamer.php
@@ -2,10 +2,17 @@
 
 namespace Spatie\MediaLibrary\Support\FileNamer;
 
+use Spatie\MediaLibrary\Conversions\Conversion;
+
 class DefaultFileNamer extends FileNamer
 {
     public function getFileName(string $fileName): string
     {
         return pathinfo($fileName, PATHINFO_FILENAME);
+    }
+
+    public function addConversionToFileName(string $fileName, Conversion $conversion): string
+    {
+        return "{$fileName}-{$conversion->getName()}";
     }
 }

--- a/src/Support/FileNamer/DefaultFileNamer.php
+++ b/src/Support/FileNamer/DefaultFileNamer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\MediaLibrary\Support\FileNamer;
+
+class DefaultFileNamer extends FileNamer
+{
+    public function getFileName(string $fileName): string
+    {
+        return pathinfo($fileName, PATHINFO_FILENAME);
+    }
+}

--- a/src/Support/FileNamer/FileNamer.php
+++ b/src/Support/FileNamer/FileNamer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\MediaLibrary\Support\FileNamer;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+abstract class FileNamer
+{
+    abstract public function getFileName(string $fileName): string;
+
+    public function addPropertiesToFileName(string $fileName, string $conversionName, int $width, int $height, string $extension): string
+    {
+        return "{$this->getFileName($fileName)}___{$conversionName}_{$width}_{$height}.{$extension}";
+    }
+
+    public function getTemporarilyFileName(Media $media, string $extension): string
+    {
+        return "{$this->getFileName($media->file_name)}.{$extension}";
+    }
+
+    public function getExtension(string $baseImage): string
+    {
+        return pathinfo($baseImage, PATHINFO_EXTENSION);
+    }
+}

--- a/src/Support/FileNamer/FileNamer.php
+++ b/src/Support/FileNamer/FileNamer.php
@@ -26,5 +26,4 @@ abstract class FileNamer
         $fileName = pathinfo($fileName, PATHINFO_FILENAME);
         return "{$fileName}___{$conversionName}_{$width}_{$height}.{$extension}";
     }
-
 }

--- a/src/Support/FileNamer/FileNamer.php
+++ b/src/Support/FileNamer/FileNamer.php
@@ -13,7 +13,7 @@ abstract class FileNamer
         return "{$this->getFileName($fileName)}___{$conversionName}_{$width}_{$height}.{$extension}";
     }
 
-    public function getTemporarilyFileName(Media $media, string $extension): string
+    public function getTemporaryFileName(Media $media, string $extension): string
     {
         return "{$this->getFileName($media->file_name)}.{$extension}";
     }

--- a/src/Support/FileNamer/FileNamer.php
+++ b/src/Support/FileNamer/FileNamer.php
@@ -2,16 +2,14 @@
 
 namespace Spatie\MediaLibrary\Support\FileNamer;
 
+use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 abstract class FileNamer
 {
     abstract public function getFileName(string $fileName): string;
 
-    public function addPropertiesToFileName(string $fileName, string $conversionName, int $width, int $height, string $extension): string
-    {
-        return "{$this->getFileName($fileName)}___{$conversionName}_{$width}_{$height}.{$extension}";
-    }
+    abstract public function addConversionToFileName(string $fileName, Conversion $conversion): string;
 
     public function getTemporaryFileName(Media $media, string $extension): string
     {
@@ -22,4 +20,11 @@ abstract class FileNamer
     {
         return pathinfo($baseImage, PATHINFO_EXTENSION);
     }
+
+    public function addPropertiesToFileName(string $fileName, string $conversionName, int $width, int $height, string $extension): string
+    {
+        $fileName = pathinfo($fileName, PATHINFO_FILENAME);
+        return "{$fileName}___{$conversionName}_{$width}_{$height}.{$extension}";
+    }
+
 }

--- a/tests/Conversions/ConversionFileNamerTest.php
+++ b/tests/Conversions/ConversionFileNamerTest.php
@@ -3,25 +3,27 @@
 namespace Spatie\MediaLibrary\Tests\Conversions;
 
 use Spatie\MediaLibrary\Tests\TestCase;
-use Spatie\MediaLibrary\Tests\TestSupport\testfiles\TestConversionFileNamer;
+use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
 
 class ConversionFileNamerTest extends TestCase
 {
+    public string $fileName = "prefix_test_suffix";
+
     /** @test */
-    public function it_can_use_a_custom_conversion_file_namer()
+    public function it_can_use_a_custom_file_namer()
     {
-        config()->set('media-library.conversion_file_namer', TestConversionFileNamer::class);
+        config()->set("media-library.file_namer", TestFileNamer::class);
 
         $this
             ->testModelWithConversion
             ->addMedia($this->getTestJpg())
             ->toMediaCollection();
 
-        $path = $this->testModelWithConversion->refresh()->getFirstMediaPath('default', 'thumb');
+        $path = $this->testModelWithConversion->refresh()->getFirstMediaPath("default", "thumb");
 
-        $this->assertStringEndsWith('test---thumb.jpg', $path);
+        $this->assertStringEndsWith("{$this->fileName}---thumb.jpg", $path);
         $this->assertFileExists($path);
 
-        $this->assertEquals('/media/1/conversions/test---thumb.jpg', $this->testModelWithConversion->getFirstMediaUrl('default', 'thumb'));
+        $this->assertEquals("/media/1/conversions/{$this->fileName}---thumb.jpg", $this->testModelWithConversion->getFirstMediaUrl("default", "thumb"));
     }
 }

--- a/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
@@ -10,6 +10,6 @@ class ResponsiveImageFileNamerTest extends ResponsiveImageTest
     {
         parent::setUp();
         config()->set("media-library.file_namer", TestFileNamer::class);
-        $this->file_name = "testing_file_namer";
+        $this->file_name = "prefix_test_suffix";
     }
 }

--- a/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
@@ -6,14 +6,10 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
 
 class ResponsiveImageFileNamerTest extends ResponsiveImageTest
 {
-    /**
-     * Runs the same set of tests as ResponsiveImageTest, but with a different
-     * File namer.
-     */
     public function setUp(): void
     {
         parent::setUp();
-        \Config::set("media-library.file_namer", TestFileNamer::class);
+        config()->set("media-library.file_namer", TestFileNamer::class);
         $this->file_name = "testing_file_namer";
     }
 }

--- a/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\ResponsiveImages;
+
+use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
+
+class ResponsiveImageFileNamerTest extends ResponsiveImageTest
+{
+    /**
+     * Runs the same set of tests as ResponsiveImageTest, but with a different
+     * File namer.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        \Config::set("media-library.file_namer", TestFileNamer::class);
+        $this->file_name = "testing_file_namer";
+    }
+}

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
@@ -10,6 +10,6 @@ class ResponsiveImageGeneratorFileNamerTest extends ResponsiveImageGeneratorTest
     {
         parent::setUp();
         config()->set("media-library.file_namer", TestFileNamer::class);
-        $this->fileName = "testing_file_namer";
+        $this->fileName = "prefix_test_suffix";
     }
 }

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\ResponsiveImages;
+
+use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
+
+class ResponsiveImageGeneratorFileNamerTest extends ResponsiveImageGeneratorTest
+{
+    /**
+     * Runs the same set of tests as ResponsiveImageGeneratorTest, but with a different
+     * File namer.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        \Config::set("media-library.file_namer", TestFileNamer::class);
+        $this->file_name = "testing_file_namer";
+    }
+}

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
@@ -6,14 +6,10 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
 
 class ResponsiveImageGeneratorFileNamerTest extends ResponsiveImageGeneratorTest
 {
-    /**
-     * Runs the same set of tests as ResponsiveImageGeneratorTest, but with a different
-     * File namer.
-     */
     public function setUp(): void
     {
         parent::setUp();
-        \Config::set("media-library.file_namer", TestFileNamer::class);
-        $this->file_name = "testing_file_namer";
+        config()->set("media-library.file_namer", TestFileNamer::class);
+        $this->fileName = "testing_file_namer";
     }
 }

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -8,6 +8,8 @@ use Spatie\MediaLibrary\Tests\TestCase;
 
 class ResponsiveImageGeneratorTest extends TestCase
 {
+    public string $file_name = "test";
+
     /** @test */
     public function it_can_generate_responsive_images()
     {
@@ -16,9 +18,9 @@ class ResponsiveImageGeneratorTest extends TestCase
                 ->withResponsiveImages()
                 ->toMediaCollection();
 
-        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_237_195.jpg'));
-        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_284_233.jpg'));
-        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_340_280.jpg'));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_237_195.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_284_233.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_340_280.jpg"));
     }
 
     /** @test */
@@ -29,11 +31,11 @@ class ResponsiveImageGeneratorTest extends TestCase
                 ->withResponsiveImagesIf(fn () => true)
                 ->toMediaCollection();
 
-        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_237_195.jpg'));
-        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_284_233.jpg'));
-        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___media_library_original_340_280.jpg'));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_237_195.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_284_233.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_340_280.jpg"));
     }
-    
+
     /** @test */
     public function it_will_not_generate_responsive_images_if_withResponsiveImagesIf_returns_false()
     {
@@ -42,7 +44,7 @@ class ResponsiveImageGeneratorTest extends TestCase
                 ->withResponsiveImagesIf(fn () => false)
                 ->toMediaCollection();
 
-        $this->assertFileDoesNotExist($this->getTempDirectory('media/1/responsive-images/test___media_library_original_237_195.jpg'));
+        $this->assertFileDoesNotExist($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_237_195.jpg"));
     }
 
     /** @test */
@@ -53,7 +55,7 @@ class ResponsiveImageGeneratorTest extends TestCase
                     ->withResponsiveImages()
                     ->toMediaCollection();
 
-        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___thumb_50_41.jpg'));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___thumb_50_41.jpg"));
     }
 
     /** @test */
@@ -64,7 +66,7 @@ class ResponsiveImageGeneratorTest extends TestCase
             ->withResponsiveImages()
             ->toMediaCollection();
 
-        $this->assertFileExists($this->getTempDirectory('media/1/responsive-images/test___pngtojpg_700_883.jpg'));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___pngtojpg_700_883.jpg"));
     }
 
     /** @test */
@@ -84,32 +86,32 @@ class ResponsiveImageGeneratorTest extends TestCase
     public function it_cleans_the_responsive_images_urls_from_the_db_before_regeneration()
     {
         $media = $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->addMedia($this->getTestFilesDirectory("test.jpg"))
             ->withResponsiveImages()
             ->toMediaCollection();
 
-        $this->assertCount(1, $media->fresh()->responsive_images['thumb']['urls']);
+        $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
 
-        $this->artisan('media-library:regenerate');
-        $this->assertCount(1, $media->fresh()->responsive_images['thumb']['urls']);
+        $this->artisan("media-library:regenerate");
+        $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
     }
 
     /** @test */
     public function it_will_add_responsive_image_entries_when_there_were_none_when_regenerating()
     {
         $media = $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->addMedia($this->getTestFilesDirectory("test.jpg"))
             ->withResponsiveImages()
             ->toMediaCollection();
 
         // remove all responsive image db entries
         $responsiveImages = $media->responsive_images;
-        $responsiveImages['thumb']['urls'] = [];
+        $responsiveImages["thumb"]["urls"] = [];
         $media->responsive_images = $responsiveImages;
         $media->save();
-        $this->assertCount(0, $media->fresh()->responsive_images['thumb']['urls']);
+        $this->assertCount(0, $media->fresh()->responsive_images["thumb"]["urls"]);
 
-        $this->artisan('media-library:regenerate');
-        $this->assertCount(1, $media->fresh()->responsive_images['thumb']['urls']);
+        $this->artisan("media-library:regenerate");
+        $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
     }
 }

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -8,7 +8,7 @@ use Spatie\MediaLibrary\Tests\TestCase;
 
 class ResponsiveImageGeneratorTest extends TestCase
 {
-    public string $file_name = "test";
+    public string $fileName = "test";
 
     /** @test */
     public function it_can_generate_responsive_images()
@@ -18,9 +18,9 @@ class ResponsiveImageGeneratorTest extends TestCase
                 ->withResponsiveImages()
                 ->toMediaCollection();
 
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_237_195.jpg"));
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_284_233.jpg"));
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_340_280.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg"));
     }
 
     /** @test */
@@ -31,9 +31,9 @@ class ResponsiveImageGeneratorTest extends TestCase
                 ->withResponsiveImagesIf(fn () => true)
                 ->toMediaCollection();
 
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_237_195.jpg"));
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_284_233.jpg"));
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_340_280.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg"));
     }
 
     /** @test */
@@ -44,7 +44,7 @@ class ResponsiveImageGeneratorTest extends TestCase
                 ->withResponsiveImagesIf(fn () => false)
                 ->toMediaCollection();
 
-        $this->assertFileDoesNotExist($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___media_library_original_237_195.jpg"));
+        $this->assertFileDoesNotExist($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
     }
 
     /** @test */
@@ -55,7 +55,7 @@ class ResponsiveImageGeneratorTest extends TestCase
                     ->withResponsiveImages()
                     ->toMediaCollection();
 
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___thumb_50_41.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg"));
     }
 
     /** @test */
@@ -66,7 +66,7 @@ class ResponsiveImageGeneratorTest extends TestCase
             ->withResponsiveImages()
             ->toMediaCollection();
 
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->file_name}___pngtojpg_700_883.jpg"));
+        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___pngtojpg_700_883.jpg"));
     }
 
     /** @test */

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -6,6 +6,8 @@ use Spatie\MediaLibrary\Tests\TestCase;
 
 class ResponsiveImageTest extends TestCase
 {
+    public string $file_name = 'test';
+
     /** @test */
     public function a_media_instance_can_get_responsive_image_urls()
     {
@@ -18,16 +20,16 @@ class ResponsiveImageTest extends TestCase
         $media = $this->testModelWithResponsiveImages->getFirstMedia();
 
         $this->assertEquals([
-            'http://localhost/media/1/responsive-images/test___media_library_original_340_280.jpg',
-            'http://localhost/media/1/responsive-images/test___media_library_original_284_233.jpg',
-            'http://localhost/media/1/responsive-images/test___media_library_original_237_195.jpg',
+            "http://localhost/media/1/responsive-images/{$this->file_name}___media_library_original_340_280.jpg",
+            "http://localhost/media/1/responsive-images/{$this->file_name}___media_library_original_284_233.jpg",
+            "http://localhost/media/1/responsive-images/{$this->file_name}___media_library_original_237_195.jpg",
         ], $media->getResponsiveImageUrls());
 
         $this->assertEquals([
-            'http://localhost/media/1/responsive-images/test___thumb_50_41.jpg',
-        ], $media->getResponsiveImageUrls('thumb'));
+            "http://localhost/media/1/responsive-images/{$this->file_name}___thumb_50_41.jpg",
+        ], $media->getResponsiveImageUrls("thumb"));
 
-        $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));
+        $this->assertEquals([], $media->getResponsiveImageUrls("non-existing-conversion"));
     }
 
     /** @test */
@@ -41,16 +43,16 @@ class ResponsiveImageTest extends TestCase
         $media = $this->testModelWithResponsiveImages->getFirstMedia();
 
         $this->assertStringContainsString(
-            'http://localhost/media/1/responsive-images/test___media_library_original_340_280.jpg 340w, http://localhost/media/1/responsive-images/test___media_library_original_284_233.jpg 284w, http://localhost/media/1/responsive-images/test___media_library_original_237_195.jpg 237w',
+            "http://localhost/media/1/responsive-images/{$this->file_name}___media_library_original_340_280.jpg 340w, http://localhost/media/1/responsive-images/{$this->file_name}___media_library_original_284_233.jpg 284w, http://localhost/media/1/responsive-images/{$this->file_name}___media_library_original_237_195.jpg 237w",
             $media->getSrcset()
         );
-        $this->assertStringContainsString('data:image/svg+xml;base64', $media->getSrcset());
+        $this->assertStringContainsString("data:image/svg+xml;base64", $media->getSrcset());
 
         $this->assertStringContainsString(
-            'http://localhost/media/1/responsive-images/test___thumb_50_41.jpg 50w',
-            $media->getSrcset('thumb')
+            "http://localhost/media/1/responsive-images/{$this->file_name}___thumb_50_41.jpg 50w",
+            $media->getSrcset("thumb")
         );
-        $this->assertStringContainsString('data:image/svg+xml;base64,', $media->getSrcset('thumb'));
+        $this->assertStringContainsString("data:image/svg+xml;base64,", $media->getSrcset("thumb"));
     }
 
     /** @test */
@@ -65,7 +67,7 @@ class ResponsiveImageTest extends TestCase
 
         $responsiveImage = $media->responsiveImages()->files->first();
 
-        $this->assertEquals('media_library_original', $responsiveImage->generatedFor());
+        $this->assertEquals("media_library_original", $responsiveImage->generatedFor());
 
         $this->assertEquals(340, $responsiveImage->width());
 
@@ -78,10 +80,10 @@ class ResponsiveImageTest extends TestCase
         $this->testModelWithResponsiveImages
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
-            ->toMediaCollection('default');
+            ->toMediaCollection("default");
 
-        $standardQualityResponsiveConversion = $this->getTempDirectory('media/1/responsive-images/test___standardQuality_340_280.jpg');
-        $lowerQualityResponsiveConversion = $this->getTempDirectory('media/1/responsive-images/test___lowerQuality_340_280.jpg');
+        $standardQualityResponsiveConversion = $this->getTempDirectory("media/1/responsive-images/{$this->file_name}___standardQuality_340_280.jpg");
+        $lowerQualityResponsiveConversion = $this->getTempDirectory("media/1/responsive-images/{$this->file_name}___lowerQuality_340_280.jpg");
 
         $this->assertLessThan(filesize($standardQualityResponsiveConversion), filesize($lowerQualityResponsiveConversion));
     }
@@ -92,13 +94,13 @@ class ResponsiveImageTest extends TestCase
         $this->testModelWithResponsiveImages
             ->addMedia($this->getTestJpg())
             ->withResponsiveImages()
-            ->storingConversionsOnDisk('secondMediaDisk')
+            ->storingConversionsOnDisk("secondMediaDisk")
             ->toMediaCollection();
 
         $media = $this->testModelWithResponsiveImages->getFirstMedia();
 
         $this->assertEquals([
-            'http://localhost/media2/1/responsive-images/test___thumb_50_41.jpg',
-        ], $media->getResponsiveImageUrls('thumb'));
+            "http://localhost/media2/1/responsive-images/{$this->file_name}___thumb_50_41.jpg",
+        ], $media->getResponsiveImageUrls("thumb"));
     }
 }

--- a/tests/TestSupport/TestFileNamer.php
+++ b/tests/TestSupport/TestFileNamer.php
@@ -6,7 +6,6 @@ use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
 
 class TestFileNamer extends FileNamer
 {
-
     public function getFileName(string $fileName): string
     {
         return 'testing_file_namer';

--- a/tests/TestSupport/TestFileNamer.php
+++ b/tests/TestSupport/TestFileNamer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport;
+
+use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
+
+class TestFileNamer extends FileNamer
+{
+
+    public function getFileName(string $fileName): string
+    {
+        return 'testing_file_namer';
+    }
+}

--- a/tests/TestSupport/testfiles/TestFileNamer.php
+++ b/tests/TestSupport/testfiles/TestFileNamer.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\TestSupport;
+namespace Spatie\MediaLibrary\Tests\TestSupport\testfiles;
 
-use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
 
 class TestFileNamer extends FileNamer
@@ -12,10 +11,5 @@ class TestFileNamer extends FileNamer
         $fileName = pathinfo($fileName, PATHINFO_FILENAME);
 
         return 'prefix_' . $fileName . '_suffix';
-    }
-
-    public function addConversionToFileName(string $fileName, Conversion $conversion): string
-    {
-        return "{$fileName}---{$conversion->getName()}";
     }
 }


### PR DESCRIPTION
It's already possible to use a custom file namer on conversions. This PR allows responsive images to use a custom file namer too. We introduce a new base class: FileNamer.php

**To do:**
- update documentation

https://github.com/spatie/laravel-medialibrary/issues/1784