### PR TITLE
Add option to disable loading of dragula via cdn in medialibrary-pro

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -219,4 +219,10 @@ return [
      * If you set this to `/my-subdir`, all your media will be stored in a `/my-subdir` directory.
      */
     'prefix' => env('MEDIA_PREFIX', ''),
+
+    /*
+     * When disabling this option, Media Library Pro don't include a script tag to load the dragula library via a CDN.
+     * You have to include the dragula library by yourself!
+     */
+    'include_dragula_cdn_script' => true,
 ];


### PR DESCRIPTION
This PR adds a new option to disable the loading of dragula via a cdn.

See also the PR https://github.com/spatie/laravel-medialibrary-pro/pull/349