### PR TITLE
Allow null in the FileAdder 'order' setter

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -142,7 +142,7 @@ class FileAdder
         return $this;
     }
 
-    public function setOrder(int $order): self
+    public function setOrder(?int $order): self
     {
         $this->order = $order;
 


### PR DESCRIPTION
When disabling the automatic order property increment (media.order_column) that gets set on each insert, null is being passed automatically by the library when you perform `$media->copy(...)`. Causing an exception to be thrown.

The property is already nullable in the definition.

Btw: Thanks for a great library!