### PR TITLE
Fix migrate:refresh issue media already exists

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -6,11 +6,15 @@ use Illuminate\Database\Migrations\Migration;
 
 class CreateMediaTable extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('media', function (Blueprint $table) {
-            $table->bigIncrements('id');
-
+            $table->id();
             $table->morphs('model');
             $table->uuid('uuid')->nullable();
             $table->string('collection_name');
@@ -22,11 +26,19 @@ class CreateMediaTable extends Migration
             $table->unsignedBigInteger('size');
             $table->json('manipulations');
             $table->json('custom_properties');
-            $table->json('generated_conversions');
             $table->json('responsive_images');
             $table->unsignedInteger('order_column')->nullable();
-
             $table->nullableTimestamps();
         });
+    }
+    
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('media');
     }
 }


### PR DESCRIPTION
## Description
> QLSTATE[42S01]: Base table or view already exists: 1050 Table 'media' already exists

This PR will fix the issue when running the `php artisan migrate:refresh` command.