### PR TITLE
Add corrections and fixed typo's in Advanced Usage docs

### DIFF
--- a/docs/advanced-usage/consuming-events.md
+++ b/docs/advanced-usage/consuming-events.md
@@ -6,7 +6,7 @@ weight: 8
 The media library will fire the following events that your handlers can listen for:
 
 ### MediaHasBeenAdded
-This event is fired after the a file has been saved to disk.
+This event is fired after a file has been saved to disk.
 
 The event has a property `media` that holds the `\Spatie\MediaLibrary\Models\Media`-object of which the file has been stored.
 

--- a/docs/advanced-usage/consuming-events.md
+++ b/docs/advanced-usage/consuming-events.md
@@ -36,7 +36,7 @@ The event has two public properties:
 
 ## Sample usage
 
-First you must created a listener class. Here's one that will log the paths of added media.
+First you must create a listener class. Here's one that will log the paths of added media.
 
 ```php
 namespace App\Listeners;

--- a/docs/advanced-usage/generating-custom-urls.md
+++ b/docs/advanced-usage/generating-custom-urls.md
@@ -7,4 +7,4 @@ When `getUrl` is called, the task of generating that url is passed to an impleme
 
 The package contains a `DefaultUrlGenerator` that can generate urls for a media library that is stored inside the public path. It can also generate URLs for S3.
 
-If you are storing your media files in a private directory or are using a different filesystem, you can write your own `UrlGenerator`. Your generator must implement to the `Spatie\MediaLibrary\Support\UrlGenerator\UrlGenerator` interface. 
+If you are storing your media files in a private directory or are using a different filesystem, you can write your own `UrlGenerator`. Your generator must implement the `Spatie\MediaLibrary\Support\UrlGenerator\UrlGenerator` interface. 

--- a/docs/advanced-usage/naming-files.md
+++ b/docs/advanced-usage/naming-files.md
@@ -6,17 +6,17 @@ weight: 11
 ### Naming original and conversion files
 
 
-By default, all original files will retain the original name. All conversion files will be named in this format:
+By default, all original files will retain the original name. All converted files will be named in this format:
 
 ```
 {original-file-name-without-extension}-{name-of-the-conversion}.{extension}
 ```
 
-Should you want to name your original or conversion file using another format,
-then you can specify the class name of your own `FileNamer` in the `file_namer` key
-of the `media-library.php` config file.
+If you want to use a different formatting to name your original or converted file(s),
+you can specify the class name of your own `FileNamer` under the `file_namer` key
+within the `media-library.php` config file.
 
-The only requirements is that your class extends `Spatie\MediaLibrary\Support\FileNamer\FileNamer`.
+The only requirement is that your class extends `Spatie\MediaLibrary\Support\FileNamer\FileNamer`.
 In your class you should implement 3 methods:
 1. `originalFileName` should return the name you'd like for the original file. Return the name without the extension.
 2. `conversionFileName` should return the media file name combined with the conversion name
@@ -58,5 +58,5 @@ By default, all responsive image files will be named in this format:
 {original-file-name-without-extension}___{name-of-the-conversion}_{width}_{height}.{extension}
 ```
 
-Just like the conversion file names, you can use another format for naming your files
+Just like the naming of converted files, you can use another format for naming your files
 by using your own `FileNamer` class. It is only possible to prefix the name, because other parts are needed in processing responsive images.

--- a/docs/advanced-usage/ordering-media.md
+++ b/docs/advanced-usage/ordering-media.md
@@ -3,7 +3,7 @@ title: Ordering media
 weight: 6
 ---
 
-This package has a built in feature to help you order the media in your project. By default all inserted media items are ordered by their creation order (from the oldest to the newest) using the `order_column` column of the `media` table.
+This package has a built-in feature to help you order the media in your project. By default, all inserted media items are arranged in order by their time of creation (from the oldest to the newest) using the `order_column` column of the `media` table.
 
 You can easily reorder a list of media by calling  ̀Media::setNewOrder`:
 
@@ -20,7 +20,7 @@ You can easily reorder a list of media by calling  ̀Media::setNewOrder`:
 Media::setNewOrder([11, 2, 26]);
 ```
 
-Of course you can also manually change the value of the `order_column`.
+Of course, you can also manually change the value of the `order_column`.
 
 ```php
 $media->order_column = 10;

--- a/docs/advanced-usage/overriding-the-default-filesystem-behaviour.md
+++ b/docs/advanced-usage/overriding-the-default-filesystem-behaviour.md
@@ -5,7 +5,7 @@ weight: 10
 
 The `Spatie\MediaLibrary\MediaCollections\Filesystem` class contains the behavior for actions like adding files, renaming files and deleting files. It applies these actions to the disks (local, S3, etc) that you configured.
 
-If you want to override the default behavior you can create your own  implementation by extending `Spatie\MediaLibrary\MediaCollections\Filesystem`. You then bind your own class to the service container in the `AppServiceProvider`:
+If you want to override the default behavior you can create your own implementation by extending `Spatie\MediaLibrary\MediaCollections\Filesystem`. You then bind your own class to the service container in the `AppServiceProvider`:
 
 ```php
 use App\CustomFilesystem;

--- a/docs/advanced-usage/rendering-media.md
+++ b/docs/advanced-usage/rendering-media.md
@@ -23,7 +23,7 @@ You can also use this shorthand:
 Here is the converted image: {{ $media('thumb') }}
 ```
 
-You can extra attributes by calling `attributes`.
+You can add extra attributes by calling `attributes`.
 
 ```blade
 Here is the image with some attributes: {{ $media->img()->attributes(['class' => 'my-class']) }}

--- a/docs/advanced-usage/using-a-custom-media-downloader.md
+++ b/docs/advanced-usage/using-a-custom-media-downloader.md
@@ -5,7 +5,7 @@ weight: 6
 
 By default, when using the `addMediaFromUrl` method, the package internally uses `fopen` to download the media. In some cases though, the media can be behind a firewall or you need to attach specific headers to get access.
 
-To do that, you can specify your own Media Downloader by creating a class that implements the Downloader interface. This method must fetch the resource and return the location of the temporary file.
+To do that, you can specify your own Media Downloader by creating a class that implements the `Downloader` interface. This method must fetch the resource and return the location of the temporary file.
 
 For example, consider the following example which uses curl with custom headers to fetch the media.
 


### PR DESCRIPTION
In my last PR I found a typo and in this PR I'm submitting some corrections and typo fixes for the documentation section on "Advanced Usage". 