### PR TITLE
add index to order_column migration

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -24,7 +24,7 @@ class CreateMediaTable extends Migration
             $table->json('custom_properties');
             $table->json('generated_conversions');
             $table->json('responsive_images');
-            $table->unsignedInteger('order_column')->nullable();
+            $table->unsignedInteger('order_column')->nullable()->index();
 
             $table->nullableTimestamps();
         });


### PR DESCRIPTION
This PR adds an index to the order_column migration.

It significantly speeds up adding media with large media tables (>10m entries)