### PR TITLE
Feature/add media deleted event

### DIFF
--- a/docs/advanced-usage/consuming-events.md
+++ b/docs/advanced-usage/consuming-events.md
@@ -6,7 +6,7 @@ weight: 8
 The media library will fire the following events that your handlers can listen for:
 
 ### MediaHasBeenAdded
-This event is fired after the a file has been saved to disk.
+This event is fired after a file has been saved to disk.
 
 The event has a property `media` that holds the `\Spatie\MediaLibrary\Models\Media`-object of which the file has been stored.
 

--- a/docs/advanced-usage/consuming-events.md
+++ b/docs/advanced-usage/consuming-events.md
@@ -10,6 +10,11 @@ This event is fired after a file has been saved to disk.
 
 The event has a property `media` that holds the `\Spatie\MediaLibrary\Models\Media`-object of which the file has been stored.
 
+### MediaHasBeenDeleted
+This event is fired after a `Media` model entry was deleted.
+
+The event has a property `media` that holds the `\Spatie\MediaLibrary\Models\Media`-object of which the file was stored previously.
+
 ### ConversionWillStart
 This event is fired right before a conversion will start.
 

--- a/src/MediaCollections/Events/MediaHasBeenDeleted.php
+++ b/src/MediaCollections/Events/MediaHasBeenDeleted.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\MediaLibrary\MediaCollections\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class MediaHasBeenDeleted
+{
+    use SerializesModels;
+
+    public Media $media;
+
+    public function __construct(Media $media)
+    {
+        $this->media = $media;
+    }
+}

--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\Conversions\FileManipulator;
 use Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenAdded;
+use Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenDeleted;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\File;
 use Spatie\MediaLibrary\Support\PathGenerator\PathGeneratorFactory;
@@ -211,6 +212,8 @@ class Filesystem
                     report($exception);
                 }
             });
+
+        event(new MediaHasBeenDeleted($media));
     }
 
     public function removeFile(Media $media, string $path): void

--- a/tests/MediaCollections/EventTest.php
+++ b/tests/MediaCollections/EventTest.php
@@ -24,12 +24,12 @@ class EventTest extends TestCase
 
         Event::assertDispatched(MediaHasBeenAdded::class);
     }
-    
+
     /** @test */
     public function it_will_fire_the_media_deleted_event_when_a_media_entity_is_deleted()
     {
         Event::fake([
-            MediaHasBeenDeleted::class
+            MediaHasBeenDeleted::class,
         ]);
 
         $this->addMediaTo($this->testModel);

--- a/tests/MediaCollections/EventTest.php
+++ b/tests/MediaCollections/EventTest.php
@@ -4,6 +4,7 @@ namespace Spatie\MediaLibrary\Tests\MediaCollections;
 
 use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenAdded;
+use Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenDeleted;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
@@ -12,18 +13,36 @@ class EventTest extends TestCase
     public function setUp(): void
     {
         parent::setup();
-
-        Event::fake();
     }
 
     /** @test */
     public function it_will_fire_the_media_added_event()
     {
+        Event::fake();
+
         $this->addMediaTo($this->testModel);
 
         Event::assertDispatched(MediaHasBeenAdded::class);
     }
     
+    /** @test */
+    public function it_will_fire_the_media_deleted_event_when_a_media_entity_is_deleted()
+    {
+        Event::fake([
+            MediaHasBeenDeleted::class
+        ]);
+
+        $this->addMediaTo($this->testModel);
+        $media = $this->testModel->getMedia()->first();
+
+        $media->delete();
+
+        Event::assertDispatched(MediaHasBeenDeleted::class, function (MediaHasBeenDeleted $event) use ($media) {
+            return $event->media->id === $media->id
+                && $event->media->getPath() === $media->getPath();
+        });
+    }
+
     private function addMediaTo(TestModel $testModel): void
     {
         $testModel->addMedia($this->getTestJpg())->toMediaCollection();

--- a/tests/MediaCollections/EventTest.php
+++ b/tests/MediaCollections/EventTest.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary\Tests\MediaCollections;
 use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenAdded;
 use Spatie\MediaLibrary\Tests\TestCase;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
 class EventTest extends TestCase
 {
@@ -18,8 +19,13 @@ class EventTest extends TestCase
     /** @test */
     public function it_will_fire_the_media_added_event()
     {
-        $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+        $this->addMediaTo($this->testModel);
 
         Event::assertDispatched(MediaHasBeenAdded::class);
+    }
+    
+    private function addMediaTo(TestModel $testModel): void
+    {
+        $testModel->addMedia($this->getTestJpg())->toMediaCollection();
     }
 }


### PR DESCRIPTION
## Intro
As proposed in #2574 this PR adds support for dispatching a `MediaHasBeenDeleted` event, whenever a `Media` entity is deleted.

## What has been done
- The `MediaHasBeenDeleted` event was added.
- The event is dispatched from the `removeAllFiles()` call in `FileSystem`: 
  Since the `MediaObserver` model observer hooks into the `deleted()` lifecycle hook of the specified `Media` model, following the calls eventually lead to a call to the `removeAllFiles()` method on the `Filesystem` class. From here, the `MediaHasBeenDeleted` event is dispatched.
- Updated the `EventTest` testcase:
  - Extracted common logic to a `addMediaTo()` method
  - Since the `MediaHasBeenDeleted` event is only fired after the model event "deleted" has been fired, the test exclusively fakes the `MediaHasBeenDeleted` event.
- Updated the "Consuming Events" section in the documentation:
  - Fixed a typo in the "MediaHasBeenAdded" section
  - Added section for "MediaHasBeenDeleted" event 

closes #2574.