### PR TITLE
Remove the need for a TemporaryDirectory when copying media

### DIFF
--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -22,6 +22,16 @@ interface HasMedia
     public function addMedia($file): FileAdder;
 
     /**
+     * Add a file from the given disk.
+     *
+     * @param string $key
+     * @param string $disk
+     *
+     * @return \Spatie\MediaLibrary\MediaCollections\FileAdder
+     */
+    public function addMediaFromDisk(string $key, string $disk = null): FileAdder;
+
+    /**
      * Copy a file to the media library.
      *
      * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $file

--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -61,6 +61,13 @@ class Filesystem
 
         $storage = Storage::disk($file->getDisk());
 
+        if ($file->getDisk() == $media->disk) {
+            $storage->move($file->getKey(), $destination);
+
+            return;
+        }
+
+
         $headers = $diskDriverName === 'local'
             ? []
             : $this->getRemoteHeadersForFile(

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -24,7 +24,6 @@ use Spatie\MediaLibrary\MediaCollections\Models\Concerns\IsSorted;
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
 use Spatie\MediaLibrary\Support\File;
 use Spatie\MediaLibrary\Support\MediaLibraryPro;
-use Spatie\MediaLibrary\Support\TemporaryDirectory;
 use Spatie\MediaLibrary\Support\UrlGenerator\UrlGeneratorFactory;
 use Spatie\MediaLibraryPro\Models\TemporaryUpload;
 
@@ -286,17 +285,13 @@ class Media extends Model implements Responsable, Htmlable
 
     public function copy(HasMedia $model, $collectionName = 'default', string $diskName = '', string $fileName = ''): self
     {
-        $temporaryDirectory = TemporaryDirectory::create();
-
-        $temporaryFile = $temporaryDirectory->path('/') . DIRECTORY_SEPARATOR . $this->file_name;
-
         /** @var \Spatie\MediaLibrary\MediaCollections\Filesystem $filesystem */
         $filesystem = app(Filesystem::class);
 
-        $filesystem->copyFromMediaLibrary($this, $temporaryFile);
+        $path = $filesystem->getMediaDirectory($this) . '/' . $this->file_name;
 
         $fileAdder = $model
-            ->addMedia($temporaryFile)
+            ->addMediaFromDisk($path, $this->disk)
             ->usingName($this->name)
             ->setOrder($this->order_column)
             ->withCustomProperties($this->custom_properties);
@@ -307,8 +302,6 @@ class Media extends Model implements Responsable, Htmlable
 
         $newMedia = $fileAdder
             ->toMediaCollection($collectionName, $diskName);
-
-        $temporaryDirectory->delete();
 
         return $newMedia;
     }


### PR DESCRIPTION
## Background 

When using the media library pro package (livewire) to upload files directly to AWS S3 the process is like this:
1. generate temporary upload url (livewire)
2. upload file from users computer to AWS S3 (livewire)
3. A temporary upload is created (livewire)
4. The livewire temporaryUpload is moved into the media-library folder structure (media-library-pro)
5. A temporary media model is created (media-library-pro)

When the submit button is pressed to save the Media item the following happens:
1. The temporary media model is retrieved (media-library-pro)
2. The final location for the saved media is determined (media-library-pro)
3. The file is copied to a temporary directory on the Laravel server from the AWS S3 storage (media-library)
4. The temporary file is then re-uploaded to its permanent storage location (The same AWS S3 instance in this case) (media-library)
5. The new permanent media model is saved (media-library)

## Problem: Large Files
We will be uploading large files to our AWS S3 (2-4 files about .8-1GB each). The current setup using the media library package means there is a whole extra download and upload step which makes this whole scenario take way more time than it needs to.

## Solution
To remove the need for this extra copy step I propose these changes to the way media library items are copied and moved.

If the media item is on a remote file storage disk and is moving to the same file storage disk then we will use the internal `Storage::move()` functionality with that disk. This is much faster than streaming because it uses the file storage systems internal move/copy functionality

If the files are moving between two separate filesystems then we will stream the file directly from one disk to the new disk without saving the file to the laravel server first.