### PR TITLE
Update CleanCommand.php

### DIFF
--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -23,7 +23,8 @@ class CleanCommand extends Command
     protected $signature = 'media-library:clean {modelType?} {collectionName?} {disk?}
     {--dry-run : List files that will be removed without removing them},
     {--force : Force the operation to run when in production},
-    {--rate-limit= : Limit the number of requests per second }';
+    {--rate-limit= : Limit the number of requests per second },
+    {--skip-conversions: Dont remove deprecated conversions}';
 
     protected $description = 'Clean deprecated conversions and files without related model.';
 
@@ -56,8 +57,10 @@ class CleanCommand extends Command
 
         $this->isDryRun = $this->option('dry-run');
         $this->rateLimit = (int) $this->option('rate-limit');
-
-        $this->deleteFilesGeneratedForDeprecatedConversions();
+        
+        if(!$this->option('skip-conversions') {
+            $this->deleteFilesGeneratedForDeprecatedConversions();
+        }
 
         $this->deleteOrphanedDirectories();
 

--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -24,7 +24,7 @@ class CleanCommand extends Command
     {--dry-run : List files that will be removed without removing them},
     {--force : Force the operation to run when in production},
     {--rate-limit= : Limit the number of requests per second },
-    {--skip-conversions: Dont remove deprecated conversions}';
+    {--skip-conversions: Do not remove deprecated conversions}';
 
     protected $description = 'Clean deprecated conversions and files without related model.';
 


### PR DESCRIPTION
Add the option to skip 'deprecated conversions' when cleaning the media directory.

I asked a question about this, but I cant find it anymore...strange. Anyway, we add some custom conversion files after media-library has done it's job. When we then run this command, media-library identifies these files as deprecated conversions, but they aren't. This is not a bug, it's quite logical that it works this way. But with this option, there is a way to leave these files intact and still remove all the orphaned directories. It should help us, and maybe others to have this option.

I would also update tests, but I couldn't find any. If there is more to be done to make this work, please let me know!