### PR TITLE
Include extra_headers when adding media from same S3 Disk

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -91,6 +91,10 @@ class Filesystem
             return false;
         }
 
+        if (count(config('media-library.remote.extra_headers')) > 0) {
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Bug: Extra Headers were not being applied when media was copied from the same S3 Disk.

Solution: Do not copy media from the same disk if ```extra_headers``` is provided.