### PR TITLE
Add starting-from-id option to regenerate command

### DIFF
--- a/docs/converting-images/regenerating-images.md
+++ b/docs/converting-images/regenerating-images.md
@@ -50,3 +50,10 @@ If you want to regenerate images starting at a specific id (inclusive), you can 
 ```bash
 php artisan media-library:regenerate --starting-from-id=1
 ```
+
+You can also start after the provided id by also passing the `--exclude-starting-id` or `-X` options
+
+```bash
+php artisan media-library:regenerate --starting-from-id=1 --exclude-starting-id
+php artisan media-library:regenerate --starting-from-id=1 -X
+```

--- a/docs/converting-images/regenerating-images.md
+++ b/docs/converting-images/regenerating-images.md
@@ -44,3 +44,9 @@ If you want to force responsive images to be regenerated, you can use the `--wit
 ```bash
 php artisan media-library:regenerate --with-responsive-images
 ```
+
+If you want to regenerate images starting at a specific id (inclusive), you can use the `--starting-from-id` option
+
+```bash
+php artisan media-library:regenerate --starting-from-id=1
+```

--- a/docs/converting-images/regenerating-images.md
+++ b/docs/converting-images/regenerating-images.md
@@ -57,3 +57,9 @@ You can also start after the provided id by also passing the `--exclude-starting
 php artisan media-library:regenerate --starting-from-id=1 --exclude-starting-id
 php artisan media-library:regenerate --starting-from-id=1 -X
 ```
+
+The `--starting-from-id` option can also be combined with the `modelType` argument
+
+```bash
+php artisan media-library:regenerate "App\Models\Post" --starting-from-id=1
+```

--- a/src/Conversions/Commands/RegenerateCommand.php
+++ b/src/Conversions/Commands/RegenerateCommand.php
@@ -18,7 +18,7 @@ class RegenerateCommand extends Command
 
     protected $signature = 'media-library:regenerate {modelType?} {--ids=*}
     {--only=* : Regenerate specific conversions}
-    {--after-date= : Regenerate media after a certain date}
+    {--starting-from-id= : Regenerate media with an id equal to or higher than the provided value}
     {--only-missing : Regenerate only missing conversions}
     {--with-responsive-images : Regenerate responsive images}
     {--force : Force the operation to run when in production}';
@@ -76,21 +76,23 @@ class RegenerateCommand extends Command
     public function getMediaToBeRegenerated(): Collection
     {
         $modelType = $this->argument('modelType') ?? '';
+
         $mediaIds = $this->getMediaIds();
-        $date = $this->option('after-date') ?? '';
-        $noDate = $date === '';
         $noIds = count($mediaIds) === 0;
 
-        if ($modelType === '' && $noIds && $noDate) {
+        $startingFromId = (int)$this->option('starting-from-id');
+        $noStartingId = $startingFromId === 0;
+
+        if ($modelType === '' && $noIds && $noStartingId) {
             return $this->mediaRepository->all();
         }
 
-        if ($noIds && $noDate) {
+        if ($noIds && $noStartingId) {
             return $this->mediaRepository->getByModelType($modelType);
         }
 
-        if (!$noDate) {
-            return $this->mediaRepository->getByCreatedAfter($date);
+        if ($noIds) {
+            return $this->mediaRepository->getByIdGreaterThan($startingFromId);
         }
 
         return $this->mediaRepository->getByIds($mediaIds);

--- a/src/Conversions/Commands/RegenerateCommand.php
+++ b/src/Conversions/Commands/RegenerateCommand.php
@@ -76,15 +76,17 @@ class RegenerateCommand extends Command
 
     public function getMediaToBeRegenerated(): Collection
     {
+        // Get this arg first as it can also be passed to the greater-than-id branch
         $modelType = $this->argument('modelType') ?? '';
-        if ($modelType !== '') {
-            return $this->mediaRepository->getByModelType($modelType);
-        }
 
         $startingFromId = (int)$this->option('starting-from-id');
         if ($startingFromId !== 0) {
             $excludeStartingId = $this->option('exclude-starting-id') ?? false;
-            return $this->mediaRepository->getByIdGreaterThan($startingFromId, $excludeStartingId);
+            return $this->mediaRepository->getByIdGreaterThan($startingFromId, $excludeStartingId, $modelType);
+        }
+
+        if ($modelType !== '') {
+            return $this->mediaRepository->getByModelType($modelType);
         }
 
         $mediaIds = $this->getMediaIds();

--- a/src/Conversions/Commands/RegenerateCommand.php
+++ b/src/Conversions/Commands/RegenerateCommand.php
@@ -18,6 +18,7 @@ class RegenerateCommand extends Command
 
     protected $signature = 'media-library:regenerate {modelType?} {--ids=*}
     {--only=* : Regenerate specific conversions}
+    {--after-date= : Regenerate media after a certain date}
     {--only-missing : Regenerate only missing conversions}
     {--with-responsive-images : Regenerate responsive images}
     {--force : Force the operation to run when in production}';
@@ -76,13 +77,20 @@ class RegenerateCommand extends Command
     {
         $modelType = $this->argument('modelType') ?? '';
         $mediaIds = $this->getMediaIds();
+        $date = $this->option('after-date') ?? '';
+        $noDate = $date === '';
+        $noIds = count($mediaIds) === 0;
 
-        if ($modelType === '' && count($mediaIds) === 0) {
+        if ($modelType === '' && $noIds && $noDate) {
             return $this->mediaRepository->all();
         }
 
-        if (! count($mediaIds)) {
+        if ($noIds && $noDate) {
             return $this->mediaRepository->getByModelType($modelType);
+        }
+
+        if (!$noDate) {
+            return $this->mediaRepository->getByCreatedAfter($date);
         }
 
         return $this->mediaRepository->getByIds($mediaIds);

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -65,9 +65,9 @@ class MediaRepository
         return $this->query()->whereIn($this->model->getKeyName(), $ids)->get();
     }
 
-    public function getByIdGreaterThan(int $startingFromId): DbCollection
+    public function getByIdGreaterThan(int $startingFromId, bool $excludeStartingId = false): DbCollection
     {
-        return $this->query()->where($this->model->getKeyName(), '>=', $startingFromId)->get();
+        return $this->query()->where($this->model->getKeyName(), $excludeStartingId ? '>' : '>=', $startingFromId)->get();
     }
 
     public function getByModelTypeAndCollectionName(string $modelType, string $collectionName): DbCollection

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -65,9 +65,12 @@ class MediaRepository
         return $this->query()->whereIn($this->model->getKeyName(), $ids)->get();
     }
 
-    public function getByIdGreaterThan(int $startingFromId, bool $excludeStartingId = false): DbCollection
+    public function getByIdGreaterThan(int $startingFromId, bool $excludeStartingId = false, string $modelType = ''): DbCollection
     {
-        return $this->query()->where($this->model->getKeyName(), $excludeStartingId ? '>' : '>=', $startingFromId)->get();
+        return $this->query()
+            ->where($this->model->getKeyName(), $excludeStartingId ? '>' : '>=', $startingFromId)
+            ->when($modelType !== '', fn(Builder $q) => $q->where('model_type', $modelType))
+            ->get();
     }
 
     public function getByModelTypeAndCollectionName(string $modelType, string $collectionName): DbCollection

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -65,9 +65,9 @@ class MediaRepository
         return $this->query()->whereIn($this->model->getKeyName(), $ids)->get();
     }
 
-    public function getByCreatedAfter(string $datetime): DbCollection
+    public function getByIdGreaterThan(int $startingFromId): DbCollection
     {
-        return $this->query()->whereDate($this->model->getCreatedAtColumn(), '>=', $datetime)->get();
+        return $this->query()->where($this->model->getKeyName(), '>=', $startingFromId)->get();
     }
 
     public function getByModelTypeAndCollectionName(string $modelType, string $collectionName): DbCollection

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -65,6 +65,11 @@ class MediaRepository
         return $this->query()->whereIn($this->model->getKeyName(), $ids)->get();
     }
 
+    public function getByCreatedAfter(string $datetime): DbCollection
+    {
+        return $this->query()->whereDate($this->model->getCreatedAtColumn(), '>=', $datetime)->get();
+    }
+
     public function getByModelTypeAndCollectionName(string $modelType, string $collectionName): DbCollection
     {
         return $this->query()

--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -3,6 +3,8 @@
 namespace Spatie\MediaLibrary\Tests\Conversions\Commands;
 
 use Spatie\MediaLibrary\Tests\TestCase;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 
 class RegenerateCommandTest extends TestCase
 {
@@ -338,5 +340,45 @@ class RegenerateCommandTest extends TestCase
 
         $this->assertFileDoesNotExist($derivedImage);
         $this->assertFileExists($derivedImage2);
+    }
+
+    /** @test */
+    public function it_can_regenerate_files_starting_from_id_with_model_type()
+    {
+        $media = $this->testModelWithConversionsOnOtherDisk
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+
+        $media2 = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+
+        $media3 = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+
+        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+        $derivedImage3 = $this->getMediaDirectory("{$media3->id}/conversions/test-thumb.jpg");
+
+        unlink($derivedImage);
+        unlink($derivedImage2);
+        unlink($derivedImage3);
+
+        $this->assertFileDoesNotExist($derivedImage);
+        $this->assertFileDoesNotExist($derivedImage2);
+        $this->assertFileDoesNotExist($derivedImage3);
+
+        $this->artisan('media-library:regenerate', [
+            '--starting-from-id' => $media->getKey(),
+            'modelType' => TestModelWithConversion::class,
+        ]);
+
+        $this->assertFileDoesNotExist($derivedImage);
+        $this->assertFileExists($derivedImage2);
+        $this->assertFileExists($derivedImage3);
     }
 }

--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -254,16 +254,12 @@ class RegenerateCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_can_regenerate_files_by_created_date()
+    public function it_can_regenerate_files_by_starting_from_id()
     {
-        $this->travelTo(now()->subWeek());
-
         $media = $this->testModelWithConversion
             ->addMedia($this->getTestFilesDirectory('test.jpg'))
             ->preservingOriginal()
             ->toMediaCollection('images');
-
-        $this->travelBack();
 
         $media2 = $this->testModelWithConversion
             ->addMedia($this->getTestFilesDirectory('test.jpg'))
@@ -278,7 +274,7 @@ class RegenerateCommandTest extends TestCase
         $this->assertFileDoesNotExist($derivedImage);
         $this->assertFileDoesNotExist($derivedImage2);
 
-        $this->artisan('media-library:regenerate', ['--after-date' => now()->toDateString()]);
+        $this->artisan('media-library:regenerate', ['--starting-from-id' => $media2->getKey()]);
 
         $this->assertFileDoesNotExist($derivedImage);
         $this->assertFileExists($derivedImage2);

--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -252,4 +252,35 @@ class RegenerateCommandTest extends TestCase
             $this->assertFileExists($image);
         }
     }
+
+    /** @test */
+    public function it_can_regenerate_files_by_created_date()
+    {
+        $this->travelTo(now()->subWeek());
+
+        $media = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+
+        $this->travelBack();
+
+        $media2 = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->toMediaCollection('images');
+
+        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+
+        unlink($derivedImage);
+        unlink($derivedImage2);
+
+        $this->assertFileDoesNotExist($derivedImage);
+        $this->assertFileDoesNotExist($derivedImage2);
+
+        $this->artisan('media-library:regenerate', ['--after-date' => now()->toDateString()]);
+
+        $this->assertFileDoesNotExist($derivedImage);
+        $this->assertFileExists($derivedImage2);
+    }
 }

--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -279,4 +279,64 @@ class RegenerateCommandTest extends TestCase
         $this->assertFileDoesNotExist($derivedImage);
         $this->assertFileExists($derivedImage2);
     }
+
+    /** @test */
+    public function it_can_regenerate_files_starting_after_the_provided_id()
+    {
+        $media = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+
+        $media2 = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->toMediaCollection('images');
+
+        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+
+        unlink($derivedImage);
+        unlink($derivedImage2);
+
+        $this->assertFileDoesNotExist($derivedImage);
+        $this->assertFileDoesNotExist($derivedImage2);
+
+        $this->artisan('media-library:regenerate', [
+            '--starting-from-id' => $media->getKey(),
+            '--exclude-starting-id' => true,
+        ]);
+
+        $this->assertFileDoesNotExist($derivedImage);
+        $this->assertFileExists($derivedImage2);
+    }
+
+    /** @test */
+    public function it_can_regenerate_files_starting_after_the_provided_id_with_shortcut()
+    {
+        $media = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->preservingOriginal()
+            ->toMediaCollection('images');
+
+        $media2 = $this->testModelWithConversion
+            ->addMedia($this->getTestFilesDirectory('test.jpg'))
+            ->toMediaCollection('images');
+
+        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+
+        unlink($derivedImage);
+        unlink($derivedImage2);
+
+        $this->assertFileDoesNotExist($derivedImage);
+        $this->assertFileDoesNotExist($derivedImage2);
+
+        $this->artisan('media-library:regenerate', [
+            '--starting-from-id' => $media->getKey(),
+            '-X' => true,
+        ]);
+
+        $this->assertFileDoesNotExist($derivedImage);
+        $this->assertFileExists($derivedImage2);
+    }
 }


### PR DESCRIPTION
I have found myself wanting to regenerate recent images, but with potentially thousands of ids to pass as a command option, I thought adding a date option could be useful