### PR TITLE
[V9] Make sure only the extension is removed on DefaultFileNamer

### DIFF
--- a/src/Support/FileNamer/FileNamer.php
+++ b/src/Support/FileNamer/FileNamer.php
@@ -9,7 +9,9 @@ abstract class FileNamer
 {
     public function originalFileName(string $fileName): string
     {
-        return pathinfo($fileName, PATHINFO_FILENAME);
+        $name = pathinfo($fileName, PATHINFO_FILENAME);
+        
+        return preg_replace("/{$name}\..*/", $name, $fileName);
     }
 
     abstract public function conversionFileName(string $fileName, Conversion $conversion): string;

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -456,6 +456,21 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function the_file_name_can_be_modified_using_custom_sanitizing_and_default_file_namer()
+    {
+        $media = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->usingFileName('other/otherFileName.jpg')
+            ->sanitizingFileName(function ($fileName) {
+                return strtolower(str_replace(['#', '\\', ' '], '-', $fileName));
+            })
+            ->toMediaCollection();
+
+        $this->assertEquals('test', $media->name);
+        $this->assertFileExists($this->getMediaDirectory($media->id.'/other/otherfilename.jpg'));
+    }
+
+    /** @test */
     public function it_can_save_media_in_the_right_order()
     {
         $media = [];


### PR DESCRIPTION
According docs we can use a custom filename with `usingFileName` and a custom sanitizer with `sanitizingFileName`, but when you add a name with slash `FileNamer` cuts that part beacuse `pathinfo($fileName, PATHINFO_FILENAME)` remove all and let only file name, this PR fix that without change old behaivor

```php
$yourModel
   ->addMedia($pathToFile)
   ->usingFileName('other/otherFileName.jpg')
   ->sanitizingFileName(function($fileName) {
      return strtolower(str_replace(['#',  '\\', ' '], '-', $fileName));
   })
   ->toMediaCollection();
```
Test added