### PR TITLE
Add unique index to UUID column

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -12,7 +12,7 @@ class CreateMediaTable extends Migration
             $table->bigIncrements('id');
 
             $table->morphs('model');
-            $table->uuid('uuid')->nullable();
+            $table->uuid('uuid')->nullable()->unique();
             $table->string('collection_name');
             $table->string('name');
             $table->string('file_name');


### PR DESCRIPTION
Since the point of UUID is usually for lookups, it should be indexed. Remember that uniqueness is not enforced on null in most database systems so this checks out.