### PR TITLE
Add info about setting the default value

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,6 +5,16 @@ Because there are many breaking changes an upgrade is not that easy. There are m
 ## From v8 to v9
 
 - add a `json` column `generated_conversions` to the `media` table (take a look at the default migration for the exact definition). If you are using Media Library Pro, you should copy the values you now have in the `generated_conversions` key of the `custom_properties` column to `generated_conversions`
+  - If you have existing records in the `media` table, you will need to update the value of the `generated_conversions` column to be `[]` to avoid JSON-validation constraint errors
+  - You can do this either by adding `->default('[]')` to the column definition in the migration or by using this snippet (e.g. in Tinker):
+
+```php
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+Media::whereNull('generated_conversions')->orWhere('generated_conversions', '')->cursor()->each(
+   fn (Media $media) => $media->update(['generated_conversions' => []])
+);
+```
+
 - rename `conversion_file_namer` key in the `media-library` config to `file_namer`. This will support both the conversions and responsive images from now on. More info [in our docs](https://spatie.be/docs/laravel-medialibrary/v9/advanced-usage/naming-generated-files).
 - in several releases of v8 config options were added. We recommend going over your config file in `config/media-library.php` and add any options that are present in the default config file that ships with this package.
 


### PR DESCRIPTION
I just upgraded to v9 and added the `media.generated_conversions` field. The first time I updated an existing `Media` instance I got a JSON-validation constraint error because the newly-added field didn't have a value (it defaulted to an empty string). This PR adds info about and instructions for setting the default value to `[]` to help people avoid running into the same problem