### PR TITLE
Return Fallback url or path when conversion is not ready yet

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -312,6 +312,10 @@ trait InteractsWithMedia
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 
+        if ($conversionName !== '' && !$media->hasGeneratedConversion($conversionName)){
+            return $this->getFallbackMediaUrl($collectionName) ?: '';
+        }
+
         return $media->getUrl($conversionName);
     }
 
@@ -329,6 +333,10 @@ trait InteractsWithMedia
         $media = $this->getFirstMedia($collectionName);
 
         if (!$media) {
+            return $this->getFallbackMediaUrl($collectionName) ?: '';
+        }
+
+        if ($conversionName !== '' && !$media->hasGeneratedConversion($conversionName)){
             return $this->getFallbackMediaUrl($collectionName) ?: '';
         }
 
@@ -370,6 +378,10 @@ trait InteractsWithMedia
         $media = $this->getFirstMedia($collectionName);
 
         if (!$media) {
+            return $this->getFallbackMediaPath($collectionName) ?: '';
+        }
+
+        if ($conversionName !== '' && !$media->hasGeneratedConversion($conversionName)){
             return $this->getFallbackMediaPath($collectionName) ?: '';
         }
 

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -250,6 +250,36 @@ class GetMediaTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_default_path_to_the_first_media_in_a_collection_if_conversion_not_marked_as_generated_yet()
+    {
+        $media = $this
+            ->testModelWithConversionQueued
+            ->addMedia($this->getTestFilesDirectory('test.png'))
+            ->toMediaCollection('avatar');
+
+        $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
+        unlink($avatarThumbConversion);
+        $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
+
+        $this->assertEquals('/default.jpg', $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
+    }
+
+    /** @test */
+    public function it_can_get_the_default_url_to_the_first_media_in_a_collection_if_conversion_not_marked_as_generated_yet()
+    {
+        $media = $this
+            ->testModelWithConversionQueued
+            ->addMedia($this->getTestFilesDirectory('test.png'))
+            ->toMediaCollection('avatar');
+
+        $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
+        unlink($avatarThumbConversion);
+        $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
+
+        $this->assertEquals('/default.jpg', $this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'));
+    }
+
+    /** @test */
     public function it_will_return_preloaded_media_sorting_on_order_column()
     {
         $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');

--- a/tests/TestSupport/TestModels/TestModelWithConversionQueued.php
+++ b/tests/TestSupport/TestModels/TestModelWithConversionQueued.php
@@ -11,6 +11,10 @@ class TestModelWithConversionQueued extends TestModel
         $this->addMediaConversion('thumb')
             ->width(50);
 
+        $this->addMediaConversion('avatar_thumb')
+            ->performOnCollections('avatar')
+            ->width(50);
+
         $this->addMediaConversion('keep_original_format')
             ->keepOriginalImageFormat();
     }


### PR DESCRIPTION
current behavior when you try to access conversion using `getFirstMediaUrl` it will return correct path but the image may not be ready yet or out of the queue, this PR will check if the media `hasGeneratedConversion` before returning the path or URL and if connversion is not ready yet, it will return `FallbackMediaUrl` or `FallbackMediaPath`.