### PR TITLE
Reinsert down()

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -6,6 +6,10 @@ use Illuminate\Database\Migrations\Migration;
 
 class CreateMediaTable extends Migration
 {
+
+    /**
+     * Run the migrations.
+     */
     public function up()
     {
         Schema::create('media', function (Blueprint $table) {
@@ -28,5 +32,15 @@ class CreateMediaTable extends Migration
 
             $table->nullableTimestamps();
         });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('media');
     }
 }


### PR DESCRIPTION
The down() method in the project's media table migration stub has been dropped at some point, which breaks rollbacks.  I'm simply proposing to add it back. 