### PR TITLE
Add down() to create_media_table.php.stub

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -29,4 +29,9 @@ class CreateMediaTable extends Migration
             $table->nullableTimestamps();
         });
     }
+    
+    public function down()
+    {
+        Schema::dropIfExists('media');
+    }
 }


### PR DESCRIPTION
The generated migration has no `down()` method. I don't know if this is intended. If not, this PR adds the missing `down()` method.