### PR TITLE
[Fix] add support for dropping media table

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -28,4 +28,9 @@ class CreateMediaTable extends Migration
             $table->nullableTimestamps();
         });
     }
+    
+    public function down()
+    {
+         Schema::dropIfExists('media');
+    }
 }


### PR DESCRIPTION
On php artisan rollback the media table would be dropped.