### PR TITLE
Check for lower and uppercase image extensions but always return the original extension for conversions

### DIFF
--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -205,7 +205,7 @@ class Conversion
     {
         if ($this->shouldKeepOriginalImageFormat()) {
             if (in_array(strtolower($originalFileExtension), ['jpg', 'jpeg', 'pjpg', 'png', 'gif'])) {
-                return strtolower($originalFileExtension);
+                return $originalFileExtension;
             }
         }
 

--- a/tests/Conversions/ConversionFileExtensionTest.php
+++ b/tests/Conversions/ConversionFileExtensionTest.php
@@ -27,7 +27,7 @@ class ConversionFileExtensionTest extends TestCase
     {
         $media = $this->testModelWithConversion->addMedia($this->getUppercaseExtensionTestPng())->toMediaCollection();
 
-        $this->assertExtensionEquals('png', $media->getUrl('keep_original_format'));
+        $this->assertExtensionEquals('PNG', $media->getUrl('keep_original_format'));
     }
 
     /** @test */


### PR DESCRIPTION
Uploading images with capital JPG didn't work. 
This seems to fix the issue.

Originally fixed in: #2527 