### PR TITLE
Add pdf to image as a dependency

### DIFF
--- a/docs/converting-other-file-types/using-image-generators.md
+++ b/docs/converting-other-file-types/using-image-generators.md
@@ -22,7 +22,7 @@ The media library includes image generators for the following file types:
 
 ## PDF
 
-The PDF generator requires [Imagick](http://php.net/manual/en/imagick.setresolution.php) and [Ghostscript](https://www.ghostscript.com/). If you're running into issues with Ghostscript have a look at [issues regarding Ghostscript](https://github.com/spatie/pdf-to-image/blob/master/README.md#issues-regarding-ghostscript).
+The PDF generator requires [Imagick](http://php.net/manual/en/imagick.setresolution.php), [Ghostscript](https://www.ghostscript.com/), and [Spatie Pdf to Image](https://github.com/spatie/pdf-to-image). If you're running into issues with Ghostscript have a look at [issues regarding Ghostscript](https://github.com/spatie/pdf-to-image/blob/master/README.md#issues-regarding-ghostscript).
 
 The pdf image generator allows you to choose at which page of the pdf, the thumbnail should be created using the `pdfPageNumber` on the conversion.
 


### PR DESCRIPTION
I don't know why it's not mentioned in the docs, but I had to do a lot of tinkering in the `artisan tinker` and follow the `media-library:regenerate` down the rabbit hole to find out that I have to install this package to get pdf thumbnails.