### PR TITLE
Fix for deleted files on copy media to model

### DIFF
--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -301,6 +301,7 @@ class Media extends Model implements Responsable, Htmlable
 
         $fileAdder = $model
             ->addMediaFromDisk($path, $this->disk)
+            ->preservingOriginal()
             ->usingName($this->name)
             ->setOrder($this->order_column)
             ->withCustomProperties($this->custom_properties);

--- a/tests/Feature/Media/CopyTest.php
+++ b/tests/Feature/Media/CopyTest.php
@@ -146,4 +146,21 @@ class CopyTest extends TestCase
         $this->assertEquals($movedMedia->name, 'custom-name');
         $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
     }
+
+    /** @test */
+    public function it_preserves_original_file_on_copy_media_item_to_model()
+    {
+        $model = TestModel::create(['name' => 'original']);
+
+        $media = $model
+            ->addMedia($this->getTestJpg())
+            ->toMediaCollection();
+
+        $anotherModel = TestModel::create(['name' => 'target']);
+
+        $anotherMedia = $media->copy($anotherModel);
+
+        $this->assertFileExists($media->getPath());
+        $this->assertFileExists($anotherMedia->getPath());
+    }
 }


### PR DESCRIPTION
Greetings!

We have been losing files since upgrading to 9.10.0 when we copy media items to models, apparently introduced in #2638.

It's my first contribution to spatie, any feedback is really appreciated.