### PR TITLE
Fix link to Laravel File Storage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $newsItem->addMedia($smallFile)->toMediaCollection('downloads', 'local');
 $newsItem->addMedia($bigFile)->toMediaCollection('downloads', 's3');
 ```
 
-The storage of the files is handled by [Laravel's Filesystem](https://laravel.com/docs/5.6/filesystem),
+The storage of the files is handled by [Laravel's Filesystem](https://laravel.com/docs/filesystem),
 so you can use any filesystem you like. Additionally the package can create image manipulations
 on images and pdfs that have been added in the media library.
 


### PR DESCRIPTION
The current link points to Laravel 5.6 which is not supported by this package.

This updates the link to point to Laravel on the latest version regardless of what version is the latest now (laravel docs automatically redirects when the version isn't included).