### PR TITLE
Add down() method in migration file

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -28,4 +28,14 @@ class CreateMediaTable extends Migration
             $table->nullableTimestamps();
         });
     }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('media');
+    }
 }


### PR DESCRIPTION
This pull request added a down() method in database migration file. Without down() method, the following error occured whenever we refresh the migrations by using the command `php artisan migrate:refresh`.

Error
```
Illuminate\Database\QueryException

SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'media' already exists
```