### PR TITLE
[DOCS FIX] Fixed Media Library Pro Blade example

### DIFF
--- a/docs/handling-uploads-with-media-library-pro/processing-uploads-on-the-server.md
+++ b/docs/handling-uploads-with-media-library-pro/processing-uploads-on-the-server.md
@@ -96,7 +96,7 @@ class ProfileController
         $user = Auth::user();
 
         $user
-            ->addFromMediaLibraryRequest($request, 'avatar')
+            ->addFromMediaLibraryRequest($request->avatar)
             ->toMediaCollection('avatar');
     }
 }


### PR DESCRIPTION
Media Library Pro Blade example in the docs is not working, with error:

```
Argument 1 passed to App\Models\Listing::addFromMediaLibraryRequest() must be of the type array or null, object given
```

I've traced the reason and fixed the docs according to the example app code:
https://github.com/spatie/laravel-medialibrary-pro-app/blob/master/app/Http/Controllers/Blade/BladeAttachmentController.php#L23