### PR TITLE
Enable Storage::fake() usage

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -373,9 +373,14 @@ class FileAdder
 
     protected function ensureDiskExists(string $diskName)
     {
-        if (is_null(config("filesystems.disks.{$diskName}"))) {
+        try{
+            if (!is_a(Storage::disk($diskName), \Illuminate\Contracts\Filesystem\Filesystem::class)) {
+                throw DiskDoesNotExist::create($diskName);
+            }
+        } catch (\Exception $e){
             throw DiskDoesNotExist::create($diskName);
         }
+
     }
 
     public function defaultSanitizer(string $fileName): string

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -649,4 +649,19 @@ class IntegrationTest extends TestCase
 
         $this->assertEquals(200, $result->getStatusCode());
     }
+
+    /** @test */
+    public function it_is_compatible_with_storage_fake(){
+
+        $storage = Storage::fake('images');
+
+        $file = \Illuminate\Http\UploadedFile::fake()->image('fake-image.png');
+
+        config()->set('media-library.disk_name', 'images');
+
+        $media = $this->testModel->addMedia($file)->toMediaCollection('default', 'images');
+
+        $this->assertTrue($storage->exists($media->id.'/'.$media->file_name));
+
+    }
 }


### PR DESCRIPTION
I tried to use this library with Storage::fake() and found that I couldn't because the FileAdder is looking in the configuration to see if the disk is configured. For developer ease I have changed that check to actually attempt to get the FileSystem with Storage::disk, because file-configured, test-configured and Storage::fake disks will all work, and disks that don't exist will throw an Exception, which gets turned into a DiskDoesNotExist exception.