### PR TITLE
Fix #2372 the fallback should be the original image

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -313,7 +313,7 @@ trait InteractsWithMedia
         }
 
         if ($conversionName !== '' && !$media->hasGeneratedConversion($conversionName)) {
-            return $this->getFallbackMediaUrl($collectionName) ?: '';
+            return $media->getUrl();
         }
 
         return $media->getUrl($conversionName);
@@ -337,7 +337,7 @@ trait InteractsWithMedia
         }
 
         if ($conversionName !== '' && !$media->hasGeneratedConversion($conversionName)) {
-            return $this->getFallbackMediaUrl($collectionName) ?: '';
+            return $media->getTemporaryUrl($expiration);
         }
 
         return $media->getTemporaryUrl($expiration, $conversionName);
@@ -382,7 +382,7 @@ trait InteractsWithMedia
         }
 
         if ($conversionName !== '' && !$media->hasGeneratedConversion($conversionName)) {
-            return $this->getFallbackMediaPath($collectionName) ?: '';
+            return $media->getPath();
         }
 
         return $media->getPath($conversionName);

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -291,7 +291,7 @@ class GetMediaTest extends TestCase
         unlink($avatarThumbConversion);
         $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
 
-        $this->assertEquals("/{$media->id}/test.jpg", $this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'));
+        $this->assertEquals("/media/{$media->id}/test.jpg", $this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'));
     }
 
     /** @test */

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -254,14 +254,29 @@ class GetMediaTest extends TestCase
     {
         $media = $this
             ->testModelWithConversionQueued
-            ->addMedia($this->getTestFilesDirectory('test.png'))
+            ->addMedia($this->getTestJpg())
             ->toMediaCollection('avatar');
 
         $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
         unlink($avatarThumbConversion);
         $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
 
-        $this->assertEquals('/default.jpg', $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
+        $this->assertEquals($this->getTestJpg(), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
+    }
+    
+    /** @test */
+    public function it_can_get_the_correct_path_to_the_converted_media_in_a_collection_if_conversion_is_marked_as_generated()
+    {
+        $media = $this
+            ->testModelWithConversionQueued
+            ->addMedia($this->getTestJpg())
+            ->toMediaCollection('avatar');
+
+        $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
+        unlink($avatarThumbConversion);
+        $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionAsGenerated('avatar_thumb');
+
+        $this->assertEquals($this->testModelWithConversionQueued->getFirstMedia('avatar')->getPath('avatar_thumb'), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
     }
 
     /** @test */
@@ -269,14 +284,14 @@ class GetMediaTest extends TestCase
     {
         $media = $this
             ->testModelWithConversionQueued
-            ->addMedia($this->getTestFilesDirectory('test.png'))
+            ->addMedia($this->getTestJpg())
             ->toMediaCollection('avatar');
 
         $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
         unlink($avatarThumbConversion);
         $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
 
-        $this->assertEquals('/default.jpg', $this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'));
+        $this->assertEquals($this->getTestJpg(), $this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'));
     }
 
     /** @test */

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -261,7 +261,7 @@ class GetMediaTest extends TestCase
         unlink($avatarThumbConversion);
         $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
 
-        $this->assertEquals($this->getTestJpg(), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
+        $this->assertEquals($this->getMediaDirectory("{$media->id}/test.jpg"), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
     }
     
     /** @test */
@@ -274,9 +274,9 @@ class GetMediaTest extends TestCase
 
         $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
         unlink($avatarThumbConversion);
-        $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionAsGenerated('avatar_thumb');
+        $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionGenerated('avatar_thumb');
 
-        $this->assertEquals($this->testModelWithConversionQueued->getFirstMedia('avatar')->getPath('avatar_thumb'), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
+        $this->assertEquals($media->getPath('avatar_thumb'), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
     }
 
     /** @test */
@@ -291,7 +291,7 @@ class GetMediaTest extends TestCase
         unlink($avatarThumbConversion);
         $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
 
-        $this->assertEquals($this->getTestJpg(), $this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'));
+        $this->assertEquals("/{$media->id}/test.jpg", $this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'));
     }
 
     /** @test */


### PR DESCRIPTION
#2369 Introduced some undesired behavior, it would be better to return the original image and not the fallback one until the conversions are generated

Partially fixes #2372 