### PR TITLE
[v7] PHP8 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,6 +52,7 @@ jobs:
               run: |
                   composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                   composer require league/flysystem-aws-s3-v3:"^1.0.13"
+                  composer require doctrine/inflector:"^1.4.1|^2.0"
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,7 +51,7 @@ jobs:
             - name: Install dependencies
               run: |
                   composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                  composer require league/flysystem-aws-s3-v3
+                  composer require league/flysystem-aws-s3-v3:"^1.0.13"
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2|^8.0",
     "ext-fileinfo": "*",
     "illuminate/bus": "~5.8.35|^6.0|^7.0|^8.0",
     "illuminate/console": "~5.8.35|^6.0|^7.0|^8.0",
@@ -45,7 +45,7 @@
     "mockery/mockery": "^1.0",
     "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
     "phpunit/phpunit" : "^8.0|^9.0",
-    "spatie/phpunit-snapshot-assertions": "^2.0"
+    "spatie/phpunit-snapshot-assertions": "^4.0"
   },
   "conflict": {
     "php-ffmpeg/php-ffmpeg": "<0.6.1"

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -24,13 +24,13 @@ class ToHtmlTest extends TestCase
     /** @test */
     public function it_can_render_itself_as_an_image()
     {
-        $this->assertEquals('<img src="/media/1/test.jpg" alt="test">', Media::first()->img()->render());
+        $this->assertEquals('<img src="/media/1/test.jpg" alt="test">', Media::first()->img());
     }
 
     /** @test */
     public function it_can_render_a_conversion_of_itself_as_an_image()
     {
-        $this->assertEquals('<img src="/media/1/conversions/test-thumb.jpg" alt="test">', Media::first()->img('thumb')->render());
+        $this->assertEquals('<img src="/media/1/conversions/test-thumb.jpg" alt="test">', Media::first()->img('thumb'));
     }
 
     /** @test */
@@ -38,7 +38,7 @@ class ToHtmlTest extends TestCase
     {
         $this->assertEquals(
             '<img class="my-class" id="my-id" src="/media/1/conversions/test-thumb.jpg" alt="test">',
-             Media::first()->img('thumb', ['class' => 'my-class', 'id' => 'my-id'])->render()
+             Media::first()->img('thumb', ['class' => 'my-class', 'id' => 'my-id'])
         );
     }
 
@@ -47,7 +47,7 @@ class ToHtmlTest extends TestCase
     {
         $this->assertEquals(
             '<img class="my-class" id="my-id" src="/media/1/test.jpg" alt="test">',
-             Media::first()->img(['class' => 'my-class', 'id' => 'my-id'])->render()
+             Media::first()->img(['class' => 'my-class', 'id' => 'my-id'])
         );
     }
 
@@ -56,7 +56,7 @@ class ToHtmlTest extends TestCase
     {
         $this->assertEquals(
             '<img class="my-class" id="my-id" src="/media/1/conversions/test-thumb.jpg" alt="test">',
-             Media::first()->img(['class' => 'my-class', 'id' => 'my-id', 'conversion' => 'thumb'])->render()
+             Media::first()->img(['class' => 'my-class', 'id' => 'my-id', 'conversion' => 'thumb'])
         );
     }
 
@@ -77,7 +77,7 @@ class ToHtmlTest extends TestCase
             ->addMedia($this->getTestPdf())
             ->toMediaCollection();
 
-        $this->assertEquals('', $media->img()->render());
+        $this->assertEquals('', $media->img());
     }
 
     /** @test */
@@ -88,7 +88,7 @@ class ToHtmlTest extends TestCase
             ->withResponsiveImages()
             ->toMediaCollection();
 
-        $image = $media->refresh()->img()->render();
+        $image = $media->refresh()->img();
 
         $this->assertEquals(3, substr_count($image, '/media/2/responsive-images/'));
         $this->assertTrue(Str::contains($image, 'data:image/svg+xml;base64,'));
@@ -101,7 +101,7 @@ class ToHtmlTest extends TestCase
             ->addMedia($this->getTestJpg())
             ->toMediaCollection();
 
-        $image = $media->refresh()->img('thumb')->render();
+        $image = $media->refresh()->img('thumb');
 
         $this->assertStringContainsString('/media/2/responsive-images/', $image);
         $this->assertStringContainsString('data:image/svg+xml;base64,', $image);
@@ -117,7 +117,7 @@ class ToHtmlTest extends TestCase
             ->withResponsiveImages()
             ->toMediaCollection();
 
-        $imgTag = $media->refresh()->img()->render();
+        $imgTag = $media->refresh()->img();
 
         $this->assertEquals('<img srcset="http://localhost/media/2/responsive-images/test___medialibrary_original_340_280.jpg 340w, http://localhost/media/2/responsive-images/test___medialibrary_original_284_233.jpg 284w, http://localhost/media/2/responsive-images/test___medialibrary_original_237_195.jpg 237w" src="/media/2/test.jpg" width="340">', $imgTag);
     }

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -24,13 +24,13 @@ class ToHtmlTest extends TestCase
     /** @test */
     public function it_can_render_itself_as_an_image()
     {
-        $this->assertEquals('<img src="/media/1/test.jpg" alt="test">', Media::first()->img());
+        $this->assertEquals('<img src="/media/1/test.jpg" alt="test">', Media::first()->img()->render());
     }
 
     /** @test */
     public function it_can_render_a_conversion_of_itself_as_an_image()
     {
-        $this->assertEquals('<img src="/media/1/conversions/test-thumb.jpg" alt="test">', Media::first()->img('thumb'));
+        $this->assertEquals('<img src="/media/1/conversions/test-thumb.jpg" alt="test">', Media::first()->img('thumb')->render());
     }
 
     /** @test */
@@ -38,7 +38,7 @@ class ToHtmlTest extends TestCase
     {
         $this->assertEquals(
             '<img class="my-class" id="my-id" src="/media/1/conversions/test-thumb.jpg" alt="test">',
-             Media::first()->img('thumb', ['class' => 'my-class', 'id' => 'my-id'])
+             Media::first()->img('thumb', ['class' => 'my-class', 'id' => 'my-id'])->render()
         );
     }
 
@@ -47,7 +47,7 @@ class ToHtmlTest extends TestCase
     {
         $this->assertEquals(
             '<img class="my-class" id="my-id" src="/media/1/test.jpg" alt="test">',
-             Media::first()->img(['class' => 'my-class', 'id' => 'my-id'])
+             Media::first()->img(['class' => 'my-class', 'id' => 'my-id'])->render()
         );
     }
 
@@ -56,7 +56,7 @@ class ToHtmlTest extends TestCase
     {
         $this->assertEquals(
             '<img class="my-class" id="my-id" src="/media/1/conversions/test-thumb.jpg" alt="test">',
-             Media::first()->img(['class' => 'my-class', 'id' => 'my-id', 'conversion' => 'thumb'])
+             Media::first()->img(['class' => 'my-class', 'id' => 'my-id', 'conversion' => 'thumb'])->render()
         );
     }
 
@@ -77,7 +77,7 @@ class ToHtmlTest extends TestCase
             ->addMedia($this->getTestPdf())
             ->toMediaCollection();
 
-        $this->assertEquals('', $media->img());
+        $this->assertEquals('', $media->img()->render());
     }
 
     /** @test */
@@ -88,7 +88,7 @@ class ToHtmlTest extends TestCase
             ->withResponsiveImages()
             ->toMediaCollection();
 
-        $image = $media->refresh()->img();
+        $image = $media->refresh()->img()->render();
 
         $this->assertEquals(3, substr_count($image, '/media/2/responsive-images/'));
         $this->assertTrue(Str::contains($image, 'data:image/svg+xml;base64,'));
@@ -101,7 +101,7 @@ class ToHtmlTest extends TestCase
             ->addMedia($this->getTestJpg())
             ->toMediaCollection();
 
-        $image = $media->refresh()->img('thumb');
+        $image = $media->refresh()->img('thumb')->render();
 
         $this->assertStringContainsString('/media/2/responsive-images/', $image);
         $this->assertStringContainsString('data:image/svg+xml;base64,', $image);
@@ -117,7 +117,7 @@ class ToHtmlTest extends TestCase
             ->withResponsiveImages()
             ->toMediaCollection();
 
-        $imgTag = $media->refresh()->img();
+        $imgTag = $media->refresh()->img()->render();
 
         $this->assertEquals('<img srcset="http://localhost/media/2/responsive-images/test___medialibrary_original_340_280.jpg 340w, http://localhost/media/2/responsive-images/test___medialibrary_original_284_233.jpg 284w, http://localhost/media/2/responsive-images/test___medialibrary_original_237_195.jpg 237w" src="/media/2/test.jpg" width="340">', $imgTag);
     }


### PR DESCRIPTION
Testing v7 on Php 8
```
PHPUnit 9.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.5
```

On `P7.4 - L8.* - prefer-lowest` is the only error, on my localhost pass all test, here is adding a letter "S" to table's name
`Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 no such table: medias (SQL: select max("order_column") as aggregate from "medias")`