### PR TITLE
Fix missing image preview URLs in Inertia Projects

### DIFF
--- a/src/MediaCollections/Models/Collections/MediaCollection.php
+++ b/src/MediaCollections/Models/Collections/MediaCollection.php
@@ -30,6 +30,27 @@ class MediaCollection extends Collection implements Htmlable
     {
         return $this->sum('size');
     }
+    
+    public function toArray()
+    {
+        if (! ($this->formFieldName ?? $this->collectionName)) {
+            return [];
+        }
+
+        return old($this->formFieldName ?? $this->collectionName) ?? $this->map(function (Media $media) {
+            return [
+                'name' => $media->name,
+                'file_name' => $media->file_name,
+                'uuid' => $media->uuid,
+                'preview_url' => $media->hasGeneratedConversion('preview') ? $media->getUrl('preview') : '',
+                'original_url' => $media->getUrl(),
+                'order' => $media->order_column,
+                'custom_properties' => $media->custom_properties,
+                'extension' => $media->extension,
+                'size' => $media->size,
+            ];
+        })->keyBy('uuid');
+    }
 
     public function toHtml()
     {


### PR DESCRIPTION
When using Inertia.js with Laravel, preview_url is not being populated causing missing thumbnails in the Media Library Pro Vue components. This is because the Inertia::render() method checks if a prop is arrayable. If so, it calls the toArray method. This PR adds the toArray method for proper mapping of media objects when used with Inertia.js.