### PR TITLE
Allow conversions of any mime type to be rendered

### DIFF
--- a/src/MediaCollections/HtmlableMedia.php
+++ b/src/MediaCollections/HtmlableMedia.php
@@ -45,7 +45,7 @@ class HtmlableMedia implements Htmlable
 
     public function toHtml()
     {
-        if (! (new Image())->canHandleMime($this->media->mime_type)) {
+        if (empty($this->conversionName) && ! (new Image())->canHandleMime($this->media->mime_type)) {
             return '';
         }
 
@@ -62,6 +62,10 @@ class HtmlableMedia implements Htmlable
             $conversionObject = ConversionCollection::createForMedia($this->media)->getByName($this->conversionName);
 
             $loadingAttributeValue = $conversionObject->getLoadingAttributeValue();
+        }
+
+        if (empty($conversionObject) && ! (new Image())->canHandleMime($this->media->mime_type)) {
+            return '';
         }
 
         if ($this->loadingAttributeValue !== '') {


### PR DESCRIPTION
This allows conversions of any mime type to be rendered, rather than just limiting the rendering of media that is of an image based mime type. It still prevents rendering if the conversion is not available. It means that out of the box, no extra coding is required to render a selection of conversions of any form of file.