### PR TITLE
Added array type hint to $casts to match Laravel

### DIFF
--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -40,7 +40,7 @@ class Media extends Model implements Responsable, Htmlable
 
     protected $guarded = [];
 
-    protected $casts = [
+    protected array $casts = [
         'manipulations' => 'array',
         'custom_properties' => 'array',
         'generated_conversions' => 'array',


### PR DESCRIPTION
In the latest versions of Laravel src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php the $casts variable has an array type hint. (Tested in 8.39.0)

When postAutoloadDump runs after installing spatie/laravel-medialibrary there is a Symfony\Component\ErrorHandler\Error\FatalError: 
Type of Spatie\MediaLibrary\MediaCollections\Models\Media::$casts must be array (as in class Illuminate\Database\Eloquent\Model)

Adding this type hint fixes the error.