### PR TITLE
Allow customization of the file name of a Media when adding it to a zip

### DIFF
--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -70,7 +70,7 @@ class MediaStream implements Responsable
     {
         $headers = [
             'Content-Disposition' => "attachment; filename=\"{$this->zipName}\"",
-            'Content-Type' => 'application/octet-stream',
+            'Content-Type'        => 'application/octet-stream',
         ];
 
         return new StreamedResponse(fn () => $this->getZipStream(), 200, $headers);
@@ -98,39 +98,50 @@ class MediaStream implements Responsable
     protected function getZipStreamContents(): Collection
     {
         return $this->mediaItems->map(fn (Media $media, $mediaItemIndex) => [
-            'fileNameInZip' => $this->getZipFileNamePrefix($this->mediaItems, $mediaItemIndex).$this->getFileNameWithSuffix($this->mediaItems, $mediaItemIndex),
-            'media' => $media,
-        ]);
+        'fileNameInZip' => $this->getZipFileNamePrefix($this->mediaItems, $mediaItemIndex) . $this->getFileNameWithSuffix($this->mediaItems, $mediaItemIndex),
+        'media'         => $media,
+    ]);
     }
 
     protected function getFileNameWithSuffix(Collection $mediaItems, int $currentIndex): string
     {
         $fileNameCount = 0;
 
-        $fileName = $mediaItems[$currentIndex]->file_name;
-
         foreach ($mediaItems as $index => $media) {
             if ($index >= $currentIndex) {
                 break;
             }
 
-            if ($this->getZipFileNamePrefix($mediaItems, $index).$media->file_name === $this->getZipFileNamePrefix($mediaItems, $currentIndex).$fileName) {
+            if ($this->getZipFileNameWithSuffix($mediaItems, $index) === $this->getZipFileNameWithSuffix($mediaItems, $currentIndex)) {
                 $fileNameCount++;
             }
         }
-
         if ($fileNameCount === 0) {
-            return $fileName;
+            return $this->getZipFileName($mediaItems, $currentIndex);
         }
 
-        $extension = pathinfo($fileName, PATHINFO_EXTENSION);
-        $fileNameWithoutExtension = pathinfo($fileName, PATHINFO_FILENAME);
+        $extension = pathinfo($mediaItems[$currentIndex]->file_name, PATHINFO_EXTENSION);
 
-        return "{$fileNameWithoutExtension} ({$fileNameCount}).{$extension}";
+        return $this->getZipFileNameWithoutExtension($mediaItems, $currentIndex) . " ({$fileNameCount}).{$extension}";
     }
 
     protected function getZipFileNamePrefix(Collection $mediaItems, int $currentIndex): string
     {
         return $mediaItems[$currentIndex]->hasCustomProperty('zip_filename_prefix') ? $mediaItems[$currentIndex]->getCustomProperty('zip_filename_prefix') : '';
+    }
+
+    protected function getZipFileNameWithoutExtension(Collection $mediaItems, int $currentIndex): string
+    {
+        return $mediaItems[$currentIndex]->hasCustomProperty('zip_filename_suffix') ? $mediaItems[$currentIndex]->getCustomProperty('zip_filename_suffix') : pathinfo($mediaItems[$currentIndex]->file_name, PATHINFO_FILENAME);
+    }
+
+    protected function getZipFileNameWithSuffix(Collection $mediaItems, int $currentIndex): string
+    {
+        return $this->getZipFileNamePrefix($mediaItems, $currentIndex) . $this->getZipFileName($mediaItems, $currentIndex);
+    }
+
+    public function getZipFileName(Collection $mediaItems, int $currentIndex): string
+    {
+        return $this->getZipFileNameWithoutExtension($mediaItems, $currentIndex) . '.' . pathinfo($mediaItems[$currentIndex]->file_name, PATHINFO_EXTENSION);
     }
 }

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -101,8 +101,16 @@ class MediaStreamTest extends TestCase
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
     }
 
+    /** @test */
     public function media_with_zip_file_folder_prefix_property_saved_in_correct_zip_folder_and_correct_suffix()
     {
+        foreach (range(1, 2) as $i) {
+            $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->preservingOriginal()
+                ->toMediaCollection();
+        }
+
         foreach (range(1, 2) as $i) {
             $this->testModel
                 ->addMedia($this->getTestJpg())
@@ -112,6 +120,23 @@ class MediaStreamTest extends TestCase
                 ])
                 ->toMediaCollection();
         }
+
+        $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->preservingOriginal()
+                ->withCustomProperties([
+                    'zip_filename_suffix' => 'foo',
+                ])
+                ->toMediaCollection();
+
+        $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->preservingOriginal()
+                ->withCustomProperties([
+                    'zip_filename_prefix' => 'folder/subfolder/',
+                    'zip_filename_suffix' => 'foo',
+                ])
+                ->toMediaCollection();
 
         $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
 
@@ -124,11 +149,13 @@ class MediaStreamTest extends TestCase
         file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test.jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (1).jpg');
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (3).jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'foo.jpg');
 
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (2).jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (1).jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/foo.jpg');
     }
 
     /** @test */


### PR DESCRIPTION
Currently you can only specify the sub folder when adding a file to a zip.

I would allow the customization of the file name while doing it by adding a custom property : 

`zip_filename_suffix`

Update in the documentation : 

https://github.com/spatie/laravel-medialibrary/pull/2175

