### PR TITLE
Update PerformConversionsJob.php to automatically delete job if model is missing

### DIFF
--- a/src/Conversions/Jobs/PerformConversionsJob.php
+++ b/src/Conversions/Jobs/PerformConversionsJob.php
@@ -14,6 +14,8 @@ class PerformConversionsJob implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels, Queueable;
 
+    public $deleteWhenMissingModels = true;
+
     protected ConversionCollection $conversions;
 
     protected Media $media;


### PR DESCRIPTION
Automatically delete a queued job if the model is missing, e.g. if media is deleted before the job has a chance to process.

Utilizes the [Ignore Missing Models](https://laravel.com/docs/8.x/queues#ignoring-missing-models) behavior in Laravel.