### PR TITLE
Pure Flysystem AdapterInterface support for url generator

### DIFF
--- a/src/Support/UrlGenerator/DefaultUrlGenerator.php
+++ b/src/Support/UrlGenerator/DefaultUrlGenerator.php
@@ -4,6 +4,7 @@ namespace Spatie\MediaLibrary\Support\UrlGenerator;
 
 use DateTimeInterface;
 use Illuminate\Support\Str;
+use League\Flysystem\Adapter\AbstractAdapter;
 
 class DefaultUrlGenerator extends BaseUrlGenerator
 {
@@ -36,7 +37,10 @@ class DefaultUrlGenerator extends BaseUrlGenerator
             $adapter = $adapter->getAdapter();
         }
 
-        $pathPrefix = $adapter->getPathPrefix();
+        $pathPrefix = '';
+        if ($adapter instanceof AbstractAdapter) {
+            $pathPrefix = $adapter->getPathPrefix();
+        }
 
         return $pathPrefix.$this->getPathRelativeToRoot();
     }


### PR DESCRIPTION
Some file system adapters can implement pure AdapterInterface (without utilitary AbstractAdapter). AdapterInterface doesn't have `getPathPrefix()` method. We should support this case.