### PR TITLE
Include --force param to image_optimzer . jpegoptim

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -85,6 +85,7 @@ return [
     'image_optimizers' => [
         Spatie\ImageOptimizer\Optimizers\Jpegoptim::class => [
             '-m85', // set maximum quality to 85%
+            '--force', // ensure that progressive generation is always done also if a little bigger
             '--strip-all', // this strips out all text information such as comments and EXIF data
             '--all-progressive', // this will make sure the resulting image is a progressive one
         ],


### PR DESCRIPTION
I wonder why 20% of my conversions are not progressive. 
Jpegoptim is handling this by the --force param.
If the resulting image is only 1 Bit bigger than it is non-progressive
saved.