### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,11 +3,16 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
+/.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.travis.yml        export-ignore
+/.php_cs.dist.php   export-ignore
+/art                export-ignore
 /phpunit.xml.dist   export-ignore
 /.scrutinizer.yml   export-ignore
 /.styleci.yml       export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
+/docs               export-ignore
+/UPGRADING.md       export-ignore


### PR DESCRIPTION
Make the package **4.66 MB** (4,886,528 bytes) lighter on vendor

https://github.com/spatie/spatie.be/blob/4d8d699c1230888af4ded98814733033b765aa95/app/Console/Commands/ImportDocsFromRepositoriesCommand.php#L119-L120
With `git pull origin ${branch} && cp -r docs/* ../../../docs/{$repository['name']}/{$alias}` it would copy the docs despite the `export-ignore`, right?

I did test it, i get the docs despite the `export-ignore`