### PR TITLE
make media uuid creation optional

### DIFF
--- a/src/MediaCollections/Models/Concerns/Uuidable.php
+++ b/src/MediaCollections/Models/Concerns/Uuidable.php
@@ -5,12 +5,12 @@ namespace Spatie\MediaLibrary\MediaCollections\Models\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
-trait HasUuid
+trait Uuidable
 {
-    public static function bootHasUuid()
+    public static function bootUuidable()
     {
         static::creating(function (Model $model) {
-            if (empty($model->uuid)) {
+            if ($model::usesUuids() && empty($model->uuid)) {
                 $model->uuid = (string) Str::uuid();
             }
         });
@@ -18,6 +18,14 @@ trait HasUuid
 
     public static function findByUuid(string $uuid): ?Model
     {
-        return static::where('uuid', $uuid)->first();
+        if (static::usesUuids()) {
+            return static::where('uuid', $uuid)->first();
+        }
+
+        return null;
+    }
+
+    protected static function usesUuids() {
+        return config('media-library.uses_media_uuids', true);
     }
 }

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -17,7 +17,7 @@ use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\MediaCollections\HtmlableMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Collections\MediaCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Concerns\CustomMediaProperties;
-use Spatie\MediaLibrary\MediaCollections\Models\Concerns\HasUuid;
+use Spatie\MediaLibrary\MediaCollections\Models\Concerns\Uuidable;
 use Spatie\MediaLibrary\MediaCollections\Models\Concerns\IsSorted;
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
 use Spatie\MediaLibrary\Support\File;
@@ -28,7 +28,7 @@ class Media extends Model implements Responsable, Htmlable
 {
     use IsSorted,
         CustomMediaProperties,
-        HasUuid;
+        Uuidable;
 
     protected $table = 'media';
 

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -12,6 +12,7 @@ use Spatie\MediaLibrary\MediaCollections\Exceptions\MimeTypeNotAllowed;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\RequestDoesNotHaveFile;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\UnknownType;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -631,5 +632,17 @@ class IntegrationTest extends TestCase
         $result = $this->call('get', 'upload', [], [], ['file' => ['name'=>$fileUpload]]);
 
         $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    /** @test */
+    public function it_can_add_media_thats_not_uuid_enabled()
+    {
+        config()->set('media-library.uses_media_uuids', false);
+
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->toMediaCollection();
+
+        $this->assertEquals(null, $media->uuid);
     }
 }


### PR DESCRIPTION
Make the automatic uuid creation optional, and eliminate the need for a spurious DB column, for apps that don't need it. Default to creating uuids. Can be disabled with the config key `media-library.uses_media_uuids`, or by overriding `Media::usesUuids()`.