### PR TITLE
Allow image generators to accept config

### DIFF
--- a/docs/converting-other-file-types/creating-a-custom-image-generator.md
+++ b/docs/converting-other-file-types/creating-a-custom-image-generator.md
@@ -7,7 +7,7 @@ If you want to generate a conversion for a file type that is not covered out of 
 
 In the following example we'll create a custom generator that can convert a Powerpoint to an image.
 
-## Creating the custom generator
+## Creating a custom image generator
 
 The first step for creating a custom generator is to create a class that extends `Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGenerator`:
 
@@ -53,10 +53,41 @@ class PowerPoint extends ImageGenerator
 
 ## Registering the custom generator
 
-If you want the generator to be applied to all your models, you can override the `Media` class as explained in the
-[using your own model](/laravel-medialibrary/v9/advanced-usage/using-your-own-model/) page and modify the
-`getImageGenerators` method in your own `Media` class.
+After creating your custom image generator, you should add the class name to the `image_generators` key of the `media-library` config file.
 
+```php
+// in config/laravel-medialibrary.php
+'image_generators' => [
+    // ...
+    YourImageGenerator::class,
+], 
+```
+
+## Passing configuration to a custom image generator
+
+When registering a custom image generator in the `media-library` config file, you can pass values like this
+
+```php
+// in config/laravel-medialibrary.php
+'image_generators' => [
+    // ...
+    YourImageGenerator::class => ['myArgument' => 'value', 'myOtherArgument' => 'otherValue'],
+], 
+```
+
+In your custom image generator you can accept those arguments in the constructor.
+
+```php
+class YourImageGenerator
+{
+    public function __construct(string $myArgument, string $myOtherArgument)
+    {
+        // do something with these arguments
+    }
+}
+```
+
+## Only using a custom image generator a specific model
 
 If the generator only needs to be applied to one of your models you can override the `getImageGenerators` in that model like this:
 

--- a/src/Conversions/ImageGenerators/ImageGeneratorFactory.php
+++ b/src/Conversions/ImageGenerators/ImageGeneratorFactory.php
@@ -10,7 +10,15 @@ class ImageGeneratorFactory
     public static function getImageGenerators(): Collection
     {
         return collect(config('media-library.image_generators'))
-            ->map(fn (string $imageGeneratorClassName) => app($imageGeneratorClassName));
+            ->map(function ($imageGeneratorClassName, $key) {
+                $imageGeneratorConfig = [];
+
+                if (! is_numeric($key)) {
+                    $imageGeneratorConfig = $imageGeneratorClassName;
+                    $imageGeneratorClassName = $key;
+                }
+                return app($imageGeneratorClassName, $imageGeneratorConfig);
+            });
     }
 
     public static function forExtension(?string $extension): ?ImageGenerator

--- a/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
+++ b/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
@@ -12,7 +12,7 @@ class TestImageGeneratorWithConfigTest extends TestCase
     public function image_generators_can_get_parameter_from_the_config_file()
     {
         config()->set('media-library.image_generators', [
-            TestImageGeneratorWithConfig::class => ['test' => 'value', 'test2' => 'value2'],
+            TestImageGeneratorWithConfig::class => ['firstName' => 'firstValue', 'secondName' => 'secondValue'],
         ]);
 
         $imageGenerators = ImageGeneratorFactory::getImageGenerators();
@@ -20,8 +20,23 @@ class TestImageGeneratorWithConfigTest extends TestCase
         $testGeneratorWithConfig = $imageGenerators->first();
 
         $this->assertInstanceOf(TestImageGeneratorWithConfig::class, $testGeneratorWithConfig);
-        $this->assertEquals('value', $testGeneratorWithConfig->test);
-        $this->assertEquals('value2', $testGeneratorWithConfig->test2);
+        $this->assertEquals('firstValue', $testGeneratorWithConfig->firstName);
+        $this->assertEquals('secondValue', $testGeneratorWithConfig->secondName);
+    }
 
+    /** @test */
+    public function image_generators_will_receive_config_parameters_by_name()
+    {
+        config()->set('media-library.image_generators', [
+            TestImageGeneratorWithConfig::class => ['secondName' => 'secondValue', 'firstName' => 'firstValue', ],
+        ]);
+
+        $imageGenerators = ImageGeneratorFactory::getImageGenerators();
+
+        $testGeneratorWithConfig = $imageGenerators->first();
+
+        $this->assertInstanceOf(TestImageGeneratorWithConfig::class, $testGeneratorWithConfig);
+        $this->assertEquals('firstValue', $testGeneratorWithConfig->firstName);
+        $this->assertEquals('secondValue', $testGeneratorWithConfig->secondName);
     }
 }

--- a/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
+++ b/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Conversions\ImageGenerators;
+
+use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
+use Spatie\MediaLibrary\Tests\TestCase;
+use Spatie\MediaLibrary\Tests\TestSupport\TestImageGeneratorWithConfig;
+
+class TestImageGeneratorWithConfigTest extends TestCase
+{
+    /** @test */
+    public function image_generators_can_get_parameter_from_the_config_file()
+    {
+        config()->set('media-library.image_generators', [
+            TestImageGeneratorWithConfig::class => ['test' => 'value', 'test2' => 'value2'],
+        ]);
+
+        $imageGenerators = ImageGeneratorFactory::getImageGenerators();
+
+        $testGeneratorWithConfig = $imageGenerators->first();
+
+        $this->assertInstanceOf(TestImageGeneratorWithConfig::class, $testGeneratorWithConfig);
+        $this->assertEquals('value', $testGeneratorWithConfig->test);
+        $this->assertEquals('value2', $testGeneratorWithConfig->test2);
+
+    }
+}

--- a/tests/TestSupport/TestImageGeneratorWithConfig.php
+++ b/tests/TestSupport/TestImageGeneratorWithConfig.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport;
+
+use Illuminate\Support\Collection;
+use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGenerator;
+
+class TestImageGeneratorWithConfig extends ImageGenerator
+{
+    public string $test;
+
+    public string $test2;
+
+    public function __construct(string $test, string $test2)
+    {
+        $this->test = $test;
+
+        $this->test2 = $test2;
+    }
+
+    public function convert(string $file, Conversion $conversion = null): string
+    {
+        // TODO: Implement convert() method.
+    }
+
+    public function requirementsAreInstalled(): bool
+    {
+        // TODO: Implement requirementsAreInstalled() method.
+    }
+
+    public function supportedExtensions(): Collection
+    {
+        // TODO: Implement supportedExtensions() method.
+    }
+
+    public function supportedMimeTypes(): Collection
+    {
+        // TODO: Implement supportedMimeTypes() method.
+    }
+}

--- a/tests/TestSupport/TestImageGeneratorWithConfig.php
+++ b/tests/TestSupport/TestImageGeneratorWithConfig.php
@@ -8,15 +8,15 @@ use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGenerator;
 
 class TestImageGeneratorWithConfig extends ImageGenerator
 {
-    public string $test;
+    public string $firstName;
 
-    public string $test2;
+    public string $secondName;
 
-    public function __construct(string $test, string $test2)
+    public function __construct(string $firstName, string $secondName)
     {
-        $this->test = $test;
+        $this->firstName = $firstName;
 
-        $this->test2 = $test2;
+        $this->secondName = $secondName;
     }
 
     public function convert(string $file, Conversion $conversion = null): string


### PR DESCRIPTION
When registering a custom image generator in the `media-library` config file, you can pass values like this

```php
// in config/laravel-medialibrary.php
'image_generators' => [
    // ...
    YourImageGenerator::class => ['myArgument' => 'value', 'myOtherArgument' => 'otherValue'],
], 
```

In your custom image generator you can accept those arguments in the constructor.

```php
class YourImageGenerator
{
    public function __construct(string $myArgument, string $myOtherArgument)
    {
        // do something with these arguments
    }
}
```