### PR TITLE
addMediaFromStream

### DIFF
--- a/docs/api/adding-files.md
+++ b/docs/api/adding-files.md
@@ -157,6 +157,28 @@ $model
     ->toMediaCollection();
 ```
 
+### addMediaFromStream
+
+```php
+/**
+ * Add a file to the media library from a stream.
+ *
+ * @param $stream
+ *
+ * @return \Spatie\MediaLibrary\MediaCollections\FileAdder
+ */
+ public function addMediaFromStream($stream): FileAdder
+```
+
+The file will be named 'text.txt' by default. A specific file name can be set using `usingFileName`
+
+```php
+$model
+    ->addMediaFromStream($stream)
+    ->usingFileName('custom-filename.txt')
+    ->toMediaCollection();
+```
+
 ### copyMedia
 
 ```php

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -238,6 +238,26 @@ trait InteractsWithMedia
     }
 
     /**
+     * Add a file to the media library from a stream.
+     *
+     * @param $stream
+     *
+     * @return \Spatie\MediaLibrary\MediaCollections\FileAdder
+     */
+    public function addMediaFromStream($stream): FileAdder
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'media-library');
+
+        file_put_contents($tmpFile, $stream);
+
+        $file = app(FileAdderFactory::class)
+            ->create($this, $tmpFile)
+            ->usingFileName('text.txt');
+
+        return $file;
+    }
+
+    /**
      * Copy a file to the media library.
      *
      * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $file

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -557,6 +557,21 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function a_stream_can_be_accepted_to_be_added_to_the_media_library()
+    {
+        $string = 'test123';
+        $stream = fopen('php://temp','w+');
+        fwrite($stream, $string);
+        rewind($stream);
+
+        $media = $this->testModel
+            ->addMediaFromStream($stream)
+            ->toMediaCollection();
+
+        $this->assertEquals($string, file_get_contents($media->getPath()));
+    }
+
+    /** @test */
     public function it_can_add_data_uri_prefixed_base64_encoded_file_to_the_medialibrary()
     {
         $testFile = $this->getTestJpg();


### PR DESCRIPTION
some times the url is protected by auth and the return is 
`http-message/StreamInterface`
or its a return of `ZipArchive::getStream` which is resource

this pull request adds the ability to call `addMediaFromStream` and pass any type of stream
and behaving like `addMediaFromString` for file naming