### PR TITLE
Fixed generated conversions race-condition

### DIFF
--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -34,8 +34,8 @@ class FileManipulator
             ->partition(fn (Conversion $conversion) => $conversion->shouldBeQueued());
 
         $this
-            ->dispatchQueuedConversions($media, $queuedConversions, $onlyMissing)
-            ->performConversions($conversions, $media, $onlyMissing);
+            ->performConversions($conversions, $media, $onlyMissing)
+            ->dispatchQueuedConversions($media, $queuedConversions, $onlyMissing);
     }
 
     public function performConversions(


### PR DESCRIPTION
Fixed job overriding so nonQueued conversions get executed before the queued conversions get started. Adresses #2226. 

If I need to add tests I'd love some guidance, I tried to setup a failing test first but I had no luck recreating the behaviour inside a test.
