### PR TITLE
Update handling-uploads-with-vue.md

### DIFF
--- a/docs/handling-uploads-with-media-library-pro/handling-uploads-with-vue.md
+++ b/docs/handling-uploads-with-media-library-pro/handling-uploads-with-vue.md
@@ -279,7 +279,7 @@ The components keep track of whether they're ready to be submitted, you can use 
             @is-ready-to-submit-change="isReadyToSubmit = $event"
         />
 
-        <button :disabled="isReadyToSubmit">Submit</button>
+        <button :disabled="!isReadyToSubmit">Submit</button>
     </form>
 </template>
 


### PR DESCRIPTION
Add `!` to line 282 so button is disabled while form is _not ready_ to submit.

Without `!` the behavior disabled the button when ready to submit and **enabled** while _not ready_ to submit.