### PR TITLE
Fix method name in preview manipulation example

### DIFF
--- a/docs/handling-uploads-with-media-library-pro/processing-uploads-on-the-server.md
+++ b/docs/handling-uploads-with-media-library-pro/processing-uploads-on-the-server.md
@@ -383,7 +383,7 @@ use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\Image\Manipulations;
 
 // in a service provider
-TemporaryUpload::manipulatePreview(function(Conversion $conversion) {
+TemporaryUpload::previewManipulation(function(Conversion $conversion) {
     $conversion->fit(Manipulations::FIT_CROP, 300, 300);
 });
 ```


### PR DESCRIPTION
The function `TemporaryUpload::manipulatePreview` does not exist. It should be `TemporaryUpload::previewManipulation`.