### PR TITLE
Fix the version number for Version 9 in installation doc

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -8,13 +8,13 @@ Media library can be installed via Composer:
 If you only use the base package issue this command:
 
 ```bash
-composer require "spatie/laravel-medialibrary:^8.0.0"
+composer require "spatie/laravel-medialibrary:^9.0.0"
 ```
 
 If you have a license for media library pro, you should use `laravel-media-library-pro`
 
 ```bash
-composer require "spatie/laravel-medialibrary-pro:^8.0.0"
+composer require "spatie/laravel-medialibrary-pro:^9.0.0"
 ```
 
 ## Preparing the database


### PR DESCRIPTION
Hello, I noticed in the documentations in the version 9 (master), The composer command refers to version 8.0.0 . 
I changed both of medialibrary and assumed that medialibrary-pro also has version 9. 