### PR TITLE
Add getPathRelativeToRoot method to Media model

### DIFF
--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -83,6 +83,13 @@ class Media extends Model implements Responsable, Htmlable
         return $urlGenerator->getPath();
     }
 
+    public function getPathRelativeToRoot(string $conversionName = ''): string
+    {
+        $urlGenerator = UrlGeneratorFactory::createForMedia($this, $conversionName);
+
+        return $urlGenerator->getPathRelativeToRoot();
+    }
+
     public function getTypeAttribute(): string
     {
         $type = $this->getTypeFromExtension();

--- a/src/Support/UrlGenerator/UrlGenerator.php
+++ b/src/Support/UrlGenerator/UrlGenerator.php
@@ -13,6 +13,8 @@ interface UrlGenerator
 
     public function getPath(): string;
 
+    public function getPathRelativeToRoot(): string;
+
     public function setMedia(Media $media): self;
 
     public function setConversion(Conversion $conversion): self;


### PR DESCRIPTION
This PR adds a `getPathRelativeToRoot()` method to the Media model, which for example enables test assertions like this:

```
Storage::fake('avatars');

$this->patch('/avatar', [
    'avatar' => UploadedFile::fake()->image('avatar1.jpg'),
]); 

$this->assertNotNull($media = $user->getFirstMedia('avatars'));
Storage::disk('avatars')->assertExists($media->getPathRelativeToRoot());
```

Since this changes the UrlGenerator interface it will have to be targeted for the next major version. I will add tests and upgrade instructions if you are willing to accept this addition.