### PR TITLE
DiskDoesNotExist moved to it's own class

### DIFF
--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\Conversions\FileManipulator;
-use Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
@@ -145,7 +145,7 @@ class CleanCommand extends Command
         $diskName = $this->argument('disk') ?: config('media-library.disk_name');
 
         if (is_null(config("filesystems.disks.{$diskName}"))) {
-            throw FileCannotBeAdded::diskDoesNotExist($diskName);
+            throw DiskDoesNotExist::create($diskName);
         }
         $mediaClass = config('media-library.media_model');
         $mediaInstance = new $mediaClass();

--- a/tests/Conversions/Commands/CleanConversionsTest.php
+++ b/tests/Conversions/Commands/CleanConversionsTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Tests\Conversions\Commands;
 
 use Illuminate\Support\Facades\DB;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
@@ -185,5 +186,17 @@ class CleanConversionsTest extends TestCase
 
         $this->assertEquals($originalResponsiveImagesContent, $media->responsive_images);
         $this->assertFileDoesNotExist($deprecatedReponsiveImagesPath);
+    }
+
+
+    /** @test */
+    public function it_will_throw_an_exception_when_using_a_non_existing_disk()
+    {
+        $this->expectException(DiskDoesNotExist::class);
+
+        config(['media-library.disk_name' => 'diskdoesnotexist']);
+
+        $this->artisan('media-library:clean')
+            ->assertExitCode(1);
     }
 }

--- a/tests/Conversions/Commands/CleanConversionsTest.php
+++ b/tests/Conversions/Commands/CleanConversionsTest.php
@@ -188,7 +188,6 @@ class CleanConversionsTest extends TestCase
         $this->assertFileDoesNotExist($deprecatedReponsiveImagesPath);
     }
 
-
     /** @test */
     public function it_will_throw_an_exception_when_using_a_non_existing_disk()
     {


### PR DESCRIPTION
In version 8, `diskDoesNotExist` was moved to its own exception class. 