### PR TITLE
Fixed typo in attribute name

### DIFF
--- a/src/Conversions/ConversionCollection.php
+++ b/src/Conversions/ConversionCollection.php
@@ -57,7 +57,7 @@ class ConversionCollection extends Collection
         if ($model->registerMediaConversionsUsingModelInstance) {
             $model = $media->model;
 
-            $model->mediaConversion = [];
+            $model->mediaConversions = [];
         }
 
         $model->registerAllMediaConversions($media);


### PR DESCRIPTION
The name of the `InteractsWithMediaLibrary` attribute `$mediaConversions` was mistyped in an assignment in the `ConversionCollection`