### PR TITLE
Fixes incompatible return types error caussed PHPStorm's inability to resolve self

### DIFF
--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -42,7 +42,7 @@ interface HasMedia
      */
     public function getMedia(string $collectionName = 'default', $filters = []): Collection;
 
-    public function clearMediaCollection(string $collectionName = 'default'): self;
+    public function clearMediaCollection(string $collectionName = 'default'): HasMedia;
 
     /**
      * Remove all media in the given collection except some.
@@ -52,7 +52,7 @@ interface HasMedia
      *
      * @return $this
      */
-    public function clearMediaCollectionExcept(string $collectionName = 'default', $excludedMedia = []): self;
+    public function clearMediaCollectionExcept(string $collectionName = 'default', $excludedMedia = []): HasMedia;
 
     /**
      * Determines if the media files should be preserved when the media object gets deleted.

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -408,7 +408,7 @@ trait InteractsWithMedia
         }
     }
 
-    public function clearMediaCollection(string $collectionName = 'default'): self
+    public function clearMediaCollection(string $collectionName = 'default'): HasMedia
     {
         $this
             ->getMedia($collectionName)
@@ -431,7 +431,7 @@ trait InteractsWithMedia
      *
      * @return $this
      */
-    public function clearMediaCollectionExcept(string $collectionName = 'default', $excludedMedia = []): self
+    public function clearMediaCollectionExcept(string $collectionName = 'default', $excludedMedia = []): HasMedia
     {
         if ($excludedMedia instanceof Media) {
             $excludedMedia = collect()->push($excludedMedia);


### PR DESCRIPTION
This fixes #1999 and fixes #2164

There is nothing wrong with using self per se, but it causes an unnecessary error in PHPStorm that is pretty annoying. 
I don't see any harm in returning `HasMedia` instead of `self`, but you might think otherwise. 

**Alternative solution:** wait for a fix in PHPStrom. This is the issue on their issue tracker: 
https://youtrack.jetbrains.com/issue/WI-57097