### PR TITLE
Check existence of a directory before removing it

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -196,7 +196,8 @@ class Filesystem
         collect([$mediaDirectory, $conversionsDirectory, $responsiveImagesDirectory])
             ->each(function (string $directory) use ($media) {
                 try {
-                    $this->filesystem->disk($media->conversions_disk)->deleteDirectory($directory);
+                    if ($this->filesystem->disk($media->conversions_disk)->exists($directory))
+                        $this->filesystem->disk($media->conversions_disk)->deleteDirectory($directory);
                 } catch (Exception $exception) {
                     report($exception);
                 }


### PR DESCRIPTION
I have a collection of directories and I want to remove them recursively but in a special case of mine, maybe one of the directories contains the others as a nested directory and any effort to remove a child or nested directory will result in an error, so we have to check the existence of every directory before removing it to avoid error and crashe.


```
Illuminate\Support\Collection {#1870
  #items: array:3 [
    0 => "albums/774/"
    1 => "albums/774/conversions/"
    2 => "albums/774/responsive-images/"
  ]
}
```

related issue: #2349 