### PR TITLE
Add `Collection` typehint to `addMultipleMediaFromRequest`

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -120,7 +120,7 @@ trait InteractsWithMedia
      *
      * @return \Spatie\MediaLibrary\MediaCollections\FileAdder[]
      */
-    public function addMultipleMediaFromRequest(array $keys)
+    public function addMultipleMediaFromRequest(array $keys): Collection
     {
         return app(FileAdderFactory::class)->createMultipleFromRequest($this, $keys);
     }


### PR DESCRIPTION
Resolves #2388 

I've added the `Collection` type hint which makes intellisense happy when chaining methods

![image](https://user-images.githubusercontent.com/8126758/114382568-69537e80-9b84-11eb-9ab6-94608887caaf.png)
