### PR TITLE
Customize Filename in Zip using `zip_filename` custom property

### DIFF
--- a/docs/advanced-usage/using-custom-properties.md
+++ b/docs/advanced-usage/using-custom-properties.md
@@ -75,7 +75,8 @@ title: Special custom properties
 weight: 2
 ---
 
-## ZIP File Folders
+## File Structure customization in zip files
+### Folders and Subfolders
 
 The ZIP export stores all media files in the root folder of the ZIP file.
 
@@ -87,6 +88,23 @@ Each media can be assigned to a subfolder.
 $mediaItem = Media::find($id);
 
 $mediaItem->setCustomProperty('zip_filename_prefix', 'folder/subfolder/'); // stores $mediaItem in Subfolder
+
+$mediaItem->save();
+
+$mediaStream =  MediaStream::create('export.zip');
+$mediaStream->addMedia($mediaItem);
+```
+
+### Custom Filename
+
+The ZIP export uses the original filename of the media.
+
+If you want to save media with custom names, you can do this with the help of the special custom property 'zip_filename'.
+
+```php
+$mediaItem = Media::find($id);
+
+$mediaItem->setCustomProperty('zip_filename', 'custom_filename.jpg'); // stores $mediaItem as custom_filename.jpg
 
 $mediaItem->save();
 

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -161,4 +161,128 @@ class MediaStreamTest extends TestCase
 
         $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'just_a_string_prefix test.jpg');
     }
+
+    /** @test */
+    public function media_with_zip_file_folder_name_property_saved_in_correct_zip_folder_and_correct_name()
+    {
+        foreach (range(1, 2) as $i) {
+            $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->preservingOriginal()
+                ->toMediaCollection();
+        }
+
+        foreach (range(1, 2) as $i) {
+            $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->preservingOriginal()
+                ->withCustomProperties([
+                    'zip_filename' => 'folder/subfolder/test.jpg',
+                ])
+                ->toMediaCollection();
+        }
+
+        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+        ob_start();
+        @$zipStreamResponse->toResponse(request())->sendContent();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $temporaryDirectory = (new TemporaryDirectory())->create();
+        file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test.jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (1).jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (1).jpg');
+    }
+
+    /** @test */
+    public function media_with_zip_file_name_property_saved_with_correct_name()
+    {
+        $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->withCustomProperties([
+                'zip_filename' => 'test_name.jpg',
+            ])
+            ->toMediaCollection();
+
+        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+        ob_start();
+        @$zipStreamResponse->toResponse(request())->sendContent();
+        $content = ob_get_contents();
+        ob_end_clean();
+        $temporaryDirectory = (new TemporaryDirectory())->create();
+        file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test_name.jpg');
+    }
+
+    /** @test */
+    public function media_with_zip_file_name_and_prefix_property_saved_in_correct_zip_folder_and_correct_name()
+    {
+        foreach (range(1, 2) as $i) {
+            $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->preservingOriginal()
+                ->toMediaCollection();
+        }
+
+        foreach (range(1, 2) as $i) {
+            $this->testModel
+                ->addMedia($this->getTestJpg())
+                ->preservingOriginal()
+                ->withCustomProperties([
+                    'zip_filename_prefix' => 'folder/subfolder/',
+                    'zip_filename' => 'test.jpg',
+                ])
+                ->toMediaCollection();
+        }
+
+        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+        ob_start();
+        @$zipStreamResponse->toResponse(request())->sendContent();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $temporaryDirectory = (new TemporaryDirectory())->create();
+        file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test.jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (1).jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (1).jpg');
+    }
+
+    /** @test */
+    public function media_with_zip_file_name_and_prefix_property_saved_with_correct_name()
+    {
+        $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->withCustomProperties([
+                'zip_filename_prefix' => 'alakazam_',
+                'zip_filename' => 'test_name.jpg',
+            ])
+            ->toMediaCollection();
+
+        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+        ob_start();
+        @$zipStreamResponse->toResponse(request())->sendContent();
+        $content = ob_get_contents();
+        ob_end_clean();
+        $temporaryDirectory = (new TemporaryDirectory())->create();
+        file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'alakazam_test_name.jpg');
+    }
 }


### PR DESCRIPTION
This PR aims to allow setting custom filenames for media in zip files.
This is required in use cases where `zip_filename_prefix` is not sufficient.

- [x] Passed existing tests.
- [x] Added new tests.
- [x] Updated documentation.

The behavior right now is that filename will be in the following format
`zip_filename_prefix` `zip_filename`

`zip_filename` falls back to `$mediaItem->file_name` if the property does not exist
The file extension is not preserved and has to be set in `zip_filename`