### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -57,7 +57,7 @@ jobs:
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             - name: Execute tests
-              run: vendor/bin/phpunit
+              run: vendor/bin/pest
               env:
                 AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                 AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/composer.json
+++ b/composer.json
@@ -46,10 +46,10 @@
         "league/flysystem-aws-s3-v3": "^1.0.29",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^6.23|^7.0",
-        "phpunit/phpunit": "^9.5",
         "spatie/laravel-ray": "^1.27",
         "spatie/pdf-to-image": "^2.1",
-        "spatie/phpunit-snapshot-assertions": "^4.2"
+        "spatie/phpunit-snapshot-assertions": "^4.2",
+        "pestphp/pest": "^1.20"
     },
     "conflict": {
         "php-ffmpeg/php-ffmpeg": "<0.6.1"

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "ext-zip": "*",
+        "ext-imagick": "*",
         "aws/aws-sdk-php": "^3.133.11",
         "doctrine/dbal": "^2.13",
         "guzzlehttp/guzzle": "^7.4",
@@ -49,7 +50,7 @@
         "spatie/laravel-ray": "^1.27",
         "spatie/pdf-to-image": "^2.1",
         "spatie/phpunit-snapshot-assertions": "^4.2",
-        "pestphp/pest": "^1.20"
+        "pestphp/pest": "^1.20",
     },
     "conflict": {
         "php-ffmpeg/php-ffmpeg": "<0.6.1"

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "minimum-stability": "stable",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
     },
     "scripts": {
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
-        "test": "vendor/bin/phpunit"
+        "test": "vendor/bin/pest"
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/Conversions/Commands/CleanCommandTest/CleanResponsiveImagesTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest/CleanResponsiveImagesTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 it('can clean responsive images', function () {

--- a/tests/Conversions/Commands/CleanCommandTest/CleanResponsiveImagesTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest/CleanResponsiveImagesTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can clean responsive images', function () {
     $media = $this->testModelWithResponsiveImages

--- a/tests/Conversions/Commands/CleanCommandTest/CleanResponsiveImagesTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest/CleanResponsiveImagesTest.php
@@ -1,35 +1,30 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\Commands\CleanCommandTest;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class CleanResponsiveImagesTest extends TestCase
-{
-    /** @test */
-    public function it_can_clean_responsive_images()
-    {
-        $media = $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection();
+uses(TestCase::class);
 
-        $deprecatedResponsiveImageFileName = 'test___deprecatedConversion_50_41.jpg';
-        $deprecatedReponsiveImagesPath = $this->getMediaDirectory("1/responsive-images/{$deprecatedResponsiveImageFileName}");
-        touch($deprecatedReponsiveImagesPath);
+it('can clean responsive images', function () {
+    $media = $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection();
 
-        $originalResponsiveImagesContent = $media->responsive_images;
-        $newResponsiveImages = $originalResponsiveImagesContent;
-        $newResponsiveImages['deprecatedConversion'] = $originalResponsiveImagesContent['thumb'];
-        $newResponsiveImages['deprecatedConversion']['urls'][0] = $deprecatedResponsiveImageFileName;
-        $media->responsive_images = $newResponsiveImages;
-        $media->save();
+    $deprecatedResponsiveImageFileName = 'test___deprecatedConversion_50_41.jpg';
+    $deprecatedReponsiveImagesPath = $this->getMediaDirectory("1/responsive-images/{$deprecatedResponsiveImageFileName}");
+    touch($deprecatedReponsiveImagesPath);
 
-        $this->artisan('media-library:clean');
+    $originalResponsiveImagesContent = $media->responsive_images;
+    $newResponsiveImages = $originalResponsiveImagesContent;
+    $newResponsiveImages['deprecatedConversion'] = $originalResponsiveImagesContent['thumb'];
+    $newResponsiveImages['deprecatedConversion']['urls'][0] = $deprecatedResponsiveImageFileName;
+    $media->responsive_images = $newResponsiveImages;
+    $media->save();
 
-        $media->refresh();
+    $this->artisan('media-library:clean');
 
-        $this->assertEquals($originalResponsiveImagesContent, $media->responsive_images);
-        $this->assertFileDoesNotExist($deprecatedReponsiveImagesPath);
-    }
-}
+    $media->refresh();
+
+    $this->assertEquals($originalResponsiveImagesContent, $media->responsive_images);
+    $this->assertFileDoesNotExist($deprecatedReponsiveImagesPath);
+});

--- a/tests/Conversions/Commands/CleanCommandTest/CleanResponsiveImagesTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest/CleanResponsiveImagesTest.php
@@ -25,6 +25,6 @@ it('can clean responsive images', function () {
 
     $media->refresh();
 
-    $this->assertEquals($originalResponsiveImagesContent, $media->responsive_images);
+    expect($media->responsive_images)->toEqual($originalResponsiveImagesContent);
     $this->assertFileDoesNotExist($deprecatedReponsiveImagesPath);
 });

--- a/tests/Conversions/Commands/CleanConversionsTest.php
+++ b/tests/Conversions/Commands/CleanConversionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\Commands;
-
 use Illuminate\Support\Facades\DB;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -9,193 +7,171 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 
-class CleanConversionsTest extends TestCase
-{
-    protected array $media;
+uses(TestCase::class);
 
-    public function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    $this->media['model1']['collection1'] = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection1');
 
-        $this->media['model1']['collection1'] = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('collection1');
+    $this->media['model1']['collection2'] = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection2');
 
-        $this->media['model1']['collection2'] = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('collection2');
+    $this->media['model2']['collection1'] = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection1');
 
-        $this->media['model2']['collection1'] = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('collection1');
+    $this->media['model2']['collection2'] = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection2');
 
-        $this->media['model2']['collection2'] = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('collection2');
+    mkdir($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/conversions"));
+    mkdir($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/conversions"));
 
-        mkdir($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/conversions"));
-        mkdir($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/conversions"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+});
 
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
-    }
+it('can clean deprecated conversion files with none arguments given', function () {
+    $media = $this->media['model2']['collection1'];
+    $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-deprecated.jpg");
 
-    /** @test */
-    public function it_can_clean_deprecated_conversion_files_with_none_arguments_given()
-    {
-        $media = $this->media['model2']['collection1'];
-        $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-deprecated.jpg");
+    touch($deprecatedImage);
+    $this->assertFileExists($deprecatedImage);
 
-        touch($deprecatedImage);
-        $this->assertFileExists($deprecatedImage);
+    $this->artisan('media-library:clean');
 
-        $this->artisan('media-library:clean');
+    $this->assertFileDoesNotExist($deprecatedImage);
+    $this->assertFileExists($this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg"));
+});
 
-        $this->assertFileDoesNotExist($deprecatedImage);
-        $this->assertFileExists($this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg"));
-    }
+test('generated conversion are cleared after cleanup', function () {
+    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    $media = $this->media['model2']['collection1'];
 
-    /** @test */
-    public function generated_conversion_are_cleared_after_cleanup()
-    {
-        /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
-        $media = $this->media['model2']['collection1'];
+    Media::where('id', '<>', $media->id)->delete();
 
-        Media::where('id', '<>', $media->id)->delete();
+    $media->markAsConversionGenerated('test-deprecated');
 
-        $media->markAsConversionGenerated('test-deprecated');
+    $media->save();
 
-        $media->save();
+    $this->assertTrue($media->refresh()->hasGeneratedConversion('test-deprecated'));
 
-        $this->assertTrue($media->refresh()->hasGeneratedConversion('test-deprecated'));
+    $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-deprecated.jpg");
 
-        $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-deprecated.jpg");
+    touch($deprecatedImage);
 
-        touch($deprecatedImage);
+    $this->artisan('media-library:clean');
 
-        $this->artisan('media-library:clean');
+    $media->refresh();
 
-        $media->refresh();
+    $this->assertFalse($media->hasGeneratedConversion('test-deprecated'));
+});
 
-        $this->assertFalse($media->hasGeneratedConversion('test-deprecated'));
-    }
+it('can clean deprecated conversion files from a specific model type', function () {
+    $media1 = $this->media['model1']['collection1'];
+    $media2 = $this->media['model2']['collection1'];
 
-    /** @test */
-    public function it_can_clean_deprecated_conversion_files_from_a_specific_model_type()
-    {
-        $media1 = $this->media['model1']['collection1'];
-        $media2 = $this->media['model2']['collection1'];
+    $deprecatedImage1 = $this->getMediaDirectory("{$media1->id}/conversions/deprecated.jpg");
+    $deprecatedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/deprecated.jpg");
+    touch($deprecatedImage1);
+    touch($deprecatedImage2);
 
-        $deprecatedImage1 = $this->getMediaDirectory("{$media1->id}/conversions/deprecated.jpg");
-        $deprecatedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/deprecated.jpg");
-        touch($deprecatedImage1);
-        touch($deprecatedImage2);
+    $this->artisan('media-library:clean', [
+        'modelType' => TestModelWithConversion::class,
+    ]);
 
-        $this->artisan('media-library:clean', [
-            'modelType' => TestModelWithConversion::class,
-        ]);
+    $this->assertFileExists($deprecatedImage1);
+    $this->assertFileDoesNotExist($deprecatedImage2);
+});
 
-        $this->assertFileExists($deprecatedImage1);
-        $this->assertFileDoesNotExist($deprecatedImage2);
-    }
+it('can clean deprecated conversion files from a specific collection', function () {
+    $media1 = $this->media['model1']['collection1'];
+    $media2 = $this->media['model1']['collection2'];
 
-    /** @test */
-    public function it_can_clean_deprecated_conversion_files_from_a_specific_collection()
-    {
-        $media1 = $this->media['model1']['collection1'];
-        $media2 = $this->media['model1']['collection2'];
+    $deprecatedImage1 = $this->getMediaDirectory("{$media1->id}/conversions/deprecated.jpg");
+    $deprecatedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/deprecated.jpg");
+    touch($deprecatedImage1);
+    touch($deprecatedImage2);
 
-        $deprecatedImage1 = $this->getMediaDirectory("{$media1->id}/conversions/deprecated.jpg");
-        $deprecatedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/deprecated.jpg");
-        touch($deprecatedImage1);
-        touch($deprecatedImage2);
+    $this->artisan('media-library:clean', [
+        'collectionName' => 'collection2',
+    ]);
 
-        $this->artisan('media-library:clean', [
-            'collectionName' => 'collection2',
-        ]);
+    $this->assertFileExists($deprecatedImage1);
+    $this->assertFileDoesNotExist($deprecatedImage2);
+});
 
-        $this->assertFileExists($deprecatedImage1);
-        $this->assertFileDoesNotExist($deprecatedImage2);
-    }
+it('can clean deprecated conversion files from a specific model type and collection', function () {
+    $media1 = $this->media['model1']['collection1'];
+    $media2 = $this->media['model1']['collection2'];
+    $media3 = $this->media['model2']['collection1'];
 
-    /** @test */
-    public function it_can_clean_deprecated_conversion_files_from_a_specific_model_type_and_collection()
-    {
-        $media1 = $this->media['model1']['collection1'];
-        $media2 = $this->media['model1']['collection2'];
-        $media3 = $this->media['model2']['collection1'];
+    $deprecatedImage1 = $this->getMediaDirectory("{$media1->id}/conversions/deprecated.jpg");
+    $deprecatedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/deprecated.jpg");
+    $deprecatedImage3 = $this->getMediaDirectory("{$media3->id}/conversions/deprecated.jpg");
 
-        $deprecatedImage1 = $this->getMediaDirectory("{$media1->id}/conversions/deprecated.jpg");
-        $deprecatedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/deprecated.jpg");
-        $deprecatedImage3 = $this->getMediaDirectory("{$media3->id}/conversions/deprecated.jpg");
+    touch($deprecatedImage1);
+    touch($deprecatedImage2);
+    touch($deprecatedImage3);
 
-        touch($deprecatedImage1);
-        touch($deprecatedImage2);
-        touch($deprecatedImage3);
+    $this->artisan('media-library:clean', [
+        'modelType' => TestModel::class,
+        'collectionName' => 'collection1',
+    ]);
 
-        $this->artisan('media-library:clean', [
-            'modelType' => TestModel::class,
-            'collectionName' => 'collection1',
-        ]);
+    $this->assertFileDoesNotExist($deprecatedImage1);
+    $this->assertFileExists($deprecatedImage2);
+    $this->assertFileExists($deprecatedImage3);
+});
 
-        $this->assertFileDoesNotExist($deprecatedImage1);
-        $this->assertFileExists($deprecatedImage2);
-        $this->assertFileExists($deprecatedImage3);
-    }
+it('can clean orphan files in the media disk', function () {
+    // Dirty delete
+    DB::table('media')->delete($this->media['model1']['collection1']->id);
 
-    /** @test */
-    public function it_can_clean_orphan_files_in_the_media_disk()
-    {
-        // Dirty delete
-        DB::table('media')->delete($this->media['model1']['collection1']->id);
+    $this->artisan('media-library:clean');
 
-        $this->artisan('media-library:clean');
+    $this->assertFileDoesNotExist($this->getMediaDirectory($this->media['model1']['collection1']->id));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
+});
 
-        $this->assertFileDoesNotExist($this->getMediaDirectory($this->media['model1']['collection1']->id));
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
-    }
+it('can clean responsive images', function () {
+    $media = $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection();
 
-    /** @test */
-    public function it_can_clean_responsive_images()
-    {
-        $media = $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection();
+    $deprecatedResponsiveImageFileName = 'test___deprecatedConversion_50_41.jpg';
+    $deprecatedReponsiveImagesPath = $this->getMediaDirectory("5/responsive-images/{$deprecatedResponsiveImageFileName}");
+    touch($deprecatedReponsiveImagesPath);
 
-        $deprecatedResponsiveImageFileName = 'test___deprecatedConversion_50_41.jpg';
-        $deprecatedReponsiveImagesPath = $this->getMediaDirectory("5/responsive-images/{$deprecatedResponsiveImageFileName}");
-        touch($deprecatedReponsiveImagesPath);
+    $originalResponsiveImagesContent = $media->responsive_images;
+    $newResponsiveImages = $originalResponsiveImagesContent;
+    $newResponsiveImages['deprecatedConversion'] = $originalResponsiveImagesContent['thumb'];
+    $newResponsiveImages['deprecatedConversion']['urls'][0] = $deprecatedResponsiveImageFileName;
+    $media->responsive_images = $newResponsiveImages;
+    $media->save();
 
-        $originalResponsiveImagesContent = $media->responsive_images;
-        $newResponsiveImages = $originalResponsiveImagesContent;
-        $newResponsiveImages['deprecatedConversion'] = $originalResponsiveImagesContent['thumb'];
-        $newResponsiveImages['deprecatedConversion']['urls'][0] = $deprecatedResponsiveImageFileName;
-        $media->responsive_images = $newResponsiveImages;
-        $media->save();
+    $this->artisan('media-library:clean');
 
-        $this->artisan('media-library:clean');
+    $media->refresh();
 
-        $media->refresh();
+    $this->assertEquals($originalResponsiveImagesContent, $media->responsive_images);
+    $this->assertFileDoesNotExist($deprecatedReponsiveImagesPath);
+});
 
-        $this->assertEquals($originalResponsiveImagesContent, $media->responsive_images);
-        $this->assertFileDoesNotExist($deprecatedReponsiveImagesPath);
-    }
+it('will throw an exception when using a non existing disk', function () {
+    $this->expectException(DiskDoesNotExist::class);
 
-    /** @test */
-    public function it_will_throw_an_exception_when_using_a_non_existing_disk()
-    {
-        $this->expectException(DiskDoesNotExist::class);
+    config(['media-library.disk_name' => 'diskdoesnotexist']);
 
-        config(['media-library.disk_name' => 'diskdoesnotexist']);
-
-        $this->artisan('media-library:clean')
-            ->assertExitCode(1);
-    }
-}
+    $this->artisan('media-library:clean')
+        ->assertExitCode(1);
+});

--- a/tests/Conversions/Commands/CleanConversionsTest.php
+++ b/tests/Conversions/Commands/CleanConversionsTest.php
@@ -3,10 +3,8 @@
 use Illuminate\Support\Facades\DB;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
-
 
 beforeEach(function () {
     $this->media['model1']['collection1'] = $this->testModel

--- a/tests/Conversions/Commands/CleanConversionsTest.php
+++ b/tests/Conversions/Commands/CleanConversionsTest.php
@@ -33,10 +33,10 @@ beforeEach(function () {
     mkdir($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/conversions"));
     mkdir($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/conversions"));
 
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+    expect($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"))->toBeFile();
+    expect($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"))->toBeFile();
+    expect($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"))->toBeFile();
+    expect($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"))->toBeFile();
 });
 
 it('can clean deprecated conversion files with none arguments given', function () {
@@ -44,12 +44,12 @@ it('can clean deprecated conversion files with none arguments given', function (
     $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-deprecated.jpg");
 
     touch($deprecatedImage);
-    $this->assertFileExists($deprecatedImage);
+    expect($deprecatedImage)->toBeFile();
 
     $this->artisan('media-library:clean');
 
     $this->assertFileDoesNotExist($deprecatedImage);
-    $this->assertFileExists($this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg"));
+    expect($this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg"))->toBeFile();
 });
 
 test('generated conversion are cleared after cleanup', function () {
@@ -62,7 +62,7 @@ test('generated conversion are cleared after cleanup', function () {
 
     $media->save();
 
-    $this->assertTrue($media->refresh()->hasGeneratedConversion('test-deprecated'));
+    expect($media->refresh()->hasGeneratedConversion('test-deprecated'))->toBeTrue();
 
     $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-deprecated.jpg");
 
@@ -72,7 +72,7 @@ test('generated conversion are cleared after cleanup', function () {
 
     $media->refresh();
 
-    $this->assertFalse($media->hasGeneratedConversion('test-deprecated'));
+    expect($media->hasGeneratedConversion('test-deprecated'))->toBeFalse();
 });
 
 it('can clean deprecated conversion files from a specific model type', function () {
@@ -88,7 +88,7 @@ it('can clean deprecated conversion files from a specific model type', function 
         'modelType' => TestModelWithConversion::class,
     ]);
 
-    $this->assertFileExists($deprecatedImage1);
+    expect($deprecatedImage1)->toBeFile();
     $this->assertFileDoesNotExist($deprecatedImage2);
 });
 
@@ -105,7 +105,7 @@ it('can clean deprecated conversion files from a specific collection', function 
         'collectionName' => 'collection2',
     ]);
 
-    $this->assertFileExists($deprecatedImage1);
+    expect($deprecatedImage1)->toBeFile();
     $this->assertFileDoesNotExist($deprecatedImage2);
 });
 
@@ -128,8 +128,8 @@ it('can clean deprecated conversion files from a specific model type and collect
     ]);
 
     $this->assertFileDoesNotExist($deprecatedImage1);
-    $this->assertFileExists($deprecatedImage2);
-    $this->assertFileExists($deprecatedImage3);
+    expect($deprecatedImage2)->toBeFile();
+    expect($deprecatedImage3)->toBeFile();
 });
 
 it('can clean orphan files in the media disk', function () {
@@ -139,7 +139,7 @@ it('can clean orphan files in the media disk', function () {
     $this->artisan('media-library:clean');
 
     $this->assertFileDoesNotExist($this->getMediaDirectory($this->media['model1']['collection1']->id));
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
+    expect($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"))->toBeFile();
 });
 
 it('can clean responsive images', function () {
@@ -163,7 +163,7 @@ it('can clean responsive images', function () {
 
     $media->refresh();
 
-    $this->assertEquals($originalResponsiveImagesContent, $media->responsive_images);
+    expect($media->responsive_images)->toEqual($originalResponsiveImagesContent);
     $this->assertFileDoesNotExist($deprecatedReponsiveImagesPath);
 });
 

--- a/tests/Conversions/Commands/CleanConversionsTest.php
+++ b/tests/Conversions/Commands/CleanConversionsTest.php
@@ -7,7 +7,6 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $this->media['model1']['collection1'] = $this->testModel

--- a/tests/Conversions/Commands/ClearCommandTest.php
+++ b/tests/Conversions/Commands/ClearCommandTest.php
@@ -26,10 +26,10 @@ beforeEach(function () {
         ->preservingOriginal()
         ->toMediaCollection('collection2');
 
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+    expect($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"))->toBeFile();
+    expect($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"))->toBeFile();
+    expect($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"))->toBeFile();
+    expect($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"))->toBeFile();
 });
 
 it('can clear all media', function () {
@@ -50,8 +50,8 @@ it('can clear media from a specific model type', function () {
     $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
     $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
 
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+    expect($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"))->toBeFile();
+    expect($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"))->toBeFile();
 });
 
 it('can clear media from a specific collection', function () {
@@ -59,10 +59,10 @@ it('can clear media from a specific collection', function () {
         'collectionName' => 'collection2',
     ]);
 
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
+    expect($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"))->toBeFile();
     $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
 
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
+    expect($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"))->toBeFile();
     $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
 });
 
@@ -72,9 +72,9 @@ it('can clear media from a specific model type and collection', function () {
         'collectionName' => 'collection2',
     ]);
 
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
+    expect($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"))->toBeFile();
     $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
 
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
-    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+    expect($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"))->toBeFile();
+    expect($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"))->toBeFile();
 });

--- a/tests/Conversions/Commands/ClearCommandTest.php
+++ b/tests/Conversions/Commands/ClearCommandTest.php
@@ -1,96 +1,80 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\Commands;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-class ClearCommandTest extends TestCase
-{
-    protected array $media;
+uses(TestCase::class);
 
-    public function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    $this->media['model1']['collection1'] = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection1');
 
-        $this->media['model1']['collection1'] = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('collection1');
+    $this->media['model1']['collection2'] = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection2');
 
-        $this->media['model1']['collection2'] = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('collection2');
+    $this->media['model2']['collection1'] = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection1');
 
-        $this->media['model2']['collection1'] = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('collection1');
+    $this->media['model2']['collection2'] = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection2');
 
-        $this->media['model2']['collection2'] = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('collection2');
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+});
 
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
-    }
+it('can clear all media', function () {
+    $this->artisan('media-library:clear');
 
-    /** @test */
-    public function it_can_clear_all_media()
-    {
-        $this->artisan('media-library:clear');
+    $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
+    $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
 
-        $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
-        $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
+    $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
+    $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+});
 
-        $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
-        $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
-    }
+it('can clear media from a specific model type', function () {
+    $this->artisan('media-library:clear', [
+        'modelType' => TestModel::class,
+    ]);
 
-    /** @test */
-    public function it_can_clear_media_from_a_specific_model_type()
-    {
-        $this->artisan('media-library:clear', [
-            'modelType' => TestModel::class,
-        ]);
+    $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
+    $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
 
-        $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
-        $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+});
 
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
-    }
+it('can clear media from a specific collection', function () {
+    $this->artisan('media-library:clear', [
+        'collectionName' => 'collection2',
+    ]);
 
-    /** @test */
-    public function it_can_clear_media_from_a_specific_collection()
-    {
-        $this->artisan('media-library:clear', [
-            'collectionName' => 'collection2',
-        ]);
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
+    $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
 
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
-        $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
+    $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+});
 
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
-        $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
-    }
+it('can clear media from a specific model type and collection', function () {
+    $this->artisan('media-library:clear', [
+        'modelType' => TestModel::class,
+        'collectionName' => 'collection2',
+    ]);
 
-    /** @test */
-    public function it_can_clear_media_from_a_specific_model_type_and_collection()
-    {
-        $this->artisan('media-library:clear', [
-            'modelType' => TestModel::class,
-            'collectionName' => 'collection2',
-        ]);
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
+    $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
 
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/test.jpg"));
-        $this->assertFileDoesNotExist($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"));
-
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
-        $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
-    }
-}
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection1']->id}/test.jpg"));
+    $this->assertFileExists($this->getMediaDirectory("{$this->media['model2']['collection2']->id}/test.jpg"));
+});

--- a/tests/Conversions/Commands/ClearCommandTest.php
+++ b/tests/Conversions/Commands/ClearCommandTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $this->media['model1']['collection1'] = $this->testModel

--- a/tests/Conversions/Commands/ClearCommandTest.php
+++ b/tests/Conversions/Commands/ClearCommandTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
-
 
 beforeEach(function () {
     $this->media['model1']['collection1'] = $this->testModel

--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 
-uses(TestCase::class);
 
 it('can regenerate all files', function () {
     $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection('images');

--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -19,8 +19,8 @@ it('can regenerate all files', function () {
 
     $this->artisan('media-library:regenerate');
 
-    $this->assertFileExists($derivedImage);
-    $this->assertGreaterThan($createdAt, filemtime($derivedImage));
+    expect($derivedImage)->toBeFile();
+    expect(filemtime($derivedImage))->toBeGreaterThan($createdAt);
 });
 
 it('can regenerate only missing files', function () {
@@ -52,11 +52,11 @@ it('can regenerate only missing files', function () {
         '--only-missing' => true,
     ]);
 
-    $this->assertFileExists($derivedMissingImage);
+    expect($derivedMissingImage)->toBeFile();
 
-    $this->assertSame($existsCreatedAt, filemtime($derivedImageExists));
+    expect(filemtime($derivedImageExists))->toBe($existsCreatedAt);
 
-    $this->assertGreaterThan($missingCreatedAt, filemtime($derivedMissingImage));
+    expect(filemtime($derivedMissingImage))->toBeGreaterThan($missingCreatedAt);
 });
 
 it('can regenerate missing files queued', function () {
@@ -88,11 +88,11 @@ it('can regenerate missing files queued', function () {
         '--only-missing' => true,
     ]);
 
-    $this->assertFileExists($derivedMissingImage);
+    expect($derivedMissingImage)->toBeFile();
 
-    $this->assertSame($existsCreatedAt, filemtime($derivedImageExists));
+    expect(filemtime($derivedImageExists))->toBe($existsCreatedAt);
 
-    $this->assertGreaterThan($missingCreatedAt, filemtime($derivedMissingImage));
+    expect(filemtime($derivedMissingImage))->toBeGreaterThan($missingCreatedAt);
 });
 
 it('can regenerate all files of named conversions', function () {
@@ -114,7 +114,7 @@ it('can regenerate all files of named conversions', function () {
         '--only' => 'thumb',
     ]);
 
-    $this->assertFileExists($derivedImage);
+    expect($derivedImage)->toBeFile();
     $this->assertFileDoesNotExist($derivedMissingImage);
 });
 
@@ -149,10 +149,10 @@ it('can regenerate only missing files of named conversions', function () {
         '--only' => 'thumb',
     ]);
 
-    $this->assertFileExists($derivedMissingImage);
+    expect($derivedMissingImage)->toBeFile();
     $this->assertFileDoesNotExist($derivedMissingImageOriginal);
-    $this->assertSame($existsCreatedAt, filemtime($derivedImageExists));
-    $this->assertGreaterThan($missingCreatedAt, filemtime($derivedMissingImage));
+    expect(filemtime($derivedImageExists))->toBe($existsCreatedAt);
+    expect(filemtime($derivedMissingImage))->toBeGreaterThan($missingCreatedAt);
 });
 
 it('can regenerate files by media ids', function () {
@@ -177,7 +177,7 @@ it('can regenerate files by media ids', function () {
     $this->artisan('media-library:regenerate', ['--ids' => [2]]);
 
     $this->assertFileDoesNotExist($derivedImage);
-    $this->assertFileExists($derivedImage2);
+    expect($derivedImage2)->toBeFile();
 });
 
 it('can regenerate files by comma separated media ids', function () {
@@ -201,8 +201,8 @@ it('can regenerate files by comma separated media ids', function () {
 
     $this->artisan('media-library:regenerate', ['--ids' => ['1,2']]);
 
-    $this->assertFileExists($derivedImage);
-    $this->assertFileExists($derivedImage2);
+    expect($derivedImage)->toBeFile();
+    expect($derivedImage2)->toBeFile();
 });
 
 it('can regenerate files even if there are files missing', function () {
@@ -230,7 +230,7 @@ it('can regenerate responsive images', function () {
     $this->artisan('media-library:regenerate', ['--with-responsive-images' => true])->assertExitCode(0);
 
     foreach ($responsiveImages as $image) {
-        $this->assertFileExists($image);
+        expect($image)->toBeFile();
     }
 });
 
@@ -256,7 +256,7 @@ it('can regenerate files by starting from id', function () {
     $this->artisan('media-library:regenerate', ['--starting-from-id' => $media2->getKey()]);
 
     $this->assertFileDoesNotExist($derivedImage);
-    $this->assertFileExists($derivedImage2);
+    expect($derivedImage2)->toBeFile();
 });
 
 it('can regenerate files starting after the provided id', function () {
@@ -284,7 +284,7 @@ it('can regenerate files starting after the provided id', function () {
     ]);
 
     $this->assertFileDoesNotExist($derivedImage);
-    $this->assertFileExists($derivedImage2);
+    expect($derivedImage2)->toBeFile();
 });
 
 it('can regenerate files starting after the provided id with shortcut', function () {
@@ -312,7 +312,7 @@ it('can regenerate files starting after the provided id with shortcut', function
     ]);
 
     $this->assertFileDoesNotExist($derivedImage);
-    $this->assertFileExists($derivedImage2);
+    expect($derivedImage2)->toBeFile();
 });
 
 it('can regenerate files starting from id with model type', function () {
@@ -349,6 +349,6 @@ it('can regenerate files starting from id with model type', function () {
     ]);
 
     $this->assertFileDoesNotExist($derivedImage);
-    $this->assertFileExists($derivedImage2);
-    $this->assertFileExists($derivedImage3);
+    expect($derivedImage2)->toBeFile();
+    expect($derivedImage3)->toBeFile();
 });

--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
-
 
 it('can regenerate all files', function () {
     $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection('images');

--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -1,383 +1,354 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\Commands;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 
-class RegenerateCommandTest extends TestCase
-{
-    /** @test */
-    public function it_can_regenerate_all_files()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection('images');
+uses(TestCase::class);
 
-        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
-        $createdAt = filemtime($derivedImage);
+it('can regenerate all files', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection('images');
 
-        unlink($derivedImage);
+    $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+    $createdAt = filemtime($derivedImage);
 
-        $this->assertFileDoesNotExist($derivedImage);
+    unlink($derivedImage);
 
-        sleep(1);
+    $this->assertFileDoesNotExist($derivedImage);
 
-        $this->artisan('media-library:regenerate');
+    sleep(1);
 
-        $this->assertFileExists($derivedImage);
-        $this->assertGreaterThan($createdAt, filemtime($derivedImage));
+    $this->artisan('media-library:regenerate');
+
+    $this->assertFileExists($derivedImage);
+    $this->assertGreaterThan($createdAt, filemtime($derivedImage));
+});
+
+it('can regenerate only missing files', function () {
+    $mediaExists = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection('images');
+
+    $mediaMissing = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.png'))
+        ->toMediaCollection('images');
+
+    $derivedImageExists = $this->getMediaDirectory("{$mediaExists->id}/conversions/test-thumb.jpg");
+
+    $derivedMissingImage = $this->getMediaDirectory("{$mediaMissing->id}/conversions/test-thumb.jpg");
+
+    $existsCreatedAt = filemtime($derivedImageExists);
+
+    $missingCreatedAt = filemtime($derivedMissingImage);
+
+    unlink($derivedMissingImage);
+
+    $this->assertFileDoesNotExist($derivedMissingImage);
+
+    sleep(1);
+
+    $this->artisan('media-library:regenerate', [
+        '--only-missing' => true,
+    ]);
+
+    $this->assertFileExists($derivedMissingImage);
+
+    $this->assertSame($existsCreatedAt, filemtime($derivedImageExists));
+
+    $this->assertGreaterThan($missingCreatedAt, filemtime($derivedMissingImage));
+});
+
+it('can regenerate missing files queued', function () {
+    $mediaExists = $this
+        ->testModelWithConversionQueued
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection('images');
+
+    $mediaMissing = $this
+        ->testModelWithConversionQueued
+        ->addMedia($this->getTestFilesDirectory('test.png'))
+        ->toMediaCollection('images');
+
+    $derivedImageExists = $this->getMediaDirectory("{$mediaExists->id}/conversions/test-thumb.jpg");
+
+    $derivedMissingImage = $this->getMediaDirectory("{$mediaMissing->id}/conversions/test-thumb.jpg");
+
+    $existsCreatedAt = filemtime($derivedImageExists);
+
+    $missingCreatedAt = filemtime($derivedMissingImage);
+
+    unlink($derivedMissingImage);
+
+    $this->assertFileDoesNotExist($derivedMissingImage);
+
+    sleep(1);
+
+    $this->artisan('media-library:regenerate', [
+        '--only-missing' => true,
+    ]);
+
+    $this->assertFileExists($derivedMissingImage);
+
+    $this->assertSame($existsCreatedAt, filemtime($derivedImageExists));
+
+    $this->assertGreaterThan($missingCreatedAt, filemtime($derivedMissingImage));
+});
+
+it('can regenerate all files of named conversions', function () {
+    $media = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection('images');
+
+    $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+    $derivedMissingImage = $this->getMediaDirectory("{$media->id}/conversions/test-keep_original_format.jpg");
+
+    unlink($derivedImage);
+    unlink($derivedMissingImage);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileDoesNotExist($derivedMissingImage);
+
+    $this->artisan('media-library:regenerate', [
+        '--only' => 'thumb',
+    ]);
+
+    $this->assertFileExists($derivedImage);
+    $this->assertFileDoesNotExist($derivedMissingImage);
+});
+
+it('can regenerate only missing files of named conversions', function () {
+    $mediaExists = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection('images');
+
+    $mediaMissing = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.png'))
+        ->toMediaCollection('images');
+
+    $derivedImageExists = $this->getMediaDirectory("{$mediaExists->id}/conversions/test-thumb.jpg");
+    $derivedMissingImage = $this->getMediaDirectory("{$mediaMissing->id}/conversions/test-thumb.jpg");
+    $derivedMissingImageOriginal = $this->getMediaDirectory("{$mediaMissing->id}/conversions/test-keep_original_format.png");
+
+    $existsCreatedAt = filemtime($derivedImageExists);
+    $missingCreatedAt = filemtime($derivedMissingImage);
+
+    unlink($derivedMissingImage);
+    unlink($derivedMissingImageOriginal);
+
+    $this->assertFileDoesNotExist($derivedMissingImage);
+    $this->assertFileDoesNotExist($derivedMissingImageOriginal);
+
+    sleep(1);
+
+    $this->artisan('media-library:regenerate', [
+        '--only-missing' => true,
+        '--only' => 'thumb',
+    ]);
+
+    $this->assertFileExists($derivedMissingImage);
+    $this->assertFileDoesNotExist($derivedMissingImageOriginal);
+    $this->assertSame($existsCreatedAt, filemtime($derivedImageExists));
+    $this->assertGreaterThan($missingCreatedAt, filemtime($derivedMissingImage));
+});
+
+it('can regenerate files by media ids', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+
+    $media2 = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection('images');
+
+    $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+    $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+
+    unlink($derivedImage);
+    unlink($derivedImage2);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileDoesNotExist($derivedImage2);
+
+    $this->artisan('media-library:regenerate', ['--ids' => [2]]);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileExists($derivedImage2);
+});
+
+it('can regenerate files by comma separated media ids', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+
+    $media2 = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection('images');
+
+    $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+    $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+
+    unlink($derivedImage);
+    unlink($derivedImage2);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileDoesNotExist($derivedImage2);
+
+    $this->artisan('media-library:regenerate', ['--ids' => ['1,2']]);
+
+    $this->assertFileExists($derivedImage);
+    $this->assertFileExists($derivedImage2);
+});
+
+it('can regenerate files even if there are files missing', function () {
+    $media = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection('images');
+
+    unlink($this->getMediaDirectory($media->id.'/test.jpg'));
+
+    $this->artisan('media-library:regenerate')->assertExitCode(0);
+});
+
+it('can regenerate responsive images', function () {
+    $media = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->withResponsiveImages()
+        ->toMediaCollection();
+
+    $responsiveImages = glob($this->getMediaDirectory($media->id.'/responsive-images/*'));
+
+    array_map('unlink', $responsiveImages);
+
+    $this->artisan('media-library:regenerate', ['--with-responsive-images' => true])->assertExitCode(0);
+
+    foreach ($responsiveImages as $image) {
+        $this->assertFileExists($image);
     }
+});
+
+it('can regenerate files by starting from id', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->preservingOriginal()
+        ->toMediaCollection('images');
 
-    /** @test */
-    public function it_can_regenerate_only_missing_files()
-    {
-        $mediaExists = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection('images');
+    $media2 = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection('images');
 
-        $mediaMissing = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.png'))
-            ->toMediaCollection('images');
-
-        $derivedImageExists = $this->getMediaDirectory("{$mediaExists->id}/conversions/test-thumb.jpg");
-
-        $derivedMissingImage = $this->getMediaDirectory("{$mediaMissing->id}/conversions/test-thumb.jpg");
-
-        $existsCreatedAt = filemtime($derivedImageExists);
-
-        $missingCreatedAt = filemtime($derivedMissingImage);
-
-        unlink($derivedMissingImage);
-
-        $this->assertFileDoesNotExist($derivedMissingImage);
-
-        sleep(1);
-
-        $this->artisan('media-library:regenerate', [
-            '--only-missing' => true,
-        ]);
-
-        $this->assertFileExists($derivedMissingImage);
-
-        $this->assertSame($existsCreatedAt, filemtime($derivedImageExists));
-
-        $this->assertGreaterThan($missingCreatedAt, filemtime($derivedMissingImage));
-    }
-
-    /** @test */
-    public function it_can_regenerate_missing_files_queued()
-    {
-        $mediaExists = $this
-            ->testModelWithConversionQueued
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection('images');
-
-        $mediaMissing = $this
-            ->testModelWithConversionQueued
-            ->addMedia($this->getTestFilesDirectory('test.png'))
-            ->toMediaCollection('images');
-
-        $derivedImageExists = $this->getMediaDirectory("{$mediaExists->id}/conversions/test-thumb.jpg");
-
-        $derivedMissingImage = $this->getMediaDirectory("{$mediaMissing->id}/conversions/test-thumb.jpg");
-
-        $existsCreatedAt = filemtime($derivedImageExists);
-
-        $missingCreatedAt = filemtime($derivedMissingImage);
-
-        unlink($derivedMissingImage);
-
-        $this->assertFileDoesNotExist($derivedMissingImage);
-
-        sleep(1);
-
-        $this->artisan('media-library:regenerate', [
-            '--only-missing' => true,
-        ]);
-
-        $this->assertFileExists($derivedMissingImage);
-
-        $this->assertSame($existsCreatedAt, filemtime($derivedImageExists));
-
-        $this->assertGreaterThan($missingCreatedAt, filemtime($derivedMissingImage));
-    }
-
-    /** @test */
-    public function it_can_regenerate_all_files_of_named_conversions()
-    {
-        $media = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection('images');
-
-        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
-        $derivedMissingImage = $this->getMediaDirectory("{$media->id}/conversions/test-keep_original_format.jpg");
-
-        unlink($derivedImage);
-        unlink($derivedMissingImage);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileDoesNotExist($derivedMissingImage);
-
-        $this->artisan('media-library:regenerate', [
-            '--only' => 'thumb',
-        ]);
-
-        $this->assertFileExists($derivedImage);
-        $this->assertFileDoesNotExist($derivedMissingImage);
-    }
-
-    /** @test */
-    public function it_can_regenerate_only_missing_files_of_named_conversions()
-    {
-        $mediaExists = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection('images');
-
-        $mediaMissing = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.png'))
-            ->toMediaCollection('images');
-
-        $derivedImageExists = $this->getMediaDirectory("{$mediaExists->id}/conversions/test-thumb.jpg");
-        $derivedMissingImage = $this->getMediaDirectory("{$mediaMissing->id}/conversions/test-thumb.jpg");
-        $derivedMissingImageOriginal = $this->getMediaDirectory("{$mediaMissing->id}/conversions/test-keep_original_format.png");
-
-        $existsCreatedAt = filemtime($derivedImageExists);
-        $missingCreatedAt = filemtime($derivedMissingImage);
-
-        unlink($derivedMissingImage);
-        unlink($derivedMissingImageOriginal);
-
-        $this->assertFileDoesNotExist($derivedMissingImage);
-        $this->assertFileDoesNotExist($derivedMissingImageOriginal);
-
-        sleep(1);
-
-        $this->artisan('media-library:regenerate', [
-            '--only-missing' => true,
-            '--only' => 'thumb',
-        ]);
-
-        $this->assertFileExists($derivedMissingImage);
-        $this->assertFileDoesNotExist($derivedMissingImageOriginal);
-        $this->assertSame($existsCreatedAt, filemtime($derivedImageExists));
-        $this->assertGreaterThan($missingCreatedAt, filemtime($derivedMissingImage));
-    }
-
-    /** @test */
-    public function it_can_regenerate_files_by_media_ids()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-
-        $media2 = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection('images');
-
-        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
-        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
-
-        unlink($derivedImage);
-        unlink($derivedImage2);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileDoesNotExist($derivedImage2);
-
-        $this->artisan('media-library:regenerate', ['--ids' => [2]]);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileExists($derivedImage2);
-    }
-
-    /** @test */
-    public function it_can_regenerate_files_by_comma_separated_media_ids()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-
-        $media2 = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection('images');
-
-        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
-        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
-
-        unlink($derivedImage);
-        unlink($derivedImage2);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileDoesNotExist($derivedImage2);
-
-        $this->artisan('media-library:regenerate', ['--ids' => ['1,2']]);
-
-        $this->assertFileExists($derivedImage);
-        $this->assertFileExists($derivedImage2);
-    }
-
-    /** @test */
-    public function it_can_regenerate_files_even_if_there_are_files_missing()
-    {
-        $media = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection('images');
-
-        unlink($this->getMediaDirectory($media->id.'/test.jpg'));
-
-        $this->artisan('media-library:regenerate')->assertExitCode(0);
-    }
-
-    /** @test */
-    public function it_can_regenerate_responsive_images()
-    {
-        $media = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->withResponsiveImages()
-            ->toMediaCollection();
-
-        $responsiveImages = glob($this->getMediaDirectory($media->id.'/responsive-images/*'));
-
-        array_map('unlink', $responsiveImages);
-
-        $this->artisan('media-library:regenerate', ['--with-responsive-images' => true])->assertExitCode(0);
-
-        foreach ($responsiveImages as $image) {
-            $this->assertFileExists($image);
-        }
-    }
-
-    /** @test */
-    public function it_can_regenerate_files_by_starting_from_id()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-
-        $media2 = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection('images');
-
-        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
-        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
-
-        unlink($derivedImage);
-        unlink($derivedImage2);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileDoesNotExist($derivedImage2);
-
-        $this->artisan('media-library:regenerate', ['--starting-from-id' => $media2->getKey()]);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileExists($derivedImage2);
-    }
-
-    /** @test */
-    public function it_can_regenerate_files_starting_after_the_provided_id()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-
-        $media2 = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection('images');
-
-        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
-        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
-
-        unlink($derivedImage);
-        unlink($derivedImage2);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileDoesNotExist($derivedImage2);
-
-        $this->artisan('media-library:regenerate', [
-            '--starting-from-id' => $media->getKey(),
-            '--exclude-starting-id' => true,
-        ]);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileExists($derivedImage2);
-    }
-
-    /** @test */
-    public function it_can_regenerate_files_starting_after_the_provided_id_with_shortcut()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-
-        $media2 = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection('images');
-
-        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
-        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
-
-        unlink($derivedImage);
-        unlink($derivedImage2);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileDoesNotExist($derivedImage2);
-
-        $this->artisan('media-library:regenerate', [
-            '--starting-from-id' => $media->getKey(),
-            '-X' => true,
-        ]);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileExists($derivedImage2);
-    }
-
-    /** @test */
-    public function it_can_regenerate_files_starting_from_id_with_model_type()
-    {
-        $media = $this->testModelWithConversionsOnOtherDisk
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-
-        $media2 = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-
-        $media3 = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.jpg'))
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-
-        $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
-        $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
-        $derivedImage3 = $this->getMediaDirectory("{$media3->id}/conversions/test-thumb.jpg");
-
-        unlink($derivedImage);
-        unlink($derivedImage2);
-        unlink($derivedImage3);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileDoesNotExist($derivedImage2);
-        $this->assertFileDoesNotExist($derivedImage3);
-
-        $this->artisan('media-library:regenerate', [
-            '--starting-from-id' => $media->getKey(),
-            'modelType' => TestModelWithConversion::class,
-        ]);
-
-        $this->assertFileDoesNotExist($derivedImage);
-        $this->assertFileExists($derivedImage2);
-        $this->assertFileExists($derivedImage3);
-    }
-}
+    $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+    $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+
+    unlink($derivedImage);
+    unlink($derivedImage2);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileDoesNotExist($derivedImage2);
+
+    $this->artisan('media-library:regenerate', ['--starting-from-id' => $media2->getKey()]);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileExists($derivedImage2);
+});
+
+it('can regenerate files starting after the provided id', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+
+    $media2 = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection('images');
+
+    $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+    $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+
+    unlink($derivedImage);
+    unlink($derivedImage2);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileDoesNotExist($derivedImage2);
+
+    $this->artisan('media-library:regenerate', [
+        '--starting-from-id' => $media->getKey(),
+        '--exclude-starting-id' => true,
+    ]);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileExists($derivedImage2);
+});
+
+it('can regenerate files starting after the provided id with shortcut', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+
+    $media2 = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection('images');
+
+    $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+    $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+
+    unlink($derivedImage);
+    unlink($derivedImage2);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileDoesNotExist($derivedImage2);
+
+    $this->artisan('media-library:regenerate', [
+        '--starting-from-id' => $media->getKey(),
+        '-X' => true,
+    ]);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileExists($derivedImage2);
+});
+
+it('can regenerate files starting from id with model type', function () {
+    $media = $this->testModelWithConversionsOnOtherDisk
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+
+    $media2 = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+
+    $media3 = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+
+    $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+    $derivedImage2 = $this->getMediaDirectory("{$media2->id}/conversions/test-thumb.jpg");
+    $derivedImage3 = $this->getMediaDirectory("{$media3->id}/conversions/test-thumb.jpg");
+
+    unlink($derivedImage);
+    unlink($derivedImage2);
+    unlink($derivedImage3);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileDoesNotExist($derivedImage2);
+    $this->assertFileDoesNotExist($derivedImage3);
+
+    $this->artisan('media-library:regenerate', [
+        '--starting-from-id' => $media->getKey(),
+        'modelType' => TestModelWithConversion::class,
+    ]);
+
+    $this->assertFileDoesNotExist($derivedImage);
+    $this->assertFileExists($derivedImage2);
+    $this->assertFileExists($derivedImage3);
+});

--- a/tests/Conversions/ConversionCollectionTest.php
+++ b/tests/Conversions/ConversionCollectionTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 beforeEach(function () {
     $media = $this->testModelWithConversion

--- a/tests/Conversions/ConversionCollectionTest.php
+++ b/tests/Conversions/ConversionCollectionTest.php
@@ -37,7 +37,7 @@ it('will prepend the manipulation saved on the model and the wildmark manipulati
 
     $conversion = $conversionCollection->getConversions()[0];
 
-    $this->assertEquals('thumb', $conversion->getName());
+    expect($conversion->getName())->toEqual('thumb');
 
     $manipulationSequence = $conversion
         ->getManipulations()
@@ -62,7 +62,7 @@ it('will prepend the manipulation saved on the model', function () {
 
     $conversion = $conversionCollection->getConversions()[0];
 
-    $this->assertEquals('thumb', $conversion->getName());
+    expect($conversion->getName())->toEqual('thumb');
 
     $manipulationSequence = $conversion
         ->getManipulations()
@@ -98,5 +98,5 @@ it('will apply the manipulation on the equally named conversion of every model',
         $manipulations[] = $manipulationSequence;
     }
 
-    $this->assertEquals($manipulations[0], $manipulations[1]);
+    expect($manipulations[1])->toEqual($manipulations[0]);
 });

--- a/tests/Conversions/ConversionCollectionTest.php
+++ b/tests/Conversions/ConversionCollectionTest.php
@@ -4,7 +4,6 @@ use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $media = $this->testModelWithConversion

--- a/tests/Conversions/ConversionFileExtensionTest.php
+++ b/tests/Conversions/ConversionFileExtensionTest.php
@@ -34,5 +34,5 @@ function assertExtensionEquals(string $expectedExtension, string $file)
 {
     $actualExtension = pathinfo($file, PATHINFO_EXTENSION);
 
-    test()->assertEquals($expectedExtension, $actualExtension);
+    expect($actualExtension)->toEqual($expectedExtension);
 }

--- a/tests/Conversions/ConversionFileExtensionTest.php
+++ b/tests/Conversions/ConversionFileExtensionTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('defaults to jpg when the original file is an image', function () {
     $media = $this->testModelWithConversion->addMedia($this->getTestPng())->toMediaCollection();

--- a/tests/Conversions/ConversionFileExtensionTest.php
+++ b/tests/Conversions/ConversionFileExtensionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 it('defaults to jpg when the original file is an image', function () {

--- a/tests/Conversions/ConversionFileExtensionTest.php
+++ b/tests/Conversions/ConversionFileExtensionTest.php
@@ -1,48 +1,38 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class ConversionFileExtensionTest extends TestCase
+uses(TestCase::class);
+
+it('defaults to jpg when the original file is an image', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getTestPng())->toMediaCollection();
+
+    assertExtensionEquals('jpg', $media->getUrl('thumb'));
+});
+
+it('can keep the original image format if the original file is an image', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getTestPng())->toMediaCollection();
+
+    assertExtensionEquals('png', $media->getUrl('keep_original_format'));
+});
+
+it('can keep the original image format if the original file is an image with uppercase extension', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getUppercaseExtensionTestPng())->toMediaCollection();
+
+    assertExtensionEquals('PNG', $media->getUrl('keep_original_format'));
+});
+
+it('always defaults to jpg when the original file is not an image', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getTestMp4())->toMediaCollection();
+
+    assertExtensionEquals('jpg', $media->getUrl('thumb'));
+    assertExtensionEquals('jpg', $media->getUrl('keep_original_format'));
+});
+
+// Helpers
+function assertExtensionEquals(string $expectedExtension, string $file)
 {
-    /** @test */
-    public function it_defaults_to_jpg_when_the_original_file_is_an_image()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getTestPng())->toMediaCollection();
+    $actualExtension = pathinfo($file, PATHINFO_EXTENSION);
 
-        $this->assertExtensionEquals('jpg', $media->getUrl('thumb'));
-    }
-
-    /** @test */
-    public function it_can_keep_the_original_image_format_if_the_original_file_is_an_image()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getTestPng())->toMediaCollection();
-
-        $this->assertExtensionEquals('png', $media->getUrl('keep_original_format'));
-    }
-
-    /** @test */
-    public function it_can_keep_the_original_image_format_if_the_original_file_is_an_image_with_uppercase_extension()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getUppercaseExtensionTestPng())->toMediaCollection();
-
-        $this->assertExtensionEquals('PNG', $media->getUrl('keep_original_format'));
-    }
-
-    /** @test */
-    public function it_always_defaults_to_jpg_when_the_original_file_is_not_an_image()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getTestMp4())->toMediaCollection();
-
-        $this->assertExtensionEquals('jpg', $media->getUrl('thumb'));
-        $this->assertExtensionEquals('jpg', $media->getUrl('keep_original_format'));
-    }
-
-    private function assertExtensionEquals(string $expectedExtension, string $file)
-    {
-        $actualExtension = pathinfo($file, PATHINFO_EXTENSION);
-
-        $this->assertEquals($expectedExtension, $actualExtension);
-    }
+    test()->assertEquals($expectedExtension, $actualExtension);
 }

--- a/tests/Conversions/ConversionFileNamerTest.php
+++ b/tests/Conversions/ConversionFileNamerTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
-
 
 it('can use a custom file namer', function () {
     config()->set("media-library.file_namer", TestFileNamer::class);

--- a/tests/Conversions/ConversionFileNamerTest.php
+++ b/tests/Conversions/ConversionFileNamerTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
 
-uses(TestCase::class);
 
 it('can use a custom file namer', function () {
     config()->set("media-library.file_namer", TestFileNamer::class);

--- a/tests/Conversions/ConversionFileNamerTest.php
+++ b/tests/Conversions/ConversionFileNamerTest.php
@@ -3,6 +3,8 @@
 use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
 
 it('can use a custom file namer', function () {
+    $fileName = "prefix_test_suffix";
+
     config()->set("media-library.file_namer", TestFileNamer::class);
 
     $this
@@ -12,8 +14,8 @@ it('can use a custom file namer', function () {
 
     $path = $this->testModelWithConversion->refresh()->getFirstMediaPath("default", "thumb");
 
-    expect($path)->toEndWith("{$this->fileName}---thumb.jpg");
+    expect($path)->toEndWith("{$fileName}---thumb.jpg");
     expect($path)->toBeFile();
 
-    expect($this->testModelWithConversion->getFirstMediaUrl("default", "thumb"))->toEqual("/media/1/conversions/{$this->fileName}---thumb.jpg");
+    expect($this->testModelWithConversion->getFirstMediaUrl("default", "thumb"))->toEqual("/media/1/conversions/{$fileName}---thumb.jpg");
 });

--- a/tests/Conversions/ConversionFileNamerTest.php
+++ b/tests/Conversions/ConversionFileNamerTest.php
@@ -1,29 +1,22 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
 
-class ConversionFileNamerTest extends TestCase
-{
-    public string $fileName = "prefix_test_suffix";
+uses(TestCase::class);
 
-    /** @test */
-    public function it_can_use_a_custom_file_namer()
-    {
-        config()->set("media-library.file_namer", TestFileNamer::class);
+it('can use a custom file namer', function () {
+    config()->set("media-library.file_namer", TestFileNamer::class);
 
-        $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
+    $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
 
-        $path = $this->testModelWithConversion->refresh()->getFirstMediaPath("default", "thumb");
+    $path = $this->testModelWithConversion->refresh()->getFirstMediaPath("default", "thumb");
 
-        $this->assertStringEndsWith("{$this->fileName}---thumb.jpg", $path);
-        $this->assertFileExists($path);
+    $this->assertStringEndsWith("{$this->fileName}---thumb.jpg", $path);
+    $this->assertFileExists($path);
 
-        $this->assertEquals("/media/1/conversions/{$this->fileName}---thumb.jpg", $this->testModelWithConversion->getFirstMediaUrl("default", "thumb"));
-    }
-}
+    $this->assertEquals("/media/1/conversions/{$this->fileName}---thumb.jpg", $this->testModelWithConversion->getFirstMediaUrl("default", "thumb"));
+});

--- a/tests/Conversions/ConversionFileNamerTest.php
+++ b/tests/Conversions/ConversionFileNamerTest.php
@@ -15,8 +15,8 @@ it('can use a custom file namer', function () {
 
     $path = $this->testModelWithConversion->refresh()->getFirstMediaPath("default", "thumb");
 
-    $this->assertStringEndsWith("{$this->fileName}---thumb.jpg", $path);
-    $this->assertFileExists($path);
+    expect($path)->toEndWith("{$this->fileName}---thumb.jpg");
+    expect($path)->toBeFile();
 
-    $this->assertEquals("/media/1/conversions/{$this->fileName}---thumb.jpg", $this->testModelWithConversion->getFirstMediaUrl("default", "thumb"));
+    expect($this->testModelWithConversion->getFirstMediaUrl("default", "thumb"))->toEqual("/media/1/conversions/{$this->fileName}---thumb.jpg");
 });

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -5,6 +5,7 @@ use Spatie\MediaLibrary\Conversions\Conversion;
 
 beforeEach(function () {
     $this->conversion = new Conversion($this->conversionName);
+    $this->conversionName = 'test';
 });
 
 it('can get its name', function () {

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -11,96 +11,96 @@ beforeEach(function () {
 });
 
 it('can get its name', function () {
-    $this->assertEquals($this->conversionName, $this->conversion->getName());
+    expect($this->conversion->getName())->toEqual($this->conversionName);
 });
 
 it('will add a format parameter if it was not given', function () {
     $this->conversion->width(10);
 
-    $this->assertEquals('jpg', $this->conversion->getManipulations()->getManipulationArgument('format'));
+    expect($this->conversion->getManipulations()->getManipulationArgument('format'))->toEqual('jpg');
 });
 
 it('will use the format parameter if it was given', function () {
     $this->conversion->format('png');
 
-    $this->assertEquals('png', $this->conversion->getManipulations()->getManipulationArgument('format'));
+    expect($this->conversion->getManipulations()->getManipulationArgument('format'))->toEqual('png');
 });
 
 it('will be performed on the given collection names', function () {
     $this->conversion->performOnCollections('images', 'downloads');
-    $this->assertTrue($this->conversion->shouldBePerformedOn('images'));
-    $this->assertTrue($this->conversion->shouldBePerformedOn('downloads'));
-    $this->assertFalse($this->conversion->shouldBePerformedOn('unknown'));
+    expect($this->conversion->shouldBePerformedOn('images'))->toBeTrue();
+    expect($this->conversion->shouldBePerformedOn('downloads'))->toBeTrue();
+    expect($this->conversion->shouldBePerformedOn('unknown'))->toBeFalse();
 });
 
 it('will be performed on all collections if not collection names are set', function () {
     $this->conversion->performOnCollections('*');
-    $this->assertTrue($this->conversion->shouldBePerformedOn('images'));
-    $this->assertTrue($this->conversion->shouldBePerformedOn('downloads'));
-    $this->assertTrue($this->conversion->shouldBePerformedOn('unknown'));
+    expect($this->conversion->shouldBePerformedOn('images'))->toBeTrue();
+    expect($this->conversion->shouldBePerformedOn('downloads'))->toBeTrue();
+    expect($this->conversion->shouldBePerformedOn('unknown'))->toBeTrue();
 });
 
 it('will be performed on all collections if not collection name is a star', function () {
-    $this->assertTrue($this->conversion->shouldBePerformedOn('images'));
-    $this->assertTrue($this->conversion->shouldBePerformedOn('downloads'));
-    $this->assertTrue($this->conversion->shouldBePerformedOn('unknown'));
+    expect($this->conversion->shouldBePerformedOn('images'))->toBeTrue();
+    expect($this->conversion->shouldBePerformedOn('downloads'))->toBeTrue();
+    expect($this->conversion->shouldBePerformedOn('unknown'))->toBeTrue();
 });
 
 it('will be queued without config', function () {
     config()->set('media-library.queue_conversions_by_default', null);
-    $this->assertTrue($this->conversion->shouldBeQueued());
+    expect($this->conversion->shouldBeQueued())->toBeTrue();
 });
 
 it('will be queued by default', function () {
     config()->set('media-library.queue_conversions_by_default', true);
-    $this->assertTrue($this->conversion->shouldBeQueued());
+    expect($this->conversion->shouldBeQueued())->toBeTrue();
 });
 
 it('will be non queued by default', function () {
     config()->set('media-library.queue_conversions_by_default', false);
-    $this->assertTrue($this->conversion->shouldBeQueued());
+    expect($this->conversion->shouldBeQueued())->toBeTrue();
 });
 
 it('can be set to queued', function () {
     config()->set('media-library.queue_conversions_by_default', false);
-    $this->assertTrue($this->conversion->queued()->shouldBeQueued());
+    expect($this->conversion->queued()->shouldBeQueued())->toBeTrue();
 });
 
 it('can be set to non queued', function () {
     config()->set('media-library.queue_conversions_by_default', true);
-    $this->assertFalse($this->conversion->nonQueued()->shouldBeQueued());
+    expect($this->conversion->nonQueued()->shouldBeQueued())->toBeFalse();
 });
 
 it('can determine the extension of the result', function () {
     $this->conversion->width(50);
 
-    $this->assertEquals('jpg', $this->conversion->getResultExtension());
+    expect($this->conversion->getResultExtension())->toEqual('jpg');
 
     $this->conversion->width(100)->format('png');
 
-    $this->assertEquals('png', $this->conversion->getResultExtension());
+    expect($this->conversion->getResultExtension())->toEqual('png');
 });
 
 it('can remove a previously set manipulation', function () {
-    $this->assertEquals('jpg', $this->conversion->getManipulations()->getManipulationArgument('format'));
+    expect($this->conversion->getManipulations()->getManipulationArgument('format'))->toEqual('jpg');
 
     $this->conversion->removeManipulation('format');
 
-    $this->assertNull($this->conversion->getManipulations()->getManipulationArgument('format'));
+    expect($this->conversion->getManipulations()->getManipulationArgument('format'))->toBeNull();
 });
 
 it('can remove all previously set manipulations', function () {
-    $this->assertFalse($this->conversion->getManipulations()->isEmpty());
+    expect($this->conversion->getManipulations()->isEmpty())->toBeFalse();
 
     $this->conversion->withoutManipulations();
 
-    $this->assertTrue($this->conversion->getManipulations()->isEmpty());
+    expect($this->conversion->getManipulations()->isEmpty())->toBeTrue();
 });
 
 it('will use the extract duration parameter if it was given', function () {
     $this->conversion->extractVideoFrameAtSecond(10);
 
-    $this->assertEquals(10, $this->conversion->getExtractVideoFrameAtSecond());
+    expect($this->conversion->getExtractVideoFrameAtSecond())->toEqual(10);
 });
 
 test('manipulations can be set using an instance of manipulations', function () {
@@ -163,5 +163,5 @@ it('can remove the optimization', function () {
 it('will use the pdf page number parameter if it was given', function () {
     $this->conversion->pdfPageNumber(10);
 
-    $this->assertEquals(10, $this->conversion->getPdfPageNumber());
+    expect($this->conversion->getPdfPageNumber())->toEqual(10);
 });

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -2,8 +2,6 @@
 
 use Spatie\Image\Manipulations;
 use Spatie\MediaLibrary\Conversions\Conversion;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 beforeEach(function () {
     $this->conversion = new Conversion($this->conversionName);

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -4,7 +4,6 @@ use Spatie\Image\Manipulations;
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $this->conversion = new Conversion($this->conversionName);

--- a/tests/Conversions/EventTest.php
+++ b/tests/Conversions/EventTest.php
@@ -4,8 +4,6 @@ use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\Conversions\Events\ConversionHasBeenCompleted;
 use Spatie\MediaLibrary\Conversions\Events\ConversionWillStart;
 use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenCleared;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 beforeEach(function () {
     parent::setup();

--- a/tests/Conversions/EventTest.php
+++ b/tests/Conversions/EventTest.php
@@ -6,7 +6,6 @@ use Spatie\MediaLibrary\Conversions\Events\ConversionWillStart;
 use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenCleared;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     parent::setup();

--- a/tests/Conversions/EventTest.php
+++ b/tests/Conversions/EventTest.php
@@ -1,48 +1,38 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions;
-
 use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\Conversions\Events\ConversionHasBeenCompleted;
 use Spatie\MediaLibrary\Conversions\Events\ConversionWillStart;
 use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenCleared;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class EventTest extends TestCase
-{
-    public function setUp(): void
-    {
-        parent::setup();
+uses(TestCase::class);
 
-        Event::fake();
-    }
+beforeEach(function () {
+    parent::setup();
 
-    /** @test */
-    public function it_will_fire_the_conversion_will_start_event()
-    {
-        $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection('images');
+    Event::fake();
+});
 
-        Event::assertDispatched(ConversionWillStart::class);
-    }
+it('will fire the conversion will start event', function () {
+    $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    /** @test */
-    public function it_will_fire_the_conversion_complete_event()
-    {
-        $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection('images');
+    Event::assertDispatched(ConversionWillStart::class);
+});
 
-        Event::assertDispatched(ConversionHasBeenCompleted::class);
-    }
+it('will fire the conversion complete event', function () {
+    $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    /** @test */
-    public function it_will_fire_the_collection_cleared_event()
-    {
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('images');
+    Event::assertDispatched(ConversionHasBeenCompleted::class);
+});
 
-        $this->testModel->clearMediaCollection('images');
+it('will fire the collection cleared event', function () {
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('images');
 
-        Event::assertDispatched(CollectionHasBeenCleared::class);
-    }
-}
+    $this->testModel->clearMediaCollection('images');
+
+    Event::assertDispatched(CollectionHasBeenCleared::class);
+});

--- a/tests/Conversions/FileManipulatorTest.php
+++ b/tests/Conversions/FileManipulatorTest.php
@@ -2,8 +2,6 @@
 
 use Spatie\MediaLibrary\Conversions\Actions\PerformManipulationsAction;
 use Spatie\MediaLibrary\Conversions\Conversion;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 beforeEach(function () {
     $this->conversion = new Conversion($this->conversionName);

--- a/tests/Conversions/FileManipulatorTest.php
+++ b/tests/Conversions/FileManipulatorTest.php
@@ -4,7 +4,6 @@ use Spatie\MediaLibrary\Conversions\Actions\PerformManipulationsAction;
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $this->conversion = new Conversion($this->conversionName);

--- a/tests/Conversions/FileManipulatorTest.php
+++ b/tests/Conversions/FileManipulatorTest.php
@@ -1,36 +1,24 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions;
-
 use Spatie\MediaLibrary\Conversions\Actions\PerformManipulationsAction;
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class FileManipulatorTest extends TestCase
-{
-    protected string $conversionName = 'test';
+uses(TestCase::class);
 
-    protected Conversion $conversion;
+beforeEach(function () {
+    $this->conversion = new Conversion($this->conversionName);
+});
 
-    public function setUp(): void
-    {
-        parent::setUp();
+it('does not perform manipulations if not necessary', function () {
+    $imageFile = $this->getTestJpg();
+    $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $this->conversion = new Conversion($this->conversionName);
-    }
+    $conversionTempFile = (new PerformManipulationsAction())->execute(
+        $media,
+        $this->conversion->withoutManipulations(),
+        $imageFile
+    );
 
-    /** @test */
-    public function it_does_not_perform_manipulations_if_not_necessary()
-    {
-        $imageFile = $this->getTestJpg();
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaCollection();
-
-        $conversionTempFile = (new PerformManipulationsAction())->execute(
-            $media,
-            $this->conversion->withoutManipulations(),
-            $imageFile
-        );
-
-        $this->assertEquals($imageFile, $conversionTempFile);
-    }
-}
+    $this->assertEquals($imageFile, $conversionTempFile);
+});

--- a/tests/Conversions/FileManipulatorTest.php
+++ b/tests/Conversions/FileManipulatorTest.php
@@ -20,5 +20,5 @@ it('does not perform manipulations if not necessary', function () {
         $imageFile
     );
 
-    $this->assertEquals($imageFile, $conversionTempFile);
+    expect($conversionTempFile)->toEqual($imageFile);
 });

--- a/tests/Conversions/ImageGenerators/DualTypeCheckingTest.php
+++ b/tests/Conversions/ImageGenerators/DualTypeCheckingTest.php
@@ -1,74 +1,63 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\ImageGenerators;
-
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestImageGenerator;
 
-class DualTypeCheckingTest extends TestCase
-{
-    /** @test */
-    public function it_can_convert_an_image_with_a_valid_extension_and_mime_type()
-    {
-        $generator = new TestImageGenerator();
-        $generator->shouldMatchBothExtensionsAndMimeTypes = true;
+uses(TestCase::class);
 
-        $generator->supportedMimetypes->push('supported-mime-type');
-        $generator->supportedExtensions->push('supported-extension');
+it('can convert an image with a valid extension and mime type', function () {
+    $generator = new TestImageGenerator();
+    $generator->shouldMatchBothExtensionsAndMimeTypes = true;
 
-        $media = new Media();
-        $media->mime_type = 'supported-mime-type';
-        $media->file_name = 'some-file.supported-extension';
+    $generator->supportedMimetypes->push('supported-mime-type');
+    $generator->supportedExtensions->push('supported-extension');
 
-        $this->assertTrue($generator->canConvert($media));
-    }
+    $media = new Media();
+    $media->mime_type = 'supported-mime-type';
+    $media->file_name = 'some-file.supported-extension';
 
-    /** @test */
-    public function it_cannot_convert_an_image_with_an_invalid_extension_and_mime_type()
-    {
-        $generator = new TestImageGenerator();
-        $generator->shouldMatchBothExtensionsAndMimeTypes = true;
+    $this->assertTrue($generator->canConvert($media));
+});
 
-        $generator->supportedMimetypes->push('supported-mime-type');
-        $generator->supportedExtensions->push('supported-extension');
+it('cannot convert an image with an invalid extension and mime type', function () {
+    $generator = new TestImageGenerator();
+    $generator->shouldMatchBothExtensionsAndMimeTypes = true;
 
-        $media = new Media();
-        $media->mime_type = 'invalid-mime-type';
-        $media->file_name = 'some-file.invalid-extension';
+    $generator->supportedMimetypes->push('supported-mime-type');
+    $generator->supportedExtensions->push('supported-extension');
 
-        $this->assertFalse($generator->canConvert($media));
-    }
+    $media = new Media();
+    $media->mime_type = 'invalid-mime-type';
+    $media->file_name = 'some-file.invalid-extension';
 
-    /** @test */
-    public function it_cannot_convert_an_image_with_only_a_valid_mime_type()
-    {
-        $generator = new TestImageGenerator();
-        $generator->shouldMatchBothExtensionsAndMimeTypes = true;
+    $this->assertFalse($generator->canConvert($media));
+});
 
-        $generator->supportedMimetypes->push('supported-mime-type');
-        $generator->supportedExtensions->push('supported-extension');
+it('cannot convert an image with only a valid mime type', function () {
+    $generator = new TestImageGenerator();
+    $generator->shouldMatchBothExtensionsAndMimeTypes = true;
 
-        $media = new Media();
-        $media->mime_type = 'supported-mime-type';
-        $media->file_name = 'some-file.invalid-extension';
+    $generator->supportedMimetypes->push('supported-mime-type');
+    $generator->supportedExtensions->push('supported-extension');
 
-        $this->assertFalse($generator->canConvert($media));
-    }
+    $media = new Media();
+    $media->mime_type = 'supported-mime-type';
+    $media->file_name = 'some-file.invalid-extension';
 
-    /** @test */
-    public function it_cannot_convert_an_image_with_only_a_valid_extension()
-    {
-        $generator = new TestImageGenerator();
-        $generator->shouldMatchBothExtensionsAndMimeTypes = true;
+    $this->assertFalse($generator->canConvert($media));
+});
 
-        $generator->supportedExtensions->push('supported-extension');
-        $generator->supportedMimetypes->push('supported-mime-type');
+it('cannot convert an image with only a valid extension', function () {
+    $generator = new TestImageGenerator();
+    $generator->shouldMatchBothExtensionsAndMimeTypes = true;
 
-        $media = new Media();
-        $media->mime_type = 'invalid-mime-type';
-        $media->file_name = 'some-file.supported-extension';
+    $generator->supportedExtensions->push('supported-extension');
+    $generator->supportedMimetypes->push('supported-mime-type');
 
-        $this->assertFalse($generator->canConvert($media));
-    }
-}
+    $media = new Media();
+    $media->mime_type = 'invalid-mime-type';
+    $media->file_name = 'some-file.supported-extension';
+
+    $this->assertFalse($generator->canConvert($media));
+});

--- a/tests/Conversions/ImageGenerators/DualTypeCheckingTest.php
+++ b/tests/Conversions/ImageGenerators/DualTypeCheckingTest.php
@@ -4,7 +4,6 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestImageGenerator;
 
-uses(TestCase::class);
 
 it('can convert an image with a valid extension and mime type', function () {
     $generator = new TestImageGenerator();

--- a/tests/Conversions/ImageGenerators/DualTypeCheckingTest.php
+++ b/tests/Conversions/ImageGenerators/DualTypeCheckingTest.php
@@ -17,7 +17,7 @@ it('can convert an image with a valid extension and mime type', function () {
     $media->mime_type = 'supported-mime-type';
     $media->file_name = 'some-file.supported-extension';
 
-    $this->assertTrue($generator->canConvert($media));
+    expect($generator->canConvert($media))->toBeTrue();
 });
 
 it('cannot convert an image with an invalid extension and mime type', function () {
@@ -31,7 +31,7 @@ it('cannot convert an image with an invalid extension and mime type', function (
     $media->mime_type = 'invalid-mime-type';
     $media->file_name = 'some-file.invalid-extension';
 
-    $this->assertFalse($generator->canConvert($media));
+    expect($generator->canConvert($media))->toBeFalse();
 });
 
 it('cannot convert an image with only a valid mime type', function () {
@@ -45,7 +45,7 @@ it('cannot convert an image with only a valid mime type', function () {
     $media->mime_type = 'supported-mime-type';
     $media->file_name = 'some-file.invalid-extension';
 
-    $this->assertFalse($generator->canConvert($media));
+    expect($generator->canConvert($media))->toBeFalse();
 });
 
 it('cannot convert an image with only a valid extension', function () {
@@ -59,5 +59,5 @@ it('cannot convert an image with only a valid extension', function () {
     $media->mime_type = 'invalid-mime-type';
     $media->file_name = 'some-file.supported-extension';
 
-    $this->assertFalse($generator->canConvert($media));
+    expect($generator->canConvert($media))->toBeFalse();
 });

--- a/tests/Conversions/ImageGenerators/DualTypeCheckingTest.php
+++ b/tests/Conversions/ImageGenerators/DualTypeCheckingTest.php
@@ -1,9 +1,7 @@
 <?php
 
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestImageGenerator;
-
 
 it('can convert an image with a valid extension and mime type', function () {
     $generator = new TestImageGenerator();

--- a/tests/Conversions/ImageGenerators/ImageTest.php
+++ b/tests/Conversions/ImageGenerators/ImageTest.php
@@ -1,24 +1,19 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\ImageGenerators;
-
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Image;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class ImageTest extends TestCase
-{
-    /** @test */
-    public function it_can_convert_an_image()
-    {
-        $imageGenerator = new Image();
+uses(TestCase::class);
 
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaCollection();
+it('can convert an image', function () {
+    $imageGenerator = new Image();
 
-        $this->assertTrue($imageGenerator->canConvert($media));
+    $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $imageFile = $imageGenerator->convert($media->getPath());
+    $this->assertTrue($imageGenerator->canConvert($media));
 
-        $this->assertEquals('image/jpeg', mime_content_type($imageFile));
-        $this->assertEquals($imageFile, $media->getPath());
-    }
-}
+    $imageFile = $imageGenerator->convert($media->getPath());
+
+    $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+    $this->assertEquals($imageFile, $media->getPath());
+});

--- a/tests/Conversions/ImageGenerators/ImageTest.php
+++ b/tests/Conversions/ImageGenerators/ImageTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Image;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can convert an image', function () {
     $imageGenerator = new Image();

--- a/tests/Conversions/ImageGenerators/ImageTest.php
+++ b/tests/Conversions/ImageGenerators/ImageTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Image;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can convert an image', function () {
     $imageGenerator = new Image();

--- a/tests/Conversions/ImageGenerators/ImageTest.php
+++ b/tests/Conversions/ImageGenerators/ImageTest.php
@@ -10,10 +10,10 @@ it('can convert an image', function () {
 
     $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaCollection();
 
-    $this->assertTrue($imageGenerator->canConvert($media));
+    expect($imageGenerator->canConvert($media))->toBeTrue();
 
     $imageFile = $imageGenerator->convert($media->getPath());
 
-    $this->assertEquals('image/jpeg', mime_content_type($imageFile));
-    $this->assertEquals($imageFile, $media->getPath());
+    expect(mime_content_type($imageFile))->toEqual('image/jpeg');
+    expect($media->getPath())->toEqual($imageFile);
 });

--- a/tests/Conversions/ImageGenerators/PdfTest.php
+++ b/tests/Conversions/ImageGenerators/PdfTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can convert a pdf', function () {
     $imageGenerator = new Pdf();

--- a/tests/Conversions/ImageGenerators/PdfTest.php
+++ b/tests/Conversions/ImageGenerators/PdfTest.php
@@ -1,27 +1,22 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\ImageGenerators;
-
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class PdfTest extends TestCase
-{
-    /** @test */
-    public function it_can_convert_a_pdf()
-    {
-        $imageGenerator = new Pdf();
+uses(TestCase::class);
 
-        if (! $imageGenerator->requirementsAreInstalled()) {
-            $this->markTestSkipped('Skipping pdf test because requirements to run it are not met');
-        }
+it('can convert a pdf', function () {
+    $imageGenerator = new Pdf();
 
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestPdf())->toMediaCollection();
-
-        $this->assertTrue($imageGenerator->canConvert($media));
-
-        $imageFile = $imageGenerator->convert($media->getPath());
-
-        $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+    if (! $imageGenerator->requirementsAreInstalled()) {
+        $this->markTestSkipped('Skipping pdf test because requirements to run it are not met');
     }
-}
+
+    $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestPdf())->toMediaCollection();
+
+    $this->assertTrue($imageGenerator->canConvert($media));
+
+    $imageFile = $imageGenerator->convert($media->getPath());
+
+    $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+});

--- a/tests/Conversions/ImageGenerators/PdfTest.php
+++ b/tests/Conversions/ImageGenerators/PdfTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can convert a pdf', function () {
     $imageGenerator = new Pdf();

--- a/tests/Conversions/ImageGenerators/PdfTest.php
+++ b/tests/Conversions/ImageGenerators/PdfTest.php
@@ -14,9 +14,9 @@ it('can convert a pdf', function () {
 
     $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestPdf())->toMediaCollection();
 
-    $this->assertTrue($imageGenerator->canConvert($media));
+    expect($imageGenerator->canConvert($media))->toBeTrue();
 
     $imageFile = $imageGenerator->convert($media->getPath());
 
-    $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+    expect(mime_content_type($imageFile))->toEqual('image/jpeg');
 });

--- a/tests/Conversions/ImageGenerators/SvgTest.php
+++ b/tests/Conversions/ImageGenerators/SvgTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Svg;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can convert a svg', function () {
     $imageGenerator = new Svg();

--- a/tests/Conversions/ImageGenerators/SvgTest.php
+++ b/tests/Conversions/ImageGenerators/SvgTest.php
@@ -1,27 +1,22 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\ImageGenerators;
-
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Svg;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class SvgTest extends TestCase
-{
-    /** @test */
-    public function it_can_convert_a_svg()
-    {
-        $imageGenerator = new Svg();
+uses(TestCase::class);
 
-        if (! $imageGenerator->requirementsAreInstalled()) {
-            $this->markTestSkipped('Skipping svg test because requirements to run it are not met');
-        }
+it('can convert a svg', function () {
+    $imageGenerator = new Svg();
 
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestSvg())->toMediaCollection();
-
-        $this->assertTrue($imageGenerator->canConvert($media));
-
-        $imageFile = $imageGenerator->convert($media->getPath());
-
-        $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+    if (! $imageGenerator->requirementsAreInstalled()) {
+        $this->markTestSkipped('Skipping svg test because requirements to run it are not met');
     }
-}
+
+    $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestSvg())->toMediaCollection();
+
+    $this->assertTrue($imageGenerator->canConvert($media));
+
+    $imageFile = $imageGenerator->convert($media->getPath());
+
+    $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+});

--- a/tests/Conversions/ImageGenerators/SvgTest.php
+++ b/tests/Conversions/ImageGenerators/SvgTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Svg;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can convert a svg', function () {
     $imageGenerator = new Svg();

--- a/tests/Conversions/ImageGenerators/SvgTest.php
+++ b/tests/Conversions/ImageGenerators/SvgTest.php
@@ -14,9 +14,9 @@ it('can convert a svg', function () {
 
     $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestSvg())->toMediaCollection();
 
-    $this->assertTrue($imageGenerator->canConvert($media));
+    expect($imageGenerator->canConvert($media))->toBeTrue();
 
     $imageFile = $imageGenerator->convert($media->getPath());
 
-    $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+    expect(mime_content_type($imageFile))->toEqual('image/jpeg');
 });

--- a/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
+++ b/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
@@ -4,7 +4,6 @@ use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestImageGeneratorWithConfig;
 
-uses(TestCase::class);
 
 test('image generators can get parameter from the config file', function () {
     config()->set('media-library.image_generators', [

--- a/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
+++ b/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
@@ -1,9 +1,7 @@
 <?php
 
 use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestImageGeneratorWithConfig;
-
 
 test('image generators can get parameter from the config file', function () {
     config()->set('media-library.image_generators', [

--- a/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
+++ b/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
@@ -1,43 +1,36 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\ImageGenerators;
-
 use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestImageGeneratorWithConfig;
 
-class TestImageGeneratorWithConfigTest extends TestCase
-{
-    /** @test */
-    public function image_generators_can_get_parameter_from_the_config_file()
-    {
-        config()->set('media-library.image_generators', [
-            TestImageGeneratorWithConfig::class => ['firstName' => 'firstValue', 'secondName' => 'secondValue'],
-        ]);
+uses(TestCase::class);
 
-        $imageGenerators = ImageGeneratorFactory::getImageGenerators();
+test('image generators can get parameter from the config file', function () {
+    config()->set('media-library.image_generators', [
+        TestImageGeneratorWithConfig::class => ['firstName' => 'firstValue', 'secondName' => 'secondValue'],
+    ]);
 
-        $testGeneratorWithConfig = $imageGenerators->first();
+    $imageGenerators = ImageGeneratorFactory::getImageGenerators();
 
-        $this->assertInstanceOf(TestImageGeneratorWithConfig::class, $testGeneratorWithConfig);
+    $testGeneratorWithConfig = $imageGenerators->first();
 
-        $this->assertEquals('firstValue', $testGeneratorWithConfig->firstName);
-        $this->assertEquals('secondValue', $testGeneratorWithConfig->secondName);
-    }
+    $this->assertInstanceOf(TestImageGeneratorWithConfig::class, $testGeneratorWithConfig);
 
-    /** @test */
-    public function image_generators_will_receive_config_parameters_by_name()
-    {
-        config()->set('media-library.image_generators', [
-            TestImageGeneratorWithConfig::class => ['secondName' => 'secondValue', 'firstName' => 'firstValue', ],
-        ]);
+    $this->assertEquals('firstValue', $testGeneratorWithConfig->firstName);
+    $this->assertEquals('secondValue', $testGeneratorWithConfig->secondName);
+});
 
-        $imageGenerators = ImageGeneratorFactory::getImageGenerators();
+test('image generators will receive config parameters by name', function () {
+    config()->set('media-library.image_generators', [
+        TestImageGeneratorWithConfig::class => ['secondName' => 'secondValue', 'firstName' => 'firstValue', ],
+    ]);
 
-        $testGeneratorWithConfig = $imageGenerators->first();
+    $imageGenerators = ImageGeneratorFactory::getImageGenerators();
 
-        $this->assertInstanceOf(TestImageGeneratorWithConfig::class, $testGeneratorWithConfig);
-        $this->assertEquals('firstValue', $testGeneratorWithConfig->firstName);
-        $this->assertEquals('secondValue', $testGeneratorWithConfig->secondName);
-    }
-}
+    $testGeneratorWithConfig = $imageGenerators->first();
+
+    $this->assertInstanceOf(TestImageGeneratorWithConfig::class, $testGeneratorWithConfig);
+    $this->assertEquals('firstValue', $testGeneratorWithConfig->firstName);
+    $this->assertEquals('secondValue', $testGeneratorWithConfig->secondName);
+});

--- a/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
+++ b/tests/Conversions/ImageGenerators/TestImageGeneratorWithConfigTest.php
@@ -15,10 +15,10 @@ test('image generators can get parameter from the config file', function () {
 
     $testGeneratorWithConfig = $imageGenerators->first();
 
-    $this->assertInstanceOf(TestImageGeneratorWithConfig::class, $testGeneratorWithConfig);
+    expect($testGeneratorWithConfig)->toBeInstanceOf(TestImageGeneratorWithConfig::class);
 
-    $this->assertEquals('firstValue', $testGeneratorWithConfig->firstName);
-    $this->assertEquals('secondValue', $testGeneratorWithConfig->secondName);
+    expect($testGeneratorWithConfig->firstName)->toEqual('firstValue');
+    expect($testGeneratorWithConfig->secondName)->toEqual('secondValue');
 });
 
 test('image generators will receive config parameters by name', function () {
@@ -30,7 +30,7 @@ test('image generators will receive config parameters by name', function () {
 
     $testGeneratorWithConfig = $imageGenerators->first();
 
-    $this->assertInstanceOf(TestImageGeneratorWithConfig::class, $testGeneratorWithConfig);
-    $this->assertEquals('firstValue', $testGeneratorWithConfig->firstName);
-    $this->assertEquals('secondValue', $testGeneratorWithConfig->secondName);
+    expect($testGeneratorWithConfig)->toBeInstanceOf(TestImageGeneratorWithConfig::class);
+    expect($testGeneratorWithConfig->firstName)->toEqual('firstValue');
+    expect($testGeneratorWithConfig->secondName)->toEqual('secondValue');
 });

--- a/tests/Conversions/ImageGenerators/VideoTest.php
+++ b/tests/Conversions/ImageGenerators/VideoTest.php
@@ -1,30 +1,25 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\ImageGenerators;
-
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Video;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class VideoTest extends TestCase
-{
-    /** @test */
-    public function it_can_convert_a_video()
-    {
-        $imageGenerator = new Video();
+uses(TestCase::class);
 
-        if (! $imageGenerator->requirementsAreInstalled()) {
-            $this->markTestSkipped('Skipping video test because requirements to run it are not met');
-        }
+it('can convert a video', function () {
+    $imageGenerator = new Video();
 
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestWebm())->toMediaCollection();
-
-        $this->assertTrue($imageGenerator->canConvert($media));
-
-        $imageFile = $imageGenerator->convert($media->getPath(), new Conversion('test'));
-
-        $this->assertEquals('image/jpeg', mime_content_type($imageFile));
-
-        $this->assertEquals($imageFile, str_replace('.webm', '.jpg', $media->getPath()));
+    if (! $imageGenerator->requirementsAreInstalled()) {
+        $this->markTestSkipped('Skipping video test because requirements to run it are not met');
     }
-}
+
+    $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestWebm())->toMediaCollection();
+
+    $this->assertTrue($imageGenerator->canConvert($media));
+
+    $imageFile = $imageGenerator->convert($media->getPath(), new Conversion('test'));
+
+    $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+
+    $this->assertEquals($imageFile, str_replace('.webm', '.jpg', $media->getPath()));
+});

--- a/tests/Conversions/ImageGenerators/VideoTest.php
+++ b/tests/Conversions/ImageGenerators/VideoTest.php
@@ -2,8 +2,6 @@
 
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Video;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can convert a video', function () {
     $imageGenerator = new Video();

--- a/tests/Conversions/ImageGenerators/VideoTest.php
+++ b/tests/Conversions/ImageGenerators/VideoTest.php
@@ -15,11 +15,11 @@ it('can convert a video', function () {
 
     $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestWebm())->toMediaCollection();
 
-    $this->assertTrue($imageGenerator->canConvert($media));
+    expect($imageGenerator->canConvert($media))->toBeTrue();
 
     $imageFile = $imageGenerator->convert($media->getPath(), new Conversion('test'));
 
-    $this->assertEquals('image/jpeg', mime_content_type($imageFile));
+    expect(mime_content_type($imageFile))->toEqual('image/jpeg');
 
-    $this->assertEquals($imageFile, str_replace('.webm', '.jpg', $media->getPath()));
+    expect(str_replace('.webm', '.jpg', $media->getPath()))->toEqual($imageFile);
 });

--- a/tests/Conversions/ImageGenerators/VideoTest.php
+++ b/tests/Conversions/ImageGenerators/VideoTest.php
@@ -4,7 +4,6 @@ use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Video;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can convert a video', function () {
     $imageGenerator = new Video();

--- a/tests/Conversions/ImageGenerators/WebpTest.php
+++ b/tests/Conversions/ImageGenerators/WebpTest.php
@@ -1,27 +1,22 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Conversions\ImageGenerators;
-
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Webp;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class WebpTest extends TestCase
-{
-    /** @test */
-    public function it_can_convert_a_webp()
-    {
-        $imageGenerator = new Webp();
+uses(TestCase::class);
 
-        if (! $imageGenerator->requirementsAreInstalled()) {
-            $this->markTestSkipped('Skipping webp test because requirements to run it are not met');
-        }
+it('can convert a webp', function () {
+    $imageGenerator = new Webp();
 
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestWebp())->toMediaCollection();
-
-        $this->assertTrue($imageGenerator->canConvert($media));
-
-        $imageFile = $imageGenerator->convert($media->getPath());
-
-        $this->assertEquals('image/png', mime_content_type($imageFile));
+    if (! $imageGenerator->requirementsAreInstalled()) {
+        $this->markTestSkipped('Skipping webp test because requirements to run it are not met');
     }
-}
+
+    $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestWebp())->toMediaCollection();
+
+    $this->assertTrue($imageGenerator->canConvert($media));
+
+    $imageFile = $imageGenerator->convert($media->getPath());
+
+    $this->assertEquals('image/png', mime_content_type($imageFile));
+});

--- a/tests/Conversions/ImageGenerators/WebpTest.php
+++ b/tests/Conversions/ImageGenerators/WebpTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Webp;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can convert a webp', function () {
     $imageGenerator = new Webp();

--- a/tests/Conversions/ImageGenerators/WebpTest.php
+++ b/tests/Conversions/ImageGenerators/WebpTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Webp;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can convert a webp', function () {
     $imageGenerator = new Webp();

--- a/tests/Conversions/ImageGenerators/WebpTest.php
+++ b/tests/Conversions/ImageGenerators/WebpTest.php
@@ -14,9 +14,9 @@ it('can convert a webp', function () {
 
     $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestWebp())->toMediaCollection();
 
-    $this->assertTrue($imageGenerator->canConvert($media));
+    expect($imageGenerator->canConvert($media))->toBeTrue();
 
     $imageFile = $imageGenerator->convert($media->getPath());
 
-    $this->assertEquals('image/png', mime_content_type($imageFile));
+    expect(mime_content_type($imageFile))->toEqual('image/png');
 });

--- a/tests/Feature/FileAdder/ConversionsDiskTest.php
+++ b/tests/Feature/FileAdder/ConversionsDiskTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can save conversions on a separate disk', function () {
     $media = $this->testModelWithConversion

--- a/tests/Feature/FileAdder/ConversionsDiskTest.php
+++ b/tests/Feature/FileAdder/ConversionsDiskTest.php
@@ -1,82 +1,71 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\FileAdder;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class ConversionsDiskTest extends TestCase
-{
-    /** @test */
-    public function it_can_save_conversions_on_a_separate_disk()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->storingConversionsOnDisk('secondMediaDisk')
-            ->toMediaCollection();
+uses(TestCase::class);
 
-        $this->assertEquals('public', $media->disk);
-        $this->assertEquals('secondMediaDisk', $media->conversions_disk);
+it('can save conversions on a separate disk', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->storingConversionsOnDisk('secondMediaDisk')
+        ->toMediaCollection();
 
-        $this->assertEquals("/media/{$media->id}/test.jpg", $media->getUrl());
-        $this->assertEquals("/media2/{$media->id}/conversions/test-thumb.jpg", $media->getUrl('thumb'));
+    $this->assertEquals('public', $media->disk);
+    $this->assertEquals('secondMediaDisk', $media->conversions_disk);
 
-        $originalFilePath = $media->getPath();
+    $this->assertEquals("/media/{$media->id}/test.jpg", $media->getUrl());
+    $this->assertEquals("/media2/{$media->id}/conversions/test-thumb.jpg", $media->getUrl('thumb'));
 
-        $this->assertEquals(
-            $this->getTestsPath('TestSupport/temp/media/1/test.jpg'),
-            $originalFilePath
-        );
-        $this->assertFileExists($originalFilePath);
+    $originalFilePath = $media->getPath();
 
-        $conversionsFilePath = $media->getPath('thumb');
-        $this->assertEquals(
-            $this->getTestsPath('TestSupport/temp/media2/1/conversions/test-thumb.jpg'),
-            $conversionsFilePath
-        );
-        $this->assertFileExists($conversionsFilePath);
-    }
+    $this->assertEquals(
+        $this->getTestsPath('TestSupport/temp/media/1/test.jpg'),
+        $originalFilePath
+    );
+    $this->assertFileExists($originalFilePath);
 
-    /** @test */
-    public function the_responsive_images_will_get_saved_on_the_same_disk_as_the_conversions()
-    {
-        $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestJpg())
-            ->storingConversionsOnDisk('secondMediaDisk')
-            ->toMediaCollection();
+    $conversionsFilePath = $media->getPath('thumb');
+    $this->assertEquals(
+        $this->getTestsPath('TestSupport/temp/media2/1/conversions/test-thumb.jpg'),
+        $conversionsFilePath
+    );
+    $this->assertFileExists($conversionsFilePath);
+});
 
-        $this->assertFileExists($this->getTempDirectory('media2/1/responsive-images/test___thumb_50_41.jpg'));
-    }
+test('the responsive images will get saved on the same disk as the conversions', function () {
+    $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->storingConversionsOnDisk('secondMediaDisk')
+        ->toMediaCollection();
 
-    /** @test */
-    public function deleting_media_will_also_delete_conversions_on_the_separate_disk()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->storingConversionsOnDisk('secondMediaDisk')
-            ->toMediaCollection();
+    $this->assertFileExists($this->getTempDirectory('media2/1/responsive-images/test___thumb_50_41.jpg'));
+});
 
-        $this->assertFileExists($media->getPath('thumb'));
+test('deleting media will also delete conversions on the separate disk', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->storingConversionsOnDisk('secondMediaDisk')
+        ->toMediaCollection();
 
-        $media->delete();
+    $this->assertFileExists($media->getPath('thumb'));
 
-        $this->assertFileDoesNotExist($media->getPath('thumb'));
+    $media->delete();
 
-        $originalFilePath = $media->getPath();
-        $this->assertFileDoesNotExist($originalFilePath);
-    }
+    $this->assertFileDoesNotExist($media->getPath('thumb'));
 
-    /** @test */
-    public function it_will_store_the_conversion_on_the_disk_specified_in_on_the_media_collection()
-    {
-        $media = $this->testModelWithConversionsOnOtherDisk
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('thumb');
+    $originalFilePath = $media->getPath();
+    $this->assertFileDoesNotExist($originalFilePath);
+});
 
-        $conversionsFilePath = $media->getPath('thumb');
-        $this->assertEquals(
-            $this->getTestsPath('TestSupport/temp/media2/1/conversions/test-thumb.jpg'),
-            $conversionsFilePath
-        );
-        $this->assertFileExists($conversionsFilePath);
-    }
-}
+it('will store the conversion on the disk specified in on the media collection', function () {
+    $media = $this->testModelWithConversionsOnOtherDisk
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('thumb');
+
+    $conversionsFilePath = $media->getPath('thumb');
+    $this->assertEquals(
+        $this->getTestsPath('TestSupport/temp/media2/1/conversions/test-thumb.jpg'),
+        $conversionsFilePath
+    );
+    $this->assertFileExists($conversionsFilePath);
+});

--- a/tests/Feature/FileAdder/ConversionsDiskTest.php
+++ b/tests/Feature/FileAdder/ConversionsDiskTest.php
@@ -10,11 +10,11 @@ it('can save conversions on a separate disk', function () {
         ->storingConversionsOnDisk('secondMediaDisk')
         ->toMediaCollection();
 
-    $this->assertEquals('public', $media->disk);
-    $this->assertEquals('secondMediaDisk', $media->conversions_disk);
+    expect($media->disk)->toEqual('public');
+    expect($media->conversions_disk)->toEqual('secondMediaDisk');
 
-    $this->assertEquals("/media/{$media->id}/test.jpg", $media->getUrl());
-    $this->assertEquals("/media2/{$media->id}/conversions/test-thumb.jpg", $media->getUrl('thumb'));
+    expect($media->getUrl())->toEqual("/media/{$media->id}/test.jpg");
+    expect($media->getUrl('thumb'))->toEqual("/media2/{$media->id}/conversions/test-thumb.jpg");
 
     $originalFilePath = $media->getPath();
 
@@ -22,14 +22,14 @@ it('can save conversions on a separate disk', function () {
         $this->getTestsPath('TestSupport/temp/media/1/test.jpg'),
         $originalFilePath
     );
-    $this->assertFileExists($originalFilePath);
+    expect($originalFilePath)->toBeFile();
 
     $conversionsFilePath = $media->getPath('thumb');
     $this->assertEquals(
         $this->getTestsPath('TestSupport/temp/media2/1/conversions/test-thumb.jpg'),
         $conversionsFilePath
     );
-    $this->assertFileExists($conversionsFilePath);
+    expect($conversionsFilePath)->toBeFile();
 });
 
 test('the responsive images will get saved on the same disk as the conversions', function () {
@@ -38,7 +38,7 @@ test('the responsive images will get saved on the same disk as the conversions',
         ->storingConversionsOnDisk('secondMediaDisk')
         ->toMediaCollection();
 
-    $this->assertFileExists($this->getTempDirectory('media2/1/responsive-images/test___thumb_50_41.jpg'));
+    expect($this->getTempDirectory('media2/1/responsive-images/test___thumb_50_41.jpg'))->toBeFile();
 });
 
 test('deleting media will also delete conversions on the separate disk', function () {
@@ -47,7 +47,7 @@ test('deleting media will also delete conversions on the separate disk', functio
         ->storingConversionsOnDisk('secondMediaDisk')
         ->toMediaCollection();
 
-    $this->assertFileExists($media->getPath('thumb'));
+    expect($media->getPath('thumb'))->toBeFile();
 
     $media->delete();
 
@@ -67,5 +67,5 @@ it('will store the conversion on the disk specified in on the media collection',
         $this->getTestsPath('TestSupport/temp/media2/1/conversions/test-thumb.jpg'),
         $conversionsFilePath
     );
-    $this->assertFileExists($conversionsFilePath);
+    expect($conversionsFilePath)->toBeFile();
 });

--- a/tests/Feature/FileAdder/ConversionsDiskTest.php
+++ b/tests/Feature/FileAdder/ConversionsDiskTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 it('can save conversions on a separate disk', function () {

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -21,7 +21,7 @@ it('can add an file to the default collection', function () {
         ->addMedia($this->getTestJpg())
         ->toMediaCollection();
 
-    $this->assertEquals('default', $media->collection_name);
+    expect($media->collection_name)->toEqual('default');
 });
 
 test('to media collection has an alias called to media library', function () {
@@ -29,7 +29,7 @@ test('to media collection has an alias called to media library', function () {
         ->addMedia($this->getTestJpg())
         ->toMediaLibrary();
 
-    $this->assertEquals('default', $media->collection_name);
+    expect($media->collection_name)->toEqual('default');
 });
 
 it('will throw an exception when adding a non existing file', function () {
@@ -45,7 +45,7 @@ it('can set the name of the media', function () {
         ->addMedia($this->getTestJpg())
         ->toMediaCollection();
 
-    $this->assertEquals('test', $media->name);
+    expect($media->name)->toEqual('test');
 });
 
 it('can add a file to a named collection', function () {
@@ -55,7 +55,7 @@ it('can add a file to a named collection', function () {
         ->addMedia($this->getTestJpg())
         ->toMediaCollection($collectionName);
 
-    $this->assertEquals($collectionName, $media->collection_name);
+    expect($media->collection_name)->toEqual($collectionName);
 });
 
 it('can move the original file to the media library', function () {
@@ -76,7 +76,7 @@ it('can copy the original file to the media library', function () {
         ->copyMedia($testFile)
         ->toMediaCollection('images');
 
-    $this->assertFileExists($testFile);
+    expect($testFile)->toBeFile();
     $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
 });
 
@@ -85,13 +85,13 @@ it('can handle a file without an extension', function () {
         ->addMedia($this->getTestFilesDirectory('test'))
         ->toMediaCollection();
 
-    $this->assertEquals('test', $media->name);
+    expect($media->name)->toEqual('test');
 
-    $this->assertEquals('test', $media->file_name);
+    expect($media->file_name)->toEqual('test');
 
-    $this->assertEquals("/media/{$media->id}/test", $media->getUrl());
+    expect($media->getUrl())->toEqual("/media/{$media->id}/test");
 
-    $this->assertFileExists($this->getMediaDirectory("/{$media->id}/test"));
+    expect($this->getMediaDirectory("/{$media->id}/test"))->toBeFile();
 });
 
 it('can handle an image file without an extension', function () {
@@ -99,7 +99,7 @@ it('can handle an image file without an extension', function () {
         ->addMedia($this->getTestFilesDirectory('image'))
         ->toMediaCollection();
 
-    $this->assertEquals('image', $media->type);
+    expect($media->type)->toEqual('image');
 });
 
 it('can handle a non image and non pdf file', function () {
@@ -107,13 +107,13 @@ it('can handle a non image and non pdf file', function () {
         ->addMedia($this->getTestFilesDirectory('test.txt'))
         ->toMediaCollection();
 
-    $this->assertEquals('test', $media->name);
+    expect($media->name)->toEqual('test');
 
-    $this->assertEquals('test.txt', $media->file_name);
+    expect($media->file_name)->toEqual('test.txt');
 
-    $this->assertEquals("/media/{$media->id}/test.txt", $media->getUrl());
+    expect($media->getUrl())->toEqual("/media/{$media->id}/test.txt");
 
-    $this->assertFileExists($this->getMediaDirectory("/{$media->id}/test.txt"));
+    expect($this->getMediaDirectory("/{$media->id}/test.txt"))->toBeFile();
 });
 
 it('can add an upload to the media library', function () {
@@ -128,7 +128,7 @@ it('can add an upload to the media library', function () {
         ->addMedia($uploadedFile)
         ->toMediaCollection();
 
-    $this->assertEquals('alternativename', $media->name);
+    expect($media->name)->toEqual('alternativename');
     $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
 });
 
@@ -138,7 +138,7 @@ it('can add an upload to the media library from the current request', function (
             ->addMediaFromRequest('file')
             ->toMediaCollection();
 
-        $this->assertEquals('alternativename', $media->name);
+        expect($media->name)->toEqual('alternativename');
         $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
     });
 
@@ -153,7 +153,7 @@ it('can add an upload to the media library from the current request', function (
 
     $result = $this->call('get', 'upload', [], [], ['file' => $fileUpload]);
 
-    $this->assertEquals(200, $result->getStatusCode());
+    expect($result->getStatusCode())->toEqual(200);
 });
 
 it('can add multiple uploads to the media library from the current request', function () {
@@ -166,11 +166,11 @@ it('can add multiple uploads to the media library from the current request', fun
         $fileAdders->each(function ($fileAdder) {
             $media = $fileAdder->toMediaCollection();
 
-            $this->assertEquals('alternativename', $media->name);
+            expect($media->name)->toEqual('alternativename');
             $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
         });
 
-        $this->assertCount(2, $fileAdders);
+        expect($fileAdders)->toHaveCount(2);
     });
 
     $uploadedFiles = [
@@ -190,7 +190,7 @@ it('can add multiple uploads to the media library from the current request', fun
 
     $result = $this->call('get', 'upload', [], [], $uploadedFiles);
 
-    $this->assertEquals(200, $result->getStatusCode());
+    expect($result->getStatusCode())->toEqual(200);
 });
 
 it('can add handle file keys that contain an array to the media library from the current request', function () {
@@ -205,12 +205,12 @@ it('can add handle file keys that contain an array to the media library from the
             foreach ($fileAdder as $item) {
                 $media = $item->toMediaCollection();
 
-                $this->assertEquals('alternativename', $media->name);
+                expect($media->name)->toEqual('alternativename');
                 $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
             }
         });
 
-        $this->assertCount(4, $fileAdders);
+        expect($fileAdders)->toHaveCount(4);
     });
 
     $uploadedFiles = [
@@ -244,7 +244,7 @@ it('can add handle file keys that contain an array to the media library from the
 
     $result = $this->call('get', 'upload', [], [], $uploadedFiles);
 
-    $this->assertEquals(200, $result->getStatusCode());
+    expect($result->getStatusCode())->toEqual(200);
 });
 
 it('will throw an exception when trying to add a non existing key from a request', function () {
@@ -259,7 +259,7 @@ it('will throw an exception when trying to add a non existing key from a request
             $exceptionWasThrown = true;
         }
 
-        $this->assertTrue($exceptionWasThrown);
+        expect($exceptionWasThrown)->toBeTrue();
     });
 
     $this->call('get', 'upload');
@@ -272,8 +272,8 @@ it('can add a remote file to the media library', function () {
         ->addMediaFromUrl($url)
         ->toMediaCollection();
 
-    $this->assertEquals('header', $media->name);
-    $this->assertFileExists($this->getMediaDirectory("{$media->id}/header.jpg"));
+    expect($media->name)->toEqual('header');
+    expect($this->getMediaDirectory("{$media->id}/header.jpg"))->toBeFile();
 });
 
 it('will not add local files when an url is expected', function () {
@@ -291,18 +291,18 @@ it('can add a file from a separate disk to the media library', function () {
         ->addMediaFromDisk('tmp/test.jpg', 'secondMediaDisk')
         ->toMediaCollection();
 
-    $this->assertFileExists($this->getMediaDirectory("{$media->id}/test.jpg"));
+    expect($this->getMediaDirectory("{$media->id}/test.jpg"))->toBeFile();
 });
 
 it('can natively copy a remote file from the same disk to the media library', function () {
     Storage::disk('public')->put('tmp/test.jpg', file_get_contents($this->getTestJpg()));
-    $this->assertFileExists($this->getMediaDirectory('tmp/test.jpg'));
+    expect($this->getMediaDirectory('tmp/test.jpg'))->toBeFile();
 
     $media = $this->testModel
         ->addMediaFromDisk('tmp/test.jpg', 'public')
         ->toMediaCollection();
 
-    $this->assertFileExists($this->getMediaDirectory("{$media->id}/test.jpg"));
+    expect($this->getMediaDirectory("{$media->id}/test.jpg"))->toBeFile();
     $this->assertFileDoesNotExist($this->getMediaDirectory('tmp/test.jpg'));
 });
 
@@ -313,7 +313,7 @@ it('can add a remote file with a space in the name to the media library', functi
         ->addMediaFromUrl($url)
         ->toMediaCollection();
 
-    $this->assertFileExists($this->getMediaDirectory("{$media->id}/test-with-space.jpg"));
+    expect($this->getMediaDirectory("{$media->id}/test-with-space.jpg"))->toBeFile();
 });
 
 it('can add a remote file with an accent in the name to the media library', function () {
@@ -323,7 +323,7 @@ it('can add a remote file with an accent in the name to the media library', func
         ->addMediaFromUrl($url)
         ->toMediaCollection();
 
-    $this->assertFileExists($this->getMediaDirectory("{$media->id}/AntarèsThumb.jpg"));
+    expect($this->getMediaDirectory("{$media->id}/AntarèsThumb.jpg"))->toBeFile();
 });
 
 it('wil thrown an exception when a remote file could not be added', function () {
@@ -352,7 +352,7 @@ it('can rename the media before it gets added', function () {
         ->usingName('othername')
         ->toMediaCollection();
 
-    $this->assertEquals('othername', $media->name);
+    expect($media->name)->toEqual('othername');
     $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
 });
 
@@ -362,7 +362,7 @@ it('can rename the file before it gets added', function () {
         ->usingFileName('othertest.jpg')
         ->toMediaCollection();
 
-    $this->assertEquals('test', $media->name);
+    expect($media->name)->toEqual('test');
     $this->assertFileExists($this->getMediaDirectory($media->id.'/othertest.jpg'));
 });
 
@@ -372,7 +372,7 @@ it('will remove strange characters from the file name', function () {
         ->usingFileName('other#test.jpg')
         ->toMediaCollection();
 
-    $this->assertEquals('test', $media->name);
+    expect($media->name)->toEqual('test');
     $this->assertFileExists($this->getMediaDirectory($media->id.'/other-test.jpg'));
 });
 
@@ -382,7 +382,7 @@ it('will sanitize the file name using callable', function () {
         ->sanitizingFileName(fn ($fileName) => 'new_file_name.jpg')
         ->toMediaCollection();
 
-    $this->assertEquals('test', $media->name);
+    expect($media->name)->toEqual('test');
     $this->assertFileExists($this->getMediaDirectory($media->id.'/new_file_name.jpg'));
 });
 
@@ -393,7 +393,7 @@ test('the file name can be modified using a file namer', function () {
         ->addMedia($this->getTestJpg())
         ->toMediaCollection();
 
-    $this->assertEquals('test', $media->name);
+    expect($media->name)->toEqual('test');
     $this->assertFileExists($this->getMediaDirectory($media->id.'/renamed_original_file.jpg'));
 });
 
@@ -404,7 +404,7 @@ test('the file name can be modified using custom sanitizing and default file nam
         ->sanitizingFileName(fn ($fileName) => strtolower(str_replace(['#', '\\', ' '], '-', $fileName)))
         ->toMediaCollection();
 
-    $this->assertEquals('test', $media->name);
+    expect($media->name)->toEqual('test');
     $this->assertFileExists($this->getMediaDirectory($media->id.'/other/otherfilename.jpg'));
 });
 
@@ -415,7 +415,7 @@ test('the file name can be modified using custom sanitizing and default file nam
         ->sanitizingFileName(fn ($fileName) => strtolower(str_replace(['#', '\\', ' '], '-', $fileName)))
         ->toMediaCollection();
 
-    $this->assertEquals('test', $media->name);
+    expect($media->name)->toEqual('test');
     $this->assertFileExists($this->getMediaDirectory($media->id.'/other/[0]-{0}-(0)-otherfile.name.jpg'));
 });
 
@@ -427,7 +427,7 @@ it('can save media in the right order', function () {
             ->preservingOriginal()
             ->toMediaCollection();
 
-        $this->assertEquals($index + 1, $media[$index]->order_column);
+        expect($media[$index]->order_column)->toEqual($index + 1);
     }
 });
 
@@ -438,7 +438,7 @@ it('can add properties to the saved media', function () {
         ->withProperties(['name' => 'testName'])
         ->toMediaCollection();
 
-    $this->assertEquals('testName', $media->name);
+    expect($media->name)->toEqual('testName');
 
     $media = $this->testModel
         ->addMedia($this->getTestJpg())
@@ -446,7 +446,7 @@ it('can add properties to the saved media', function () {
         ->withAttributes(['name' => 'testName'])
         ->toMediaCollection();
 
-    $this->assertEquals('testName', $media->name);
+    expect($media->name)->toEqual('testName');
 });
 
 it('can add manipulations to the saved media', function () {
@@ -456,7 +456,7 @@ it('can add manipulations to the saved media', function () {
         ->withManipulations(['thumb' => ['width' => '10']])
         ->toMediaCollection();
 
-    $this->assertEquals('10', $media->manipulations['thumb']['width']);
+    expect($media->manipulations['thumb']['width'])->toEqual('10');
 });
 
 it('can add file to model with morph map', function () {
@@ -464,7 +464,7 @@ it('can add file to model with morph map', function () {
         ->addMedia($this->getTestJpg())
         ->toMediaCollection();
 
-    $this->assertEquals($this->testModelWithMorphMap->getMorphClass(), $media->model_type);
+    expect($media->model_type)->toEqual($this->testModelWithMorphMap->getMorphClass());
 });
 
 it('will throw an exception when setting the file to a wrong type', function () {
@@ -513,7 +513,7 @@ test('a string can be accepted to be added to the media library', function () {
         ->addMediaFromString($string)
         ->toMediaCollection();
 
-    $this->assertEquals($string, file_get_contents($media->getPath()));
+    expect(file_get_contents($media->getPath()))->toEqual($string);
 });
 
 test('a stream can be accepted to be added to the media library', function () {
@@ -526,7 +526,7 @@ test('a stream can be accepted to be added to the media library', function () {
         ->addMediaFromStream($stream)
         ->toMediaCollection();
 
-    $this->assertEquals($string, file_get_contents($media->getPath()));
+    expect(file_get_contents($media->getPath()))->toEqual($string);
 });
 
 it('can add data uri prefixed base64 encoded file to the medialibrary', function () {
@@ -573,7 +573,7 @@ it('can add files on an unsaved model even if not preserving the original', func
 
     $media = $this->testUnsavedModel->getMedia();
 
-    $this->assertCount(2, $media);
+    expect($media)->toHaveCount(2);
 });
 
 it('can add an upload to the media library using dot notation', function () {
@@ -582,7 +582,7 @@ it('can add an upload to the media library using dot notation', function () {
             ->addMediaFromRequest('file.name')
             ->toMediaCollection();
 
-        $this->assertEquals('alternativename', $media->name);
+        expect($media->name)->toEqual('alternativename');
         $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
     });
 
@@ -595,5 +595,5 @@ it('can add an upload to the media library using dot notation', function () {
 
     $result = $this->call('get', 'upload', [], [], ['file' => ['name' => $fileUpload]]);
 
-    $this->assertEquals(200, $result->getStatusCode());
+    expect($result->getStatusCode())->toEqual(200);
 });

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -10,10 +10,8 @@ use Spatie\MediaLibrary\MediaCollections\Exceptions\MimeTypeNotAllowed;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\RequestDoesNotHaveFile;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\UnknownType;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\RenameOriginalFileNamer;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-
 
 it('can add an file to the default collection', function () {
     $media = $this->testModel

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -14,7 +14,6 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\RenameOriginalFileNamer;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-uses(TestCase::class);
 
 it('can add an file to the default collection', function () {
     $media = $this->testModel

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\FileAdder;
-
 use Illuminate\Support\Facades\Storage;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileDoesNotExist;
@@ -16,677 +14,586 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\RenameOriginalFileNamer;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class IntegrationTest extends TestCase
-{
-    /** @test */
-    public function it_can_add_an_file_to_the_default_collection()
-    {
+uses(TestCase::class);
+
+it('can add an file to the default collection', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
+
+    $this->assertEquals('default', $media->collection_name);
+});
+
+test('to media collection has an alias called to media library', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaLibrary();
+
+    $this->assertEquals('default', $media->collection_name);
+});
+
+it('will throw an exception when adding a non existing file', function () {
+    $this->expectException(FileDoesNotExist::class);
+
+    $this->testModel
+        ->addMedia('this-file-does-not-exist.jpg')
+        ->toMediaCollection();
+});
+
+it('can set the name of the media', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
+
+    $this->assertEquals('test', $media->name);
+});
+
+it('can add a file to a named collection', function () {
+    $collectionName = 'images';
+
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection($collectionName);
+
+    $this->assertEquals($collectionName, $media->collection_name);
+});
+
+it('can move the original file to the media library', function () {
+    $testFile = $this->getTestJpg();
+
+    $media = $this->testModel
+        ->addMedia($testFile)
+        ->toMediaCollection();
+
+    $this->assertFileDoesNotExist($testFile);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
+});
+
+it('can copy the original file to the media library', function () {
+    $testFile = $this->getTestJpg();
+
+    $media = $this->testModel
+        ->copyMedia($testFile)
+        ->toMediaCollection('images');
+
+    $this->assertFileExists($testFile);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
+});
+
+it('can handle a file without an extension', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestFilesDirectory('test'))
+        ->toMediaCollection();
+
+    $this->assertEquals('test', $media->name);
+
+    $this->assertEquals('test', $media->file_name);
+
+    $this->assertEquals("/media/{$media->id}/test", $media->getUrl());
+
+    $this->assertFileExists($this->getMediaDirectory("/{$media->id}/test"));
+});
+
+it('can handle an image file without an extension', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestFilesDirectory('image'))
+        ->toMediaCollection();
+
+    $this->assertEquals('image', $media->type);
+});
+
+it('can handle a non image and non pdf file', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestFilesDirectory('test.txt'))
+        ->toMediaCollection();
+
+    $this->assertEquals('test', $media->name);
+
+    $this->assertEquals('test.txt', $media->file_name);
+
+    $this->assertEquals("/media/{$media->id}/test.txt", $media->getUrl());
+
+    $this->assertFileExists($this->getMediaDirectory("/{$media->id}/test.txt"));
+});
+
+it('can add an upload to the media library', function () {
+    $uploadedFile = new UploadedFile(
+        $this->getTestFilesDirectory('test.jpg'),
+        'alternativename.jpg',
+        'image/jpeg',
+        filesize($this->getTestFilesDirectory('test.jpg'))
+    );
+
+    $media = $this->testModel
+        ->addMedia($uploadedFile)
+        ->toMediaCollection();
+
+    $this->assertEquals('alternativename', $media->name);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
+});
+
+it('can add an upload to the media library from the current request', function () {
+    app()['router']->get('/upload', function () {
         $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
-
-        $this->assertEquals('default', $media->collection_name);
-    }
-
-    /** @test */
-    public function toMediaCollection_has_an_alias_called_toMediaLibrary()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaLibrary();
-
-        $this->assertEquals('default', $media->collection_name);
-    }
-
-    /** @test */
-    public function it_will_throw_an_exception_when_adding_a_non_existing_file()
-    {
-        $this->expectException(FileDoesNotExist::class);
-
-        $this->testModel
-            ->addMedia('this-file-does-not-exist.jpg')
-            ->toMediaCollection();
-    }
-
-    /** @test */
-    public function it_can_set_the_name_of_the_media()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
-
-        $this->assertEquals('test', $media->name);
-    }
-
-    /** @test */
-    public function it_can_add_a_file_to_a_named_collection()
-    {
-        $collectionName = 'images';
-
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection($collectionName);
-
-        $this->assertEquals($collectionName, $media->collection_name);
-    }
-
-    /** @test */
-    public function it_can_move_the_original_file_to_the_media_library()
-    {
-        $testFile = $this->getTestJpg();
-
-        $media = $this->testModel
-            ->addMedia($testFile)
-            ->toMediaCollection();
-
-        $this->assertFileDoesNotExist($testFile);
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
-    }
-
-    /** @test */
-    public function it_can_copy_the_original_file_to_the_media_library()
-    {
-        $testFile = $this->getTestJpg();
-
-        $media = $this->testModel
-            ->copyMedia($testFile)
-            ->toMediaCollection('images');
-
-        $this->assertFileExists($testFile);
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
-    }
-
-    /** @test */
-    public function it_can_handle_a_file_without_an_extension()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestFilesDirectory('test'))
-            ->toMediaCollection();
-
-        $this->assertEquals('test', $media->name);
-
-        $this->assertEquals('test', $media->file_name);
-
-        $this->assertEquals("/media/{$media->id}/test", $media->getUrl());
-
-        $this->assertFileExists($this->getMediaDirectory("/{$media->id}/test"));
-    }
-
-    /** @test */
-    public function it_can_handle_an_image_file_without_an_extension()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestFilesDirectory('image'))
-            ->toMediaCollection();
-
-        $this->assertEquals('image', $media->type);
-    }
-
-    /** @test */
-    public function it_can_handle_a_non_image_and_non_pdf_file()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestFilesDirectory('test.txt'))
-            ->toMediaCollection();
-
-        $this->assertEquals('test', $media->name);
-
-        $this->assertEquals('test.txt', $media->file_name);
-
-        $this->assertEquals("/media/{$media->id}/test.txt", $media->getUrl());
-
-        $this->assertFileExists($this->getMediaDirectory("/{$media->id}/test.txt"));
-    }
-
-    /** @test */
-    public function it_can_add_an_upload_to_the_media_library()
-    {
-        $uploadedFile = new UploadedFile(
-            $this->getTestFilesDirectory('test.jpg'),
-            'alternativename.jpg',
-            'image/jpeg',
-            filesize($this->getTestFilesDirectory('test.jpg'))
-        );
-
-        $media = $this->testModel
-            ->addMedia($uploadedFile)
+            ->addMediaFromRequest('file')
             ->toMediaCollection();
 
         $this->assertEquals('alternativename', $media->name);
         $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
-    }
+    });
 
-    /** @test */
-    public function it_can_add_an_upload_to_the_media_library_from_the_current_request()
-    {
-        $this->app['router']->get('/upload', function () {
-            $media = $this->testModel
-                ->addMediaFromRequest('file')
-                ->toMediaCollection();
+    $fileUpload = new UploadedFile(
+        $this->getTestFilesDirectory('test.jpg'),
+        'alternativename.jpg',
+        'image/jpeg',
+        filesize($this->getTestFilesDirectory('test.jpg'))
+    );
+
+    $this->withoutExceptionHandling();
+
+    $result = $this->call('get', 'upload', [], [], ['file' => $fileUpload]);
+
+    $this->assertEquals(200, $result->getStatusCode());
+});
+
+it('can add multiple uploads to the media library from the current request', function () {
+    app()['router']->get('/upload', function () {
+        $fileAdders = collect(
+            $this->testModel
+                ->addMultipleMediaFromRequest(['file-1', 'file-2'])
+        );
+
+        $fileAdders->each(function ($fileAdder) {
+            $media = $fileAdder->toMediaCollection();
 
             $this->assertEquals('alternativename', $media->name);
             $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
         });
 
-        $fileUpload = new UploadedFile(
-            $this->getTestFilesDirectory('test.jpg'),
+        $this->assertCount(2, $fileAdders);
+    });
+
+    $uploadedFiles = [
+        'file-1' => new UploadedFile(
+            $this->getTestJpg(),
             'alternativename.jpg',
             'image/jpeg',
-            filesize($this->getTestFilesDirectory('test.jpg'))
+            filesize($this->getTestJpg())
+        ),
+        'file-2' => new UploadedFile(
+            $this->getTestSvg(),
+            'alternativename.svg',
+            'image/svg',
+            filesize($this->getTestSvg())
+        ),
+    ];
+
+    $result = $this->call('get', 'upload', [], [], $uploadedFiles);
+
+    $this->assertEquals(200, $result->getStatusCode());
+});
+
+it('can add handle file keys that contain an array to the media library from the current request', function () {
+    app()['router']->get('/upload', function () {
+        $fileAdders = collect(
+            $this->testModel->addAllMediaFromRequest()
         );
 
-        $this->withoutExceptionHandling();
+        $fileAdders->each(function ($fileAdder) {
+            $fileAdder = is_array($fileAdder) ? $fileAdder : [$fileAdder];
 
-        $result = $this->call('get', 'upload', [], [], ['file' => $fileUpload]);
-
-        $this->assertEquals(200, $result->getStatusCode());
-    }
-
-    /** @test */
-    public function it_can_add_multiple_uploads_to_the_media_library_from_the_current_request()
-    {
-        $this->app['router']->get('/upload', function () {
-            $fileAdders = collect(
-                $this->testModel
-                    ->addMultipleMediaFromRequest(['file-1', 'file-2'])
-            );
-
-            $fileAdders->each(function ($fileAdder) {
-                $media = $fileAdder->toMediaCollection();
+            foreach ($fileAdder as $item) {
+                $media = $item->toMediaCollection();
 
                 $this->assertEquals('alternativename', $media->name);
                 $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
-            });
-
-            $this->assertCount(2, $fileAdders);
-        });
-
-        $uploadedFiles = [
-            'file-1' => new UploadedFile(
-                $this->getTestJpg(),
-                'alternativename.jpg',
-                'image/jpeg',
-                filesize($this->getTestJpg())
-            ),
-            'file-2' => new UploadedFile(
-                $this->getTestSvg(),
-                'alternativename.svg',
-                'image/svg',
-                filesize($this->getTestSvg())
-            ),
-        ];
-
-        $result = $this->call('get', 'upload', [], [], $uploadedFiles);
-
-        $this->assertEquals(200, $result->getStatusCode());
-    }
-
-    /** @test */
-    public function it_can_add_handle_file_keys_that_contain_an_array_to_the_media_library_from_the_current_request()
-    {
-        $this->app['router']->get('/upload', function () {
-            $fileAdders = collect(
-                $this->testModel->addAllMediaFromRequest()
-            );
-
-            $fileAdders->each(function ($fileAdder) {
-                $fileAdder = is_array($fileAdder) ? $fileAdder : [$fileAdder];
-
-                foreach ($fileAdder as $item) {
-                    $media = $item->toMediaCollection();
-
-                    $this->assertEquals('alternativename', $media->name);
-                    $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
-                }
-            });
-
-            $this->assertCount(4, $fileAdders);
-        });
-
-        $uploadedFiles = [
-            'file-1' => new UploadedFile(
-                $this->getTestJpg(),
-                'alternativename.jpg',
-                'image/jpeg',
-                filesize($this->getTestJpg())
-            ),
-            'file-2' => new UploadedFile(
-                $this->getTestSvg(),
-                'alternativename.svg',
-                'image/svg',
-                filesize($this->getTestSvg())
-            ),
-            'medias' => [
-                new UploadedFile(
-                    $this->getTestPng(),
-                    'alternativename.png',
-                    'image/png',
-                    filesize($this->getTestPng())
-                ),
-                new UploadedFile(
-                    $this->getTestWebm(),
-                    'alternativename.webm',
-                    'video/webm',
-                    filesize($this->getTestWebm())
-                ),
-            ],
-        ];
-
-        $result = $this->call('get', 'upload', [], [], $uploadedFiles);
-
-        $this->assertEquals(200, $result->getStatusCode());
-    }
-
-    /** @test */
-    public function it_will_throw_an_exception_when_trying_to_add_a_non_existing_key_from_a_request()
-    {
-        $this->app['router']->get('/upload', function () {
-            $exceptionWasThrown = false;
-
-            try {
-                $this->testModel
-                    ->addMediaFromRequest('non existing key')
-                    ->toMediaCollection();
-            } catch (RequestDoesNotHaveFile) {
-                $exceptionWasThrown = true;
             }
-
-            $this->assertTrue($exceptionWasThrown);
         });
 
-        $this->call('get', 'upload');
-    }
-
-    /** @test */
-    public function it_can_add_a_remote_file_to_the_media_library()
-    {
-        $url = 'https://spatie.be/docs/laravel-medialibrary/v9/images/header.jpg';
-
-        $media = $this->testModel
-            ->addMediaFromUrl($url)
-            ->toMediaCollection();
-
-        $this->assertEquals('header', $media->name);
-        $this->assertFileExists($this->getMediaDirectory("{$media->id}/header.jpg"));
-    }
-
-    /** @test */
-    public function it_will_not_add_local_files_when_an_url_is_expected()
-    {
-        $this->expectException(InvalidUrl::class);
-
-        $this->testModel
-            ->addMediaFromUrl(__FILE__)
-            ->toMediaCollection();
-    }
-
-    /** @test */
-    public function it_can_add_a_file_from_a_separate_disk_to_the_media_library()
-    {
-        Storage::disk('secondMediaDisk')->put('tmp/test.jpg', file_get_contents($this->getTestJpg()));
-
-        $media = $this->testModel
-            ->addMediaFromDisk('tmp/test.jpg', 'secondMediaDisk')
-            ->toMediaCollection();
-
-        $this->assertFileExists($this->getMediaDirectory("{$media->id}/test.jpg"));
-    }
-
-    /** @test */
-    public function it_can_natively_copy_a_remote_file_from_the_same_disk_to_the_media_library()
-    {
-        Storage::disk('public')->put('tmp/test.jpg', file_get_contents($this->getTestJpg()));
-        $this->assertFileExists($this->getMediaDirectory('tmp/test.jpg'));
-
-        $media = $this->testModel
-            ->addMediaFromDisk('tmp/test.jpg', 'public')
-            ->toMediaCollection();
-
-        $this->assertFileExists($this->getMediaDirectory("{$media->id}/test.jpg"));
-        $this->assertFileDoesNotExist($this->getMediaDirectory('tmp/test.jpg'));
-    }
-
-    /** @test */
-    public function it_can_add_a_remote_file_with_a_space_in_the_name_to_the_media_library()
-    {
-        $url = 'http://spatie.github.io/laravel-medialibrary/tests/TestSupport/testfiles/test%20with%20space.jpg';
-
-        $media = $this->testModel
-            ->addMediaFromUrl($url)
-            ->toMediaCollection();
-
-        $this->assertFileExists($this->getMediaDirectory("{$media->id}/test-with-space.jpg"));
-    }
-
-    /** @test */
-    public function it_can_add_a_remote_file_with_an_accent_in_the_name_to_the_media_library()
-    {
-        $url = 'https://orbit.brightbox.com/v1/acc-jqzwj/Marquis-Leisure/reviews/images/000/000/898/original/Antar%C3%A8sThumb.jpg';
-
-        $media = $this->testModel
-            ->addMediaFromUrl($url)
-            ->toMediaCollection();
-
-        $this->assertFileExists($this->getMediaDirectory("{$media->id}/AntarèsThumb.jpg"));
-    }
-
-    /** @test */
-    public function it_wil_thrown_an_exception_when_a_remote_file_could_not_be_added()
-    {
-        $url = 'https://docs.spatie.be/images/medialibrary/thisonedoesnotexist.jpg';
-
-        $this->expectException(UnreachableUrl::class);
-
-        $this->testModel
-            ->addMediaFromUrl($url)
-            ->toMediaCollection();
-    }
-
-    /** @test */
-    public function it_wil_throw_an_exception_when_a_remote_file_has_an_invalid_mime_type()
-    {
-        $url = 'https://spatie.be/docs/laravel-medialibrary/v9/images/header.jpg';
-
-        $this->expectException(MimeTypeNotAllowed::class);
-
-        $this->testModel
-            ->addMediaFromUrl($url, ['image/png'])
-            ->toMediaCollection();
-    }
-
-    /** @test */
-    public function it_can_rename_the_media_before_it_gets_added()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->usingName('othername')
-            ->toMediaCollection();
-
-        $this->assertEquals('othername', $media->name);
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
-    }
-
-    /** @test */
-    public function it_can_rename_the_file_before_it_gets_added()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->usingFileName('othertest.jpg')
-            ->toMediaCollection();
-
-        $this->assertEquals('test', $media->name);
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/othertest.jpg'));
-    }
-
-    /** @test */
-    public function it_will_remove_strange_characters_from_the_file_name()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->usingFileName('other#test.jpg')
-            ->toMediaCollection();
-
-        $this->assertEquals('test', $media->name);
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/other-test.jpg'));
-    }
-
-    /** @test */
-    public function it_will_sanitize_the_file_name_using_callable()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->sanitizingFileName(fn ($fileName) => 'new_file_name.jpg')
-            ->toMediaCollection();
-
-        $this->assertEquals('test', $media->name);
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/new_file_name.jpg'));
-    }
-
-    /** @test */
-    public function the_file_name_can_be_modified_using_a_file_namer()
-    {
-        config()->set('media-library.file_namer', RenameOriginalFileNamer::class);
-
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
-
-        $this->assertEquals('test', $media->name);
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/renamed_original_file.jpg'));
-    }
-
-    /** @test */
-    public function the_file_name_can_be_modified_using_custom_sanitizing_and_default_file_namer()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->usingFileName('other/otherFileName.jpg')
-            ->sanitizingFileName(fn ($fileName) => strtolower(str_replace(['#', '\\', ' '], '-', $fileName)))
-            ->toMediaCollection();
-
-        $this->assertEquals('test', $media->name);
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/other/otherfilename.jpg'));
-    }
-
-    /** @test */
-    public function the_file_name_can_be_modified_using_custom_sanitizing_and_default_file_namer_and_especial_chars()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->usingFileName('other/[0]-{0}-(0)-otherFile.Name.jpg')
-            ->sanitizingFileName(fn ($fileName) => strtolower(str_replace(['#', '\\', ' '], '-', $fileName)))
-            ->toMediaCollection();
-
-        $this->assertEquals('test', $media->name);
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/other/[0]-{0}-(0)-otherfile.name.jpg'));
-    }
-
-    /** @test */
-    public function it_can_save_media_in_the_right_order()
-    {
-        $media = [];
-        foreach (range(0, 5) as $index) {
-            $media[] = $this->testModel
-                ->addMedia($this->getTestJpg())
-                ->preservingOriginal()
-                ->toMediaCollection();
-
-            $this->assertEquals($index + 1, $media[$index]->order_column);
-        }
-    }
-
-    /** @test */
-    public function it_can_add_properties_to_the_saved_media()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withProperties(['name' => 'testName'])
-            ->toMediaCollection();
-
-        $this->assertEquals('testName', $media->name);
-
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withAttributes(['name' => 'testName'])
-            ->toMediaCollection();
-
-        $this->assertEquals('testName', $media->name);
-    }
-
-    /** @test */
-    public function it_can_add_manipulations_to_the_saved_media()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withManipulations(['thumb' => ['width' => '10']])
-            ->toMediaCollection();
-
-        $this->assertEquals('10', $media->manipulations['thumb']['width']);
-    }
-
-    /** @test */
-    public function it_can_add_file_to_model_with_morph_map()
-    {
-        $media = $this->testModelWithMorphMap
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
-
-        $this->assertEquals($this->testModelWithMorphMap->getMorphClass(), $media->model_type);
-    }
-
-    /** @test */
-    public function it_will_throw_an_exception_when_setting_the_file_to_a_wrong_type()
-    {
-        $wrongType = [];
-
-        $this->expectException(UnknownType::class);
-
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->setFile($wrongType);
-    }
-
-    /** @test */
-    public function it_will_throw_an_exception_when_adding_a_file_that_is_too_big()
-    {
-        $this->app['config']->set('media-library.max_file_size', 1);
-
-        $this->expectException(FileIsTooBig::class);
-
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
-    }
-
-    /** @test */
-    public function it_will_throw_an_exception_when_adding_a_file_to_a_non_existing_disk()
-    {
-        $this->expectException(DiskDoesNotExist::class);
-
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('images', 'non-existing-disk');
-    }
-
-    /** @test */
-    public function it_can_add_a_base64_encoded_file_to_the_media_library()
-    {
-        $testFile = $this->getTestJpg();
-        $testBase64Data = base64_encode(file_get_contents($testFile));
-
-        $media = $this->testModel
-            ->addMediaFromBase64($testBase64Data)
-            ->toMediaCollection();
-
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
-    }
-
-    /** @test */
-    public function a_string_can_be_accepted_to_be_added_to_the_media_library()
-    {
-        $string = 'test123';
-
-        $media = $this->testModel
-            ->addMediaFromString($string)
-            ->toMediaCollection();
-
-        $this->assertEquals($string, file_get_contents($media->getPath()));
-    }
-
-    /** @test */
-    public function a_stream_can_be_accepted_to_be_added_to_the_media_library()
-    {
-        $string = 'test123';
-        $stream = fopen('php://temp', 'w+');
-        fwrite($stream, $string);
-        rewind($stream);
-
-        $media = $this->testModel
-            ->addMediaFromStream($stream)
-            ->toMediaCollection();
-
-        $this->assertEquals($string, file_get_contents($media->getPath()));
-    }
-
-    /** @test */
-    public function it_can_add_data_uri_prefixed_base64_encoded_file_to_the_medialibrary()
-    {
-        $testFile = $this->getTestJpg();
-        $testBase64Data = 'data:image/jpg;base64,'.base64_encode(file_get_contents($testFile));
-
-        $media = $this->testModel
-            ->addMediaFromBase64($testBase64Data)
-            ->toMediaCollection();
-
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
-    }
-
-    /** @test */
-    public function it_will_throw_an_exception_when_adding_invalid_base64_data()
-    {
-        $testFile = $this->getTestJpg();
-        $invalidBase64Data = file_get_contents($testFile);
-
-        $this->expectException(InvalidBase64Data::class);
-
-        $this->testModel
-            ->addMediaFromBase64($invalidBase64Data)
-            ->toMediaCollection();
-    }
-
-    /** @test */
-    public function it_will_throw_an_exception_when_adding_invalid_base64_mime_type()
-    {
-        $testFile = $this->getTestJpg();
-        $testBase64Data = base64_encode(file_get_contents($testFile));
-
-        $this->expectException(MimeTypeNotAllowed::class);
-
-        $this->testModel
-            ->addMediaFromBase64($testBase64Data, ['image/png'])
-            ->toMediaCollection();
-    }
-
-    /** @test */
-    public function it_can_add_files_on_an_unsaved_model_even_if_not_preserving_the_original()
-    {
-        $this->testUnsavedModel->name = 'test';
-
-        $this->testUnsavedModel->addMedia($this->getTestJpg())->toMediaCollection();
-
-        $this->testUnsavedModel->addMedia($this->getTestPdf())->toMediaCollection();
-
-        $this->testUnsavedModel->save();
-
-        $media = $this->testUnsavedModel->getMedia();
-
-        $this->assertCount(2, $media);
-    }
-
-    /** @test */
-    public function it_can_add_an_upload_to_the_media_library_using_dot_notation()
-    {
-        $this->app['router']->get('/upload', function () {
-            $media = $this->testModel
-                ->addMediaFromRequest('file.name')
-                ->toMediaCollection();
-
-            $this->assertEquals('alternativename', $media->name);
-            $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
-        });
-
-        $fileUpload = new UploadedFile(
-            $this->getTestFilesDirectory('test.jpg'),
+        $this->assertCount(4, $fileAdders);
+    });
+
+    $uploadedFiles = [
+        'file-1' => new UploadedFile(
+            $this->getTestJpg(),
             'alternativename.jpg',
             'image/jpeg',
-            filesize($this->getTestFilesDirectory('test.jpg'))
-        );
+            filesize($this->getTestJpg())
+        ),
+        'file-2' => new UploadedFile(
+            $this->getTestSvg(),
+            'alternativename.svg',
+            'image/svg',
+            filesize($this->getTestSvg())
+        ),
+        'medias' => [
+            new UploadedFile(
+                $this->getTestPng(),
+                'alternativename.png',
+                'image/png',
+                filesize($this->getTestPng())
+            ),
+            new UploadedFile(
+                $this->getTestWebm(),
+                'alternativename.webm',
+                'video/webm',
+                filesize($this->getTestWebm())
+            ),
+        ],
+    ];
 
-        $result = $this->call('get', 'upload', [], [], ['file' => ['name' => $fileUpload]]);
+    $result = $this->call('get', 'upload', [], [], $uploadedFiles);
 
-        $this->assertEquals(200, $result->getStatusCode());
+    $this->assertEquals(200, $result->getStatusCode());
+});
+
+it('will throw an exception when trying to add a non existing key from a request', function () {
+    app()['router']->get('/upload', function () {
+        $exceptionWasThrown = false;
+
+        try {
+            $this->testModel
+                ->addMediaFromRequest('non existing key')
+                ->toMediaCollection();
+        } catch (RequestDoesNotHaveFile) {
+            $exceptionWasThrown = true;
+        }
+
+        $this->assertTrue($exceptionWasThrown);
+    });
+
+    $this->call('get', 'upload');
+});
+
+it('can add a remote file to the media library', function () {
+    $url = 'https://spatie.be/docs/laravel-medialibrary/v9/images/header.jpg';
+
+    $media = $this->testModel
+        ->addMediaFromUrl($url)
+        ->toMediaCollection();
+
+    $this->assertEquals('header', $media->name);
+    $this->assertFileExists($this->getMediaDirectory("{$media->id}/header.jpg"));
+});
+
+it('will not add local files when an url is expected', function () {
+    $this->expectException(InvalidUrl::class);
+
+    $this->testModel
+        ->addMediaFromUrl(__FILE__)
+        ->toMediaCollection();
+});
+
+it('can add a file from a separate disk to the media library', function () {
+    Storage::disk('secondMediaDisk')->put('tmp/test.jpg', file_get_contents($this->getTestJpg()));
+
+    $media = $this->testModel
+        ->addMediaFromDisk('tmp/test.jpg', 'secondMediaDisk')
+        ->toMediaCollection();
+
+    $this->assertFileExists($this->getMediaDirectory("{$media->id}/test.jpg"));
+});
+
+it('can natively copy a remote file from the same disk to the media library', function () {
+    Storage::disk('public')->put('tmp/test.jpg', file_get_contents($this->getTestJpg()));
+    $this->assertFileExists($this->getMediaDirectory('tmp/test.jpg'));
+
+    $media = $this->testModel
+        ->addMediaFromDisk('tmp/test.jpg', 'public')
+        ->toMediaCollection();
+
+    $this->assertFileExists($this->getMediaDirectory("{$media->id}/test.jpg"));
+    $this->assertFileDoesNotExist($this->getMediaDirectory('tmp/test.jpg'));
+});
+
+it('can add a remote file with a space in the name to the media library', function () {
+    $url = 'http://spatie.github.io/laravel-medialibrary/tests/TestSupport/testfiles/test%20with%20space.jpg';
+
+    $media = $this->testModel
+        ->addMediaFromUrl($url)
+        ->toMediaCollection();
+
+    $this->assertFileExists($this->getMediaDirectory("{$media->id}/test-with-space.jpg"));
+});
+
+it('can add a remote file with an accent in the name to the media library', function () {
+    $url = 'https://orbit.brightbox.com/v1/acc-jqzwj/Marquis-Leisure/reviews/images/000/000/898/original/Antar%C3%A8sThumb.jpg';
+
+    $media = $this->testModel
+        ->addMediaFromUrl($url)
+        ->toMediaCollection();
+
+    $this->assertFileExists($this->getMediaDirectory("{$media->id}/AntarèsThumb.jpg"));
+});
+
+it('wil thrown an exception when a remote file could not be added', function () {
+    $url = 'https://docs.spatie.be/images/medialibrary/thisonedoesnotexist.jpg';
+
+    $this->expectException(UnreachableUrl::class);
+
+    $this->testModel
+        ->addMediaFromUrl($url)
+        ->toMediaCollection();
+});
+
+it('wil throw an exception when a remote file has an invalid mime type', function () {
+    $url = 'https://spatie.be/docs/laravel-medialibrary/v9/images/header.jpg';
+
+    $this->expectException(MimeTypeNotAllowed::class);
+
+    $this->testModel
+        ->addMediaFromUrl($url, ['image/png'])
+        ->toMediaCollection();
+});
+
+it('can rename the media before it gets added', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->usingName('othername')
+        ->toMediaCollection();
+
+    $this->assertEquals('othername', $media->name);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+});
+
+it('can rename the file before it gets added', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->usingFileName('othertest.jpg')
+        ->toMediaCollection();
+
+    $this->assertEquals('test', $media->name);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/othertest.jpg'));
+});
+
+it('will remove strange characters from the file name', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->usingFileName('other#test.jpg')
+        ->toMediaCollection();
+
+    $this->assertEquals('test', $media->name);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/other-test.jpg'));
+});
+
+it('will sanitize the file name using callable', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->sanitizingFileName(fn ($fileName) => 'new_file_name.jpg')
+        ->toMediaCollection();
+
+    $this->assertEquals('test', $media->name);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/new_file_name.jpg'));
+});
+
+test('the file name can be modified using a file namer', function () {
+    config()->set('media-library.file_namer', RenameOriginalFileNamer::class);
+
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
+
+    $this->assertEquals('test', $media->name);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/renamed_original_file.jpg'));
+});
+
+test('the file name can be modified using custom sanitizing and default file namer', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->usingFileName('other/otherFileName.jpg')
+        ->sanitizingFileName(fn ($fileName) => strtolower(str_replace(['#', '\\', ' '], '-', $fileName)))
+        ->toMediaCollection();
+
+    $this->assertEquals('test', $media->name);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/other/otherfilename.jpg'));
+});
+
+test('the file name can be modified using custom sanitizing and default file namer and especial chars', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->usingFileName('other/[0]-{0}-(0)-otherFile.Name.jpg')
+        ->sanitizingFileName(fn ($fileName) => strtolower(str_replace(['#', '\\', ' '], '-', $fileName)))
+        ->toMediaCollection();
+
+    $this->assertEquals('test', $media->name);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/other/[0]-{0}-(0)-otherfile.name.jpg'));
+});
+
+it('can save media in the right order', function () {
+    $media = [];
+    foreach (range(0, 5) as $index) {
+        $media[] = $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection();
+
+        $this->assertEquals($index + 1, $media[$index]->order_column);
     }
-}
+});
+
+it('can add properties to the saved media', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withProperties(['name' => 'testName'])
+        ->toMediaCollection();
+
+    $this->assertEquals('testName', $media->name);
+
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withAttributes(['name' => 'testName'])
+        ->toMediaCollection();
+
+    $this->assertEquals('testName', $media->name);
+});
+
+it('can add manipulations to the saved media', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withManipulations(['thumb' => ['width' => '10']])
+        ->toMediaCollection();
+
+    $this->assertEquals('10', $media->manipulations['thumb']['width']);
+});
+
+it('can add file to model with morph map', function () {
+    $media = $this->testModelWithMorphMap
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
+
+    $this->assertEquals($this->testModelWithMorphMap->getMorphClass(), $media->model_type);
+});
+
+it('will throw an exception when setting the file to a wrong type', function () {
+    $wrongType = [];
+
+    $this->expectException(UnknownType::class);
+
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->setFile($wrongType);
+});
+
+it('will throw an exception when adding a file that is too big', function () {
+    app()['config']->set('media-library.max_file_size', 1);
+
+    $this->expectException(FileIsTooBig::class);
+
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
+});
+
+it('will throw an exception when adding a file to a non existing disk', function () {
+    $this->expectException(DiskDoesNotExist::class);
+
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('images', 'non-existing-disk');
+});
+
+it('can add a base64 encoded file to the media library', function () {
+    $testFile = $this->getTestJpg();
+    $testBase64Data = base64_encode(file_get_contents($testFile));
+
+    $media = $this->testModel
+        ->addMediaFromBase64($testBase64Data)
+        ->toMediaCollection();
+
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
+});
+
+test('a string can be accepted to be added to the media library', function () {
+    $string = 'test123';
+
+    $media = $this->testModel
+        ->addMediaFromString($string)
+        ->toMediaCollection();
+
+    $this->assertEquals($string, file_get_contents($media->getPath()));
+});
+
+test('a stream can be accepted to be added to the media library', function () {
+    $string = 'test123';
+    $stream = fopen('php://temp', 'w+');
+    fwrite($stream, $string);
+    rewind($stream);
+
+    $media = $this->testModel
+        ->addMediaFromStream($stream)
+        ->toMediaCollection();
+
+    $this->assertEquals($string, file_get_contents($media->getPath()));
+});
+
+it('can add data uri prefixed base64 encoded file to the medialibrary', function () {
+    $testFile = $this->getTestJpg();
+    $testBase64Data = 'data:image/jpg;base64,'.base64_encode(file_get_contents($testFile));
+
+    $media = $this->testModel
+        ->addMediaFromBase64($testBase64Data)
+        ->toMediaCollection();
+
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
+});
+
+it('will throw an exception when adding invalid base64 data', function () {
+    $testFile = $this->getTestJpg();
+    $invalidBase64Data = file_get_contents($testFile);
+
+    $this->expectException(InvalidBase64Data::class);
+
+    $this->testModel
+        ->addMediaFromBase64($invalidBase64Data)
+        ->toMediaCollection();
+});
+
+it('will throw an exception when adding invalid base64 mime type', function () {
+    $testFile = $this->getTestJpg();
+    $testBase64Data = base64_encode(file_get_contents($testFile));
+
+    $this->expectException(MimeTypeNotAllowed::class);
+
+    $this->testModel
+        ->addMediaFromBase64($testBase64Data, ['image/png'])
+        ->toMediaCollection();
+});
+
+it('can add files on an unsaved model even if not preserving the original', function () {
+    $this->testUnsavedModel->name = 'test';
+
+    $this->testUnsavedModel->addMedia($this->getTestJpg())->toMediaCollection();
+
+    $this->testUnsavedModel->addMedia($this->getTestPdf())->toMediaCollection();
+
+    $this->testUnsavedModel->save();
+
+    $media = $this->testUnsavedModel->getMedia();
+
+    $this->assertCount(2, $media);
+});
+
+it('can add an upload to the media library using dot notation', function () {
+    app()['router']->get('/upload', function () {
+        $media = $this->testModel
+            ->addMediaFromRequest('file.name')
+            ->toMediaCollection();
+
+        $this->assertEquals('alternativename', $media->name);
+        $this->assertFileExists($this->getMediaDirectory($media->id.'/'.$media->file_name));
+    });
+
+    $fileUpload = new UploadedFile(
+        $this->getTestFilesDirectory('test.jpg'),
+        'alternativename.jpg',
+        'image/jpeg',
+        filesize($this->getTestFilesDirectory('test.jpg'))
+    );
+
+    $result = $this->call('get', 'upload', [], [], ['file' => ['name' => $fileUpload]]);
+
+    $this->assertEquals(200, $result->getStatusCode());
+});

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\FileAdder\MediaConversions;
-
 use Carbon\Carbon;
 use Imagick;
 use Spatie\Image\Manipulations;
@@ -11,148 +9,127 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 
-class AddMediaTest extends TestCase
-{
-    /** @test */
-    public function it_can_add_an_file_to_the_default_collection()
-    {
-        $media = $this->testModelWithoutMediaConversions
-            ->copyMedia($this->getTestFilesDirectory('test.jpg'))
-            ->toMediaCollection();
+uses(TestCase::class);
 
-        $this->assertEquals('default', $media->collection_name);
-    }
+it('can add an file to the default collection', function () {
+    $media = $this->testModelWithoutMediaConversions
+        ->copyMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection();
 
-    /** @test */
-    public function it_can_create_a_derived_version_of_an_image()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $this->assertEquals('default', $media->collection_name);
+});
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
-    }
+it('can create a derived version of an image', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    /** @test */
-    public function it_will_not_create_a_derived_version_for_non_registered_collections()
-    {
-        $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaCollection('downloads');
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
+});
 
-        $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
-    }
+it('will not create a derived version for non registered collections', function () {
+    $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaCollection('downloads');
 
-    /** @test */
-    public function it_will_create_a_derived_version_for_an_image_without_an_extension()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('image'))
-            ->toMediaCollection('images');
+    $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
+});
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/image-thumb.jpg'));
-    }
+it('will create a derived version for an image without an extension', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('image'))
+        ->toMediaCollection('images');
 
-    /** @test */
-    public function it_can_create_a_derived_version_for_an_image_keeping_the_original_format()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestPng())
-            ->toMediaCollection('images');
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/image-thumb.jpg'));
+});
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/test-keep_original_format.png'));
-    }
+it('can create a derived version for an image keeping the original format', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestPng())
+        ->toMediaCollection('images');
 
-    /** @test */
-    public function it_will_use_the_name_of_the_conversion_for_naming_the_converted_file()
-    {
-        $modelClass = new class () extends TestModelWithConversion {
-            public function registerMediaConversions(Media $media = null): void
-            {
-                $this->addMediaConversion('my-conversion')
-                    ->setManipulations(function (Manipulations $manipulations) {
-                        $manipulations
-                            ->removeManipulation('format');
-                    })
-                    ->nonQueued();
-            }
-        };
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/test-keep_original_format.png'));
+});
 
-        $model = $modelClass::first();
+it('will use the name of the conversion for naming the converted file', function () {
+    $modelClass = new class () extends TestModelWithConversion {
+        public function registerMediaConversions(Media $media = null) {
+            $this->addMediaConversion('my-conversion')
+                ->setManipulations(function (Manipulations $manipulations) {
+                    $manipulations
+                        ->removeManipulation('format');
+                })
+                ->nonQueued();
+        }
+    };
 
-        $media = $model
-            ->addMedia($this->getTestFilesDirectory('test.png'))
-            ->toMediaCollection('images');
+    $model = $modelClass::first();
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/test-my-conversion.png'));
-    }
+    $media = $model
+        ->addMedia($this->getTestFilesDirectory('test.png'))
+        ->toMediaCollection('images');
 
-    /** @test */
-    public function it_can_create_a_derived_version_of_a_pdf_if_imagick_exists()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestFilesDirectory('test.pdf'))
-            ->toMediaCollection('images');
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/test-my-conversion.png'));
+});
 
-        $thumbPath = $this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg');
+it('can create a derived version of a pdf if imagick exists', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestFilesDirectory('test.pdf'))
+        ->toMediaCollection('images');
 
-        class_exists(Imagick::class)
-            ? $this->assertFileExists($thumbPath)
-            : $this->assertFileDoesNotExist($thumbPath);
-    }
+    $thumbPath = $this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg');
 
-    /** @test */
-    public function it_will_not_create_a_derived_version_if_manipulations_did_not_change()
-    {
-        Carbon::setTestNow();
+    class_exists(Imagick::class)
+        ? $this->assertFileExists($thumbPath)
+        : $this->assertFileDoesNotExist($thumbPath);
+});
 
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection('images');
+it('will not create a derived version if manipulations did not change', function () {
+    Carbon::setTestNow();
 
-        $originalThumbCreatedAt = filemtime($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
+    $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-        Carbon::setTestNow(Carbon::now()->addMinute());
+    $originalThumbCreatedAt = filemtime($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
 
-        $media->order_column += 1;
-        $media->save();
+    Carbon::setTestNow(Carbon::now()->addMinute());
 
-        $thumbsCreatedAt = filemtime($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
+    $media->order_column += 1;
+    $media->save();
 
-        $this->assertEquals($originalThumbCreatedAt, $thumbsCreatedAt);
-    }
+    $thumbsCreatedAt = filemtime($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
 
-    /** @test */
-    public function it_will_have_access_the_model_instance_when_registerMediaConversionsUsingModelInstance_has_been_set()
-    {
-        $modelClass = new class () extends TestModel {
-            public bool $registerMediaConversionsUsingModelInstance = true;
+    $this->assertEquals($originalThumbCreatedAt, $thumbsCreatedAt);
+});
 
-            /**
-             * Register the conversions that should be performed.
-             *
-             * @return array
-             */
-            public function registerMediaConversions(Media $media = null): void
-            {
-                $this->addMediaConversion('thumb')
-                    ->width($this->width)
-                    ->nonQueued();
-            }
-        };
+it('will have access the model instance when register media conversions using model instance has been set', function () {
+    $modelClass = new class () extends TestModel {
+        public bool $registerMediaConversionsUsingModelInstance = true;
 
-        $model = new $modelClass();
-        $model->name = 'testmodel';
-        $model->width = 123;
-        $model->save();
+        /**
+         * Register the conversions that should be performed.
+         *
+         * @return array
+         */
+        public function registerMediaConversions(Media $media = null) {
+            $this->addMediaConversion('thumb')
+                ->width($this->width)
+                ->nonQueued();
+        }
+    };
 
-        $media = $model
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
+    $model = new $modelClass();
+    $model->name = 'testmodel';
+    $model->width = 123;
+    $model->save();
 
-        $conversionCollection = ConversionCollection::createForMedia($media);
+    $media = $model
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
 
-        $conversion = $conversionCollection->getConversions()[0];
+    $conversionCollection = ConversionCollection::createForMedia($media);
 
-        $conversionManipulations = $conversion
-            ->getManipulations()
-            ->getManipulationSequence()
-            ->toArray()[0];
+    $conversion = $conversionCollection->getConversions()[0];
 
-        $this->assertEquals(123, $conversionManipulations['width']);
-    }
-}
+    $conversionManipulations = $conversion
+        ->getManipulations()
+        ->getManipulationSequence()
+        ->toArray()[0];
+
+    $this->assertEquals(123, $conversionManipulations['width']);
+});

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -4,10 +4,8 @@ use Carbon\Carbon;
 use Spatie\Image\Manipulations;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
-
 
 it('can add an file to the default collection', function () {
     $media = $this->testModelWithoutMediaConversions

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Carbon\Carbon;
-use Imagick;
 use Spatie\Image\Manipulations;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -45,7 +45,7 @@ it('can create a derived version for an image keeping the original format', func
 
 it('will use the name of the conversion for naming the converted file', function () {
     $modelClass = new class () extends TestModelWithConversion {
-        public function registerMediaConversions(Media $media = null)
+        public function registerMediaConversions(Media $media = null): void
         {
             $this->addMediaConversion('my-conversion')
                 ->setManipulations(function (Manipulations $manipulations) {
@@ -103,7 +103,7 @@ it('will have access the model instance when register media conversions using mo
          *
          * @return array
          */
-        public function registerMediaConversions(Media $media = null)
+        public function registerMediaConversions(Media $media = null): void
         {
             $this->addMediaConversion('thumb')
                 ->width($this->width)

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -15,7 +15,7 @@ it('can add an file to the default collection', function () {
         ->copyMedia($this->getTestFilesDirectory('test.jpg'))
         ->toMediaCollection();
 
-    $this->assertEquals('default', $media->collection_name);
+    expect($media->collection_name)->toEqual('default');
 });
 
 it('can create a derived version of an image', function () {
@@ -75,7 +75,7 @@ it('can create a derived version of a pdf if imagick exists', function () {
     $thumbPath = $this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg');
 
     class_exists(Imagick::class)
-        ? $this->assertFileExists($thumbPath)
+        ? expect($thumbPath)->toBeFile()
         : $this->assertFileDoesNotExist($thumbPath);
 });
 
@@ -93,7 +93,7 @@ it('will not create a derived version if manipulations did not change', function
 
     $thumbsCreatedAt = filemtime($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
 
-    $this->assertEquals($originalThumbCreatedAt, $thumbsCreatedAt);
+    expect($thumbsCreatedAt)->toEqual($originalThumbCreatedAt);
 });
 
 it('will have access the model instance when register media conversions using model instance has been set', function () {
@@ -130,5 +130,5 @@ it('will have access the model instance when register media conversions using mo
         ->getManipulationSequence()
         ->toArray()[0];
 
-    $this->assertEquals(123, $conversionManipulations['width']);
+    expect($conversionManipulations['width'])->toEqual(123);
 });

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -8,7 +8,6 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 
-uses(TestCase::class);
 
 it('can add an file to the default collection', function () {
     $media = $this->testModelWithoutMediaConversions

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -45,7 +45,8 @@ it('can create a derived version for an image keeping the original format', func
 
 it('will use the name of the conversion for naming the converted file', function () {
     $modelClass = new class () extends TestModelWithConversion {
-        public function registerMediaConversions(Media $media = null) {
+        public function registerMediaConversions(Media $media = null)
+        {
             $this->addMediaConversion('my-conversion')
                 ->setManipulations(function (Manipulations $manipulations) {
                     $manipulations
@@ -102,7 +103,8 @@ it('will have access the model instance when register media conversions using mo
          *
          * @return array
          */
-        public function registerMediaConversions(Media $media = null) {
+        public function registerMediaConversions(Media $media = null)
+        {
             $this->addMediaConversion('thumb')
                 ->width($this->width)
                 ->nonQueued();

--- a/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
@@ -4,7 +4,6 @@ use Illuminate\Support\Facades\File;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     foreach (range(1, 3) as $index) {

--- a/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
@@ -1,9 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\File;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
-
 
 beforeEach(function () {
     foreach (range(1, 3) as $index) {

--- a/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
@@ -1,142 +1,116 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\FileAdder\MediaConversions;
-
 use Illuminate\Support\Facades\File;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
 
-class DeleteMediaTest extends TestCase
-{
-    public function setUp(): void
-    {
-        parent::setUp();
+uses(TestCase::class);
 
-        foreach (range(1, 3) as $index) {
-            $this->testModelWithoutMediaConversions
-                ->addMedia($this->getTestJpg())
-                ->preservingOriginal()
-                ->toMediaCollection();
+beforeEach(function () {
+    foreach (range(1, 3) as $index) {
+        $this->testModelWithoutMediaConversions
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection();
 
-            $this->testModelWithoutMediaConversions
-                ->addMedia($this->getTestJpg())
-                ->preservingOriginal()
-                ->toMediaCollection('images');
-        }
+        $this->testModelWithoutMediaConversions
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection('images');
     }
+});
 
-    /** @test */
-    public function it_can_clear_a_collection()
-    {
-        $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
-        $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
+it('can clear a collection', function () {
+    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
+    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
 
-        $this->testModelWithoutMediaConversions->clearMediaCollection('images');
-        $this->testModelWithoutMediaConversions = $this->testModelWithoutMediaConversions->fresh();
+    $this->testModelWithoutMediaConversions->clearMediaCollection('images');
+    $this->testModelWithoutMediaConversions = $this->testModelWithoutMediaConversions->fresh();
 
-        $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
-        $this->assertCount(0, $this->testModelWithoutMediaConversions->getMedia('images'));
-    }
+    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
+    $this->assertCount(0, $this->testModelWithoutMediaConversions->getMedia('images'));
+});
 
-    /** @test */
-    public function it_can_clear_the_default_collection()
-    {
-        $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
-        $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
+it('can clear the default collection', function () {
+    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
+    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
 
-        $this->testModelWithoutMediaConversions->clearMediaCollection();
-        $this->testModelWithoutMediaConversions = $this->testModelWithoutMediaConversions->fresh();
+    $this->testModelWithoutMediaConversions->clearMediaCollection();
+    $this->testModelWithoutMediaConversions = $this->testModelWithoutMediaConversions->fresh();
 
-        $this->assertCount(0, $this->testModelWithoutMediaConversions->getMedia('default'));
-        $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
-    }
+    $this->assertCount(0, $this->testModelWithoutMediaConversions->getMedia('default'));
+    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
+});
 
-    /** @test */
-    public function it_can_clear_a_collection_excluding_a_single_media()
-    {
-        $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
+it('can clear a collection excluding a single media', function () {
+    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
 
-        $excludedMedia = $this->testModelWithoutMediaConversions->getFirstMedia('images');
+    $excludedMedia = $this->testModelWithoutMediaConversions->getFirstMedia('images');
 
-        $this->testModelWithoutMediaConversions->clearMediaCollectionExcept('images', $excludedMedia);
+    $this->testModelWithoutMediaConversions->clearMediaCollectionExcept('images', $excludedMedia);
 
-        $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[0], $excludedMedia);
-        $this->assertCount(1, $this->testModelWithoutMediaConversions->getMedia('images'));
-    }
+    $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[0], $excludedMedia);
+    $this->assertCount(1, $this->testModelWithoutMediaConversions->getMedia('images'));
+});
 
-    /** @test */
-    public function it_can_clear_a_collection_excluding_some_media()
-    {
-        $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
-        $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
+it('can clear a collection excluding some media', function () {
+    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
+    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
 
-        $excludedMedia = $this->testModelWithoutMediaConversions->getMedia('images')->take(2);
+    $excludedMedia = $this->testModelWithoutMediaConversions->getMedia('images')->take(2);
 
-        $this->testModelWithoutMediaConversions->clearMediaCollectionExcept('images', $excludedMedia);
-        $this->testModelWithoutMediaConversions = $this->testModelWithoutMediaConversions->fresh();
+    $this->testModelWithoutMediaConversions->clearMediaCollectionExcept('images', $excludedMedia);
+    $this->testModelWithoutMediaConversions = $this->testModelWithoutMediaConversions->fresh();
 
-        $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
-        $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[0], $excludedMedia[0]);
-        $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[1], $excludedMedia[1]);
-    }
+    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
+    $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[0], $excludedMedia[0]);
+    $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[1], $excludedMedia[1]);
+});
 
-    /** @test */
-    public function it_provides_a_chainable_method_for_clearing_a_collection()
-    {
-        $result = $this->testModelWithoutMediaConversions->clearMediaCollection('images');
+it('provides a chainable method for clearing a collection', function () {
+    $result = $this->testModelWithoutMediaConversions->clearMediaCollection('images');
 
-        $this->assertInstanceOf(TestModelWithoutMediaConversions::class, $result);
-    }
+    $this->assertInstanceOf(TestModelWithoutMediaConversions::class, $result);
+});
 
-    /**
-     * @test
-     */
-    public function it_will_remove_the_files_when_clearing_a_collection()
-    {
-        $ids = $this->testModelWithoutMediaConversions->getMedia('images')->pluck('id');
+it('will remove the files when clearing a collection', function () {
+    $ids = $this->testModelWithoutMediaConversions->getMedia('images')->pluck('id');
 
-        $ids->map(function ($id) {
-            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
-        });
+    $ids->map(function ($id) {
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+    });
 
-        $this->testModelWithoutMediaConversions->clearMediaCollection('images');
+    $this->testModelWithoutMediaConversions->clearMediaCollection('images');
 
-        $ids->map(function ($id) {
-            $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
-        });
-    }
+    $ids->map(function ($id) {
+        $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
+    });
+});
 
-    /**
-     * @test
-     */
-    public function it_will_remove_the_files_when_deleting_a_subject_without_media_conversions()
-    {
-        $ids = $this->testModelWithoutMediaConversions->getMedia('images')->pluck('id');
+it('will remove the files when deleting a subject without media conversions', function () {
+    $ids = $this->testModelWithoutMediaConversions->getMedia('images')->pluck('id');
 
-        $ids->map(function ($id) {
-            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
-        });
+    $ids->map(function ($id) {
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+    });
 
-        $this->testModelWithoutMediaConversions->delete();
+    $this->testModelWithoutMediaConversions->delete();
 
-        $ids->map(function ($id) {
-            $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
-        });
-    }
+    $ids->map(function ($id) {
+        $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
+    });
+});
 
-    /** @test */
-    public function it_will_not_remove_the_files_when_deleting_a_subject_and_preserving_media()
-    {
-        $ids = $this->testModelWithoutMediaConversions->getMedia('images')->pluck('id');
+it('will not remove the files when deleting a subject and preserving media', function () {
+    $ids = $this->testModelWithoutMediaConversions->getMedia('images')->pluck('id');
 
-        $ids->map(function ($id) {
-            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
-        });
+    $ids->map(function ($id) {
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+    });
 
-        $this->testModelWithoutMediaConversions->deletePreservingMedia();
+    $this->testModelWithoutMediaConversions->deletePreservingMedia();
 
-        $ids->map(function ($id) {
-            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
-        });
-    }
-}
+    $ids->map(function ($id) {
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+    });
+});

--- a/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
@@ -21,69 +21,69 @@ beforeEach(function () {
 });
 
 it('can clear a collection', function () {
-    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
-    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
+    expect($this->testModelWithoutMediaConversions->getMedia('default'))->toHaveCount(3);
+    expect($this->testModelWithoutMediaConversions->getMedia('images'))->toHaveCount(3);
 
     $this->testModelWithoutMediaConversions->clearMediaCollection('images');
     $this->testModelWithoutMediaConversions = $this->testModelWithoutMediaConversions->fresh();
 
-    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
-    $this->assertCount(0, $this->testModelWithoutMediaConversions->getMedia('images'));
+    expect($this->testModelWithoutMediaConversions->getMedia('default'))->toHaveCount(3);
+    expect($this->testModelWithoutMediaConversions->getMedia('images'))->toHaveCount(0);
 });
 
 it('can clear the default collection', function () {
-    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
-    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
+    expect($this->testModelWithoutMediaConversions->getMedia('default'))->toHaveCount(3);
+    expect($this->testModelWithoutMediaConversions->getMedia('images'))->toHaveCount(3);
 
     $this->testModelWithoutMediaConversions->clearMediaCollection();
     $this->testModelWithoutMediaConversions = $this->testModelWithoutMediaConversions->fresh();
 
-    $this->assertCount(0, $this->testModelWithoutMediaConversions->getMedia('default'));
-    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
+    expect($this->testModelWithoutMediaConversions->getMedia('default'))->toHaveCount(0);
+    expect($this->testModelWithoutMediaConversions->getMedia('images'))->toHaveCount(3);
 });
 
 it('can clear a collection excluding a single media', function () {
-    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
+    expect($this->testModelWithoutMediaConversions->getMedia('images'))->toHaveCount(3);
 
     $excludedMedia = $this->testModelWithoutMediaConversions->getFirstMedia('images');
 
     $this->testModelWithoutMediaConversions->clearMediaCollectionExcept('images', $excludedMedia);
 
-    $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[0], $excludedMedia);
-    $this->assertCount(1, $this->testModelWithoutMediaConversions->getMedia('images'));
+    expect($excludedMedia)->toEqual($this->testModelWithoutMediaConversions->getMedia('images')[0]);
+    expect($this->testModelWithoutMediaConversions->getMedia('images'))->toHaveCount(1);
 });
 
 it('can clear a collection excluding some media', function () {
-    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
-    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('images'));
+    expect($this->testModelWithoutMediaConversions->getMedia('default'))->toHaveCount(3);
+    expect($this->testModelWithoutMediaConversions->getMedia('images'))->toHaveCount(3);
 
     $excludedMedia = $this->testModelWithoutMediaConversions->getMedia('images')->take(2);
 
     $this->testModelWithoutMediaConversions->clearMediaCollectionExcept('images', $excludedMedia);
     $this->testModelWithoutMediaConversions = $this->testModelWithoutMediaConversions->fresh();
 
-    $this->assertCount(3, $this->testModelWithoutMediaConversions->getMedia('default'));
-    $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[0], $excludedMedia[0]);
-    $this->assertEquals($this->testModelWithoutMediaConversions->getMedia('images')[1], $excludedMedia[1]);
+    expect($this->testModelWithoutMediaConversions->getMedia('default'))->toHaveCount(3);
+    expect($excludedMedia[0])->toEqual($this->testModelWithoutMediaConversions->getMedia('images')[0]);
+    expect($excludedMedia[1])->toEqual($this->testModelWithoutMediaConversions->getMedia('images')[1]);
 });
 
 it('provides a chainable method for clearing a collection', function () {
     $result = $this->testModelWithoutMediaConversions->clearMediaCollection('images');
 
-    $this->assertInstanceOf(TestModelWithoutMediaConversions::class, $result);
+    expect($result)->toBeInstanceOf(TestModelWithoutMediaConversions::class);
 });
 
 it('will remove the files when clearing a collection', function () {
     $ids = $this->testModelWithoutMediaConversions->getMedia('images')->pluck('id');
 
     $ids->map(function ($id) {
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
     });
 
     $this->testModelWithoutMediaConversions->clearMediaCollection('images');
 
     $ids->map(function ($id) {
-        $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
     });
 });
 
@@ -91,13 +91,13 @@ it('will remove the files when deleting a subject without media conversions', fu
     $ids = $this->testModelWithoutMediaConversions->getMedia('images')->pluck('id');
 
     $ids->map(function ($id) {
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
     });
 
     $this->testModelWithoutMediaConversions->delete();
 
     $ids->map(function ($id) {
-        $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
     });
 });
 
@@ -105,12 +105,12 @@ it('will not remove the files when deleting a subject and preserving media', fun
     $ids = $this->testModelWithoutMediaConversions->getMedia('images')->pluck('id');
 
     $ids->map(function ($id) {
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
     });
 
     $this->testModelWithoutMediaConversions->deletePreservingMedia();
 
     $ids->map(function ($id) {
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
     });
 });

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -8,7 +8,8 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConver
 
 it('will use the disk from a media collection', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this->addMediaCollection('images')
                 ->useDisk('secondMediaDisk');
         }
@@ -29,7 +30,8 @@ it('will use the disk from a media collection', function () {
 
 it('will not use the disk name of the collection if a diskname is specified while adding', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this->addMediaCollection('images')
                 ->useDisk('secondMediaDisk');
         }
@@ -46,7 +48,8 @@ it('will not use the disk name of the collection if a diskname is specified whil
 
 it('can register media conversions when defining media collections', function () {
     $testModel = new class () extends TestModelWithoutMediaConversions {
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this
                 ->addMediaCollection('images')
                 ->registerMediaConversions(function (Media $media) {
@@ -66,7 +69,8 @@ it('can register media conversions when defining media collections', function ()
 
 it('will not use media conversions from an unrelated collection', function () {
     $testModel = new class () extends TestModelWithoutMediaConversions {
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this
                 ->addMediaCollection('images')
                 ->registerMediaConversions(function (Media $media) {
@@ -86,13 +90,15 @@ it('will not use media conversions from an unrelated collection', function () {
 
 it('will use conversions defined in conversions and conversions defined in collections', function () {
     $testModel = new class () extends TestModelWithoutMediaConversions {
-        public function registerMediaConversions(Media $media = null) {
+        public function registerMediaConversions(Media $media = null)
+        {
             $this
                 ->addMediaConversion('another-thumb')
                 ->greyscale();
         }
 
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this
                 ->addMediaCollection('images')
                 ->registerMediaConversions(function (Media $media = null) {
@@ -114,7 +120,8 @@ it('will use conversions defined in conversions and conversions defined in colle
 
 it('can accept certain files', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this
                 ->addMediaCollection('images')
                 ->acceptsFile(fn (File $file) => $file->mimeType === 'image/jpeg');
@@ -132,7 +139,8 @@ it('can accept certain files', function () {
 
 it('can guard against invalid mimetypes', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this
                 ->addMediaCollection('images')
                 ->acceptsMimeTypes(['image/jpeg']);
@@ -150,7 +158,8 @@ it('can guard against invalid mimetypes', function () {
 
 it('can generate responsive images', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this
                 ->addMediaCollection('images')
                 ->withResponsiveImages();
@@ -174,7 +183,8 @@ it('can generate responsive images', function () {
 
 it('can generate responsive images on condition', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this
                 ->addMediaCollection('images')
                 ->withResponsiveImagesIf(true);
@@ -198,7 +208,8 @@ it('can generate responsive images on condition', function () {
 
 test('if the single file method is specified it will delete all other media and will only keep the new one', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this
                 ->addMediaCollection('images')
                 ->singleFile();
@@ -216,7 +227,8 @@ test('if the single file method is specified it will delete all other media and 
 
 test('if the only keeps latest method is specified it will delete all other media and will only keep the latest n ones', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections() {
+        public function registerMediaCollections()
+        {
             $this
                 ->addMediaCollection('images')
                 ->onlyKeepLatest(3);

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -3,10 +3,8 @@
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileUnacceptableForCollection;
 use Spatie\MediaLibrary\MediaCollections\File;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
-
 
 it('will use the disk from a media collection', function () {
     $testModel = new class () extends TestModelWithConversion {

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -172,7 +172,7 @@ it('can generate responsive images', function () {
         'http://localhost/media/1/responsive-images/test___media_library_original_237_195.jpg',
     ], $media->getResponsiveImageUrls());
 
-    $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));
+    expect($media->getResponsiveImageUrls('non-existing-conversion'))->toEqual([]);
 });
 
 it('can generate responsive images on condition', function () {
@@ -196,7 +196,7 @@ it('can generate responsive images on condition', function () {
         'http://localhost/media/1/responsive-images/test___media_library_original_237_195.jpg',
     ], $media->getResponsiveImageUrls());
 
-    $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));
+    expect($media->getResponsiveImageUrls('non-existing-conversion'))->toEqual([]);
 });
 
 test('if the single file method is specified it will delete all other media and will only keep the new one', function () {
@@ -214,7 +214,7 @@ test('if the single file method is specified it will delete all other media and 
     $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
     $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
-    $this->assertCount(1, $model->getMedia('images'));
+    expect($model->getMedia('images'))->toHaveCount(1);
 });
 
 test('if the only keeps latest method is specified it will delete all other media and will only keep the latest n ones', function () {
@@ -234,5 +234,5 @@ test('if the only keeps latest method is specified it will delete all other medi
     $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
     $this->assertFalse($model->getMedia('images')->contains(fn ($model) => $model->is($firstFile)));
-    $this->assertCount(3, $model->getMedia('images'));
+    expect($model->getMedia('images'))->toHaveCount(3);
 });

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -8,7 +8,7 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConver
 
 it('will use the disk from a media collection', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this->addMediaCollection('images')
                 ->useDisk('secondMediaDisk');
@@ -30,7 +30,7 @@ it('will use the disk from a media collection', function () {
 
 it('will not use the disk name of the collection if a diskname is specified while adding', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this->addMediaCollection('images')
                 ->useDisk('secondMediaDisk');
@@ -48,7 +48,7 @@ it('will not use the disk name of the collection if a diskname is specified whil
 
 it('can register media conversions when defining media collections', function () {
     $testModel = new class () extends TestModelWithoutMediaConversions {
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this
                 ->addMediaCollection('images')
@@ -69,7 +69,7 @@ it('can register media conversions when defining media collections', function ()
 
 it('will not use media conversions from an unrelated collection', function () {
     $testModel = new class () extends TestModelWithoutMediaConversions {
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this
                 ->addMediaCollection('images')
@@ -90,14 +90,14 @@ it('will not use media conversions from an unrelated collection', function () {
 
 it('will use conversions defined in conversions and conversions defined in collections', function () {
     $testModel = new class () extends TestModelWithoutMediaConversions {
-        public function registerMediaConversions(Media $media = null)
+        public function registerMediaConversions(Media $media = null): void
         {
             $this
                 ->addMediaConversion('another-thumb')
                 ->greyscale();
         }
 
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this
                 ->addMediaCollection('images')
@@ -120,7 +120,7 @@ it('will use conversions defined in conversions and conversions defined in colle
 
 it('can accept certain files', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this
                 ->addMediaCollection('images')
@@ -139,7 +139,7 @@ it('can accept certain files', function () {
 
 it('can guard against invalid mimetypes', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this
                 ->addMediaCollection('images')
@@ -158,7 +158,7 @@ it('can guard against invalid mimetypes', function () {
 
 it('can generate responsive images', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this
                 ->addMediaCollection('images')
@@ -183,7 +183,7 @@ it('can generate responsive images', function () {
 
 it('can generate responsive images on condition', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this
                 ->addMediaCollection('images')
@@ -208,7 +208,7 @@ it('can generate responsive images on condition', function () {
 
 test('if the single file method is specified it will delete all other media and will only keep the new one', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this
                 ->addMediaCollection('images')
@@ -227,7 +227,7 @@ test('if the single file method is specified it will delete all other media and 
 
 test('if the only keeps latest method is specified it will delete all other media and will only keep the latest n ones', function () {
     $testModel = new class () extends TestModelWithConversion {
-        public function registerMediaCollections()
+        public function registerMediaCollections(): void
         {
             $this
                 ->addMediaCollection('images')

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -7,7 +7,6 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
 
-uses(TestCase::class);
 
 it('will use the disk from a media collection', function () {
     $testModel = new class () extends TestModelWithConversion {

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\FileAdder\MediaConversions;
-
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileUnacceptableForCollection;
 use Spatie\MediaLibrary\MediaCollections\File;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -9,267 +7,232 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
 
-class MediaCollectionTest extends TestCase
-{
-    /** @test */
-    public function it_will_use_the_disk_from_a_media_collection()
-    {
-        $testModel = new class () extends TestModelWithConversion {
-            public function registerMediaCollections(): void
-            {
-                $this->addMediaCollection('images')
-                    ->useDisk('secondMediaDisk');
-            }
-        };
+uses(TestCase::class);
 
-        $model = $testModel::create(['name' => 'testmodel']);
+it('will use the disk from a media collection', function () {
+    $testModel = new class () extends TestModelWithConversion {
+        public function registerMediaCollections() {
+            $this->addMediaCollection('images')
+                ->useDisk('secondMediaDisk');
+        }
+    };
 
-        $media = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $this->assertFileDoesNotExist($this->getTempDirectory('media').'/'.$media->id.'/test.jpg');
+    $media = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
-        $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
+    $this->assertFileDoesNotExist($this->getTempDirectory('media').'/'.$media->id.'/test.jpg');
 
-        $media = $model->addMedia($this->getTestJpg())->toMediaCollection('other-images');
+    $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
 
-        $this->assertFileExists($this->getTempDirectory('media').'/'.$media->id.'/test.jpg');
-    }
+    $media = $model->addMedia($this->getTestJpg())->toMediaCollection('other-images');
 
-    /** @test */
-    public function it_will_not_use_the_disk_name_of_the_collection_if_a_diskname_is_specified_while_adding()
-    {
-        $testModel = new class () extends TestModelWithConversion {
-            public function registerMediaCollections(): void
-            {
-                $this->addMediaCollection('images')
-                    ->useDisk('secondMediaDisk');
-            }
-        };
+    $this->assertFileExists($this->getTempDirectory('media').'/'.$media->id.'/test.jpg');
+});
 
-        $model = $testModel::create(['name' => 'testmodel']);
+it('will not use the disk name of the collection if a diskname is specified while adding', function () {
+    $testModel = new class () extends TestModelWithConversion {
+        public function registerMediaCollections() {
+            $this->addMediaCollection('images')
+                ->useDisk('secondMediaDisk');
+        }
+    };
 
-        $media = $model->addMedia($this->getTestJpg())->toMediaCollection('images', 'public');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $this->assertFileExists($this->getTempDirectory('media').'/'.$media->id.'/test.jpg');
+    $media = $model->addMedia($this->getTestJpg())->toMediaCollection('images', 'public');
 
-        $this->assertFileDoesNotExist($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
-    }
+    $this->assertFileExists($this->getTempDirectory('media').'/'.$media->id.'/test.jpg');
 
-    /** @test */
-    public function it_can_register_media_conversions_when_defining_media_collections()
-    {
-        $testModel = new class () extends TestModelWithoutMediaConversions {
-            public function registerMediaCollections(): void
-            {
-                $this
-                    ->addMediaCollection('images')
-                    ->registerMediaConversions(function (Media $media) {
-                        $this
-                            ->addMediaConversion('thumb')
-                            ->greyscale();
-                    });
-            }
-        };
+    $this->assertFileDoesNotExist($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
+});
 
-        $model = $testModel::create(['name' => 'testmodel']);
+it('can register media conversions when defining media collections', function () {
+    $testModel = new class () extends TestModelWithoutMediaConversions {
+        public function registerMediaCollections() {
+            $this
+                ->addMediaCollection('images')
+                ->registerMediaConversions(function (Media $media) {
+                    $this
+                        ->addMediaConversion('thumb')
+                        ->greyscale();
+                });
+        }
+    };
 
-        $media = $model->addMedia($this->getTestJpg())->toMediaCollection('images', 'public');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $this->assertFileExists($this->getTempDirectory('media').'/'.$media->id.'/conversions/test-thumb.jpg');
-    }
+    $media = $model->addMedia($this->getTestJpg())->toMediaCollection('images', 'public');
 
-    /** @test */
-    public function it_will_not_use_media_conversions_from_an_unrelated_collection()
-    {
-        $testModel = new class () extends TestModelWithoutMediaConversions {
-            public function registerMediaCollections(): void
-            {
-                $this
-                    ->addMediaCollection('images')
-                    ->registerMediaConversions(function (Media $media) {
-                        $this
-                            ->addMediaConversion('thumb')
-                            ->greyscale();
-                    });
-            }
-        };
+    $this->assertFileExists($this->getTempDirectory('media').'/'.$media->id.'/conversions/test-thumb.jpg');
+});
 
-        $model = $testModel::create(['name' => 'testmodel']);
+it('will not use media conversions from an unrelated collection', function () {
+    $testModel = new class () extends TestModelWithoutMediaConversions {
+        public function registerMediaCollections() {
+            $this
+                ->addMediaCollection('images')
+                ->registerMediaConversions(function (Media $media) {
+                    $this
+                        ->addMediaConversion('thumb')
+                        ->greyscale();
+                });
+        }
+    };
 
-        $media = $model->addMedia($this->getTestJpg())->toMediaCollection('unrelated-collection');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $this->assertFileDoesNotExist($this->getTempDirectory('media').'/'.$media->id.'/conversions/test-thumb.jpg');
-    }
+    $media = $model->addMedia($this->getTestJpg())->toMediaCollection('unrelated-collection');
 
-    /** @test */
-    public function it_will_use_conversions_defined_in_conversions_and_conversions_defined_in_collections()
-    {
-        $testModel = new class () extends TestModelWithoutMediaConversions {
-            public function registerMediaConversions(Media $media = null): void
-            {
-                $this
-                    ->addMediaConversion('another-thumb')
-                    ->greyscale();
-            }
+    $this->assertFileDoesNotExist($this->getTempDirectory('media').'/'.$media->id.'/conversions/test-thumb.jpg');
+});
 
-            public function registerMediaCollections(): void
-            {
-                $this
-                    ->addMediaCollection('images')
-                    ->registerMediaConversions(function (Media $media = null) {
-                        $this
-                            ->addMediaConversion('thumb')
-                            ->greyscale();
-                    });
-            }
-        };
+it('will use conversions defined in conversions and conversions defined in collections', function () {
+    $testModel = new class () extends TestModelWithoutMediaConversions {
+        public function registerMediaConversions(Media $media = null) {
+            $this
+                ->addMediaConversion('another-thumb')
+                ->greyscale();
+        }
 
-        $model = $testModel::create(['name' => 'testmodel']);
+        public function registerMediaCollections() {
+            $this
+                ->addMediaCollection('images')
+                ->registerMediaConversions(function (Media $media = null) {
+                    $this
+                        ->addMediaConversion('thumb')
+                        ->greyscale();
+                });
+        }
+    };
 
-        $media = $model->addMedia($this->getTestJpg())->toMediaCollection('images', 'public');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $this->assertFileExists($this->getTempDirectory('media').'/'.$media->id.'/conversions/test-thumb.jpg');
+    $media = $model->addMedia($this->getTestJpg())->toMediaCollection('images', 'public');
 
-        $this->assertFileExists($this->getTempDirectory('media').'/'.$media->id.'/conversions/test-another-thumb.jpg');
-    }
+    $this->assertFileExists($this->getTempDirectory('media').'/'.$media->id.'/conversions/test-thumb.jpg');
 
-    /** @test */
-    public function it_can_accept_certain_files()
-    {
-        $testModel = new class () extends TestModelWithConversion {
-            public function registerMediaCollections(): void
-            {
-                $this
-                    ->addMediaCollection('images')
-                    ->acceptsFile(fn (File $file) => $file->mimeType === 'image/jpeg');
-            }
-        };
+    $this->assertFileExists($this->getTempDirectory('media').'/'.$media->id.'/conversions/test-another-thumb.jpg');
+});
 
-        $model = $testModel::create(['name' => 'testmodel']);
+it('can accept certain files', function () {
+    $testModel = new class () extends TestModelWithConversion {
+        public function registerMediaCollections() {
+            $this
+                ->addMediaCollection('images')
+                ->acceptsFile(fn (File $file) => $file->mimeType === 'image/jpeg');
+        }
+    };
 
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $this->expectException(FileUnacceptableForCollection::class);
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
-        $model->addMedia($this->getTestPdf())->preservingOriginal()->toMediaCollection('images');
-    }
+    $this->expectException(FileUnacceptableForCollection::class);
 
-    /** @test * */
-    public function it_can_guard_against_invalid_mimetypes()
-    {
-        $testModel = new class () extends TestModelWithConversion {
-            public function registerMediaCollections(): void
-            {
-                $this
-                    ->addMediaCollection('images')
-                    ->acceptsMimeTypes(['image/jpeg']);
-            }
-        };
+    $model->addMedia($this->getTestPdf())->preservingOriginal()->toMediaCollection('images');
+});
 
-        $model = $testModel::create(['name' => 'testmodel']);
+it('can guard against invalid mimetypes', function () {
+    $testModel = new class () extends TestModelWithConversion {
+        public function registerMediaCollections() {
+            $this
+                ->addMediaCollection('images')
+                ->acceptsMimeTypes(['image/jpeg']);
+        }
+    };
 
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $this->expectException(FileUnacceptableForCollection::class);
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
-        $model->addMedia($this->getTestPdf())->preservingOriginal()->toMediaCollection('images');
-    }
+    $this->expectException(FileUnacceptableForCollection::class);
 
-    /** @test * */
-    public function it_can_generate_responsive_images()
-    {
-        $testModel = new class () extends TestModelWithConversion {
-            public function registerMediaCollections(): void
-            {
-                $this
-                    ->addMediaCollection('images')
-                    ->withResponsiveImages();
-            }
-        };
+    $model->addMedia($this->getTestPdf())->preservingOriginal()->toMediaCollection('images');
+});
 
-        $model = $testModel::create(['name' => 'testmodel']);
+it('can generate responsive images', function () {
+    $testModel = new class () extends TestModelWithConversion {
+        public function registerMediaCollections() {
+            $this
+                ->addMediaCollection('images')
+                ->withResponsiveImages();
+        }
+    };
 
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $media = $model->getMedia('images')->first();
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
-        $this->assertEquals([
-            'http://localhost/media/1/responsive-images/test___media_library_original_340_280.jpg',
-            'http://localhost/media/1/responsive-images/test___media_library_original_284_233.jpg',
-            'http://localhost/media/1/responsive-images/test___media_library_original_237_195.jpg',
-        ], $media->getResponsiveImageUrls());
+    $media = $model->getMedia('images')->first();
 
-        $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));
-    }
+    $this->assertEquals([
+        'http://localhost/media/1/responsive-images/test___media_library_original_340_280.jpg',
+        'http://localhost/media/1/responsive-images/test___media_library_original_284_233.jpg',
+        'http://localhost/media/1/responsive-images/test___media_library_original_237_195.jpg',
+    ], $media->getResponsiveImageUrls());
 
-    /** @test * */
-    public function it_can_generate_responsive_images_on_condition()
-    {
-        $testModel = new class () extends TestModelWithConversion {
-            public function registerMediaCollections(): void
-            {
-                $this
-                    ->addMediaCollection('images')
-                    ->withResponsiveImagesIf(true);
-            }
-        };
+    $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));
+});
 
-        $model = $testModel::create(['name' => 'testmodel']);
+it('can generate responsive images on condition', function () {
+    $testModel = new class () extends TestModelWithConversion {
+        public function registerMediaCollections() {
+            $this
+                ->addMediaCollection('images')
+                ->withResponsiveImagesIf(true);
+        }
+    };
 
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $media = $model->getMedia('images')->first();
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
-        $this->assertEquals([
-            'http://localhost/media/1/responsive-images/test___media_library_original_340_280.jpg',
-            'http://localhost/media/1/responsive-images/test___media_library_original_284_233.jpg',
-            'http://localhost/media/1/responsive-images/test___media_library_original_237_195.jpg',
-        ], $media->getResponsiveImageUrls());
+    $media = $model->getMedia('images')->first();
 
-        $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));
-    }
+    $this->assertEquals([
+        'http://localhost/media/1/responsive-images/test___media_library_original_340_280.jpg',
+        'http://localhost/media/1/responsive-images/test___media_library_original_284_233.jpg',
+        'http://localhost/media/1/responsive-images/test___media_library_original_237_195.jpg',
+    ], $media->getResponsiveImageUrls());
 
-    /** @test */
-    public function if_the_single_file_method_is_specified_it_will_delete_all_other_media_and_will_only_keep_the_new_one()
-    {
-        $testModel = new class () extends TestModelWithConversion {
-            public function registerMediaCollections(): void
-            {
-                $this
-                    ->addMediaCollection('images')
-                    ->singleFile();
-            }
-        };
+    $this->assertEquals([], $media->getResponsiveImageUrls('non-existing-conversion'));
+});
 
-        $model = $testModel::create(['name' => 'testmodel']);
+test('if the single file method is specified it will delete all other media and will only keep the new one', function () {
+    $testModel = new class () extends TestModelWithConversion {
+        public function registerMediaCollections() {
+            $this
+                ->addMediaCollection('images')
+                ->singleFile();
+        }
+    };
 
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $this->assertCount(1, $model->getMedia('images'));
-    }
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
-    /** @test */
-    public function if_the_only_keeps_latest_method_is_specified_it_will_delete_all_other_media_and_will_only_keep_the_latest_n_ones()
-    {
-        $testModel = new class () extends TestModelWithConversion {
-            public function registerMediaCollections(): void
-            {
-                $this
-                    ->addMediaCollection('images')
-                    ->onlyKeepLatest(3);
-            }
-        };
+    $this->assertCount(1, $model->getMedia('images'));
+});
 
-        $model = $testModel::create(['name' => 'testmodel']);
+test('if the only keeps latest method is specified it will delete all other media and will only keep the latest n ones', function () {
+    $testModel = new class () extends TestModelWithConversion {
+        public function registerMediaCollections() {
+            $this
+                ->addMediaCollection('images')
+                ->onlyKeepLatest(3);
+        }
+    };
 
-        $firstFile = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model = $testModel::create(['name' => 'testmodel']);
 
-        $this->assertFalse($model->getMedia('images')->contains(fn ($model) => $model->is($firstFile)));
-        $this->assertCount(3, $model->getMedia('images'));
-    }
-}
+    $firstFile = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+    $this->assertFalse($model->getMedia('images')->contains(fn ($model) => $model->is($firstFile)));
+    $this->assertCount(3, $model->getMedia('images'));
+});

--- a/tests/Feature/FileAdder/MultipleDiskTest.php
+++ b/tests/Feature/FileAdder/MultipleDiskTest.php
@@ -1,79 +1,66 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\FileAdder;
-
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class MultipleDiskTest extends TestCase
-{
-    /** @test */
-    public function it_can_add_a_file_to_a_named_collection_on_a_specific_disk()
-    {
-        $collectionName = 'images';
-        $diskName = 'secondMediaDisk';
+uses(TestCase::class);
 
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection($collectionName, $diskName);
+it('can add a file to a named collection on a specific disk', function () {
+    $collectionName = 'images';
+    $diskName = 'secondMediaDisk';
 
-        $this->assertEquals($collectionName, $media->collection_name);
-        $this->assertEquals($diskName, $media->disk);
-        $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
-    }
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection($collectionName, $diskName);
 
-    /** @test */
-    public function it_will_throw_an_exception_when_using_a_non_existing_disk()
-    {
-        $this->expectException(FileCannotBeAdded::class);
+    $this->assertEquals($collectionName, $media->collection_name);
+    $this->assertEquals($diskName, $media->disk);
+    $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
+});
 
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('images', 'diskdoesnotexist');
-    }
+it('will throw an exception when using a non existing disk', function () {
+    $this->expectException(FileCannotBeAdded::class);
 
-    /** @test */
-    public function it_will_save_the_derived_images_on_the_same_disk_as_the_original_file()
-    {
-        $collectionName = 'images';
-        $diskName = 'secondMediaDisk';
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('images', 'diskdoesnotexist');
+});
 
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection($collectionName, $diskName);
+it('will save the derived images on the same disk as the original file', function () {
+    $collectionName = 'images';
+    $diskName = 'secondMediaDisk';
 
-        $this->assertEquals($collectionName, $media->collection_name);
-        $this->assertEquals($diskName, $media->disk);
-        $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
-        $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/conversions/test-thumb.jpg');
-    }
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection($collectionName, $diskName);
 
-    /** @test */
-    public function it_can_generate_urls_to_media_on_an_alternative_disk()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('', 'secondMediaDisk');
+    $this->assertEquals($collectionName, $media->collection_name);
+    $this->assertEquals($diskName, $media->disk);
+    $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
+    $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/conversions/test-thumb.jpg');
+});
 
-        $this->assertEquals("/media2/{$media->id}/test.jpg", $media->getUrl());
-        $this->assertEquals("/media2/{$media->id}/conversions/test-thumb.jpg", $media->getUrl('thumb'));
-    }
+it('can generate urls to media on an alternative disk', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('', 'secondMediaDisk');
 
-    /** @test */
-    public function it_can_put_files_on_the_cloud_disk_configured_the_filesystems_config_file()
-    {
-        $collectionName = 'images';
+    $this->assertEquals("/media2/{$media->id}/test.jpg", $media->getUrl());
+    $this->assertEquals("/media2/{$media->id}/conversions/test-thumb.jpg", $media->getUrl('thumb'));
+});
 
-        $diskName = 'secondMediaDisk';
+it('can put files on the cloud disk configured the filesystems config file', function () {
+    $collectionName = 'images';
 
-        $this->app['config']->set('filesystems.cloud', 'secondMediaDisk');
+    $diskName = 'secondMediaDisk';
 
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollectionOnCloudDisk($collectionName);
+    app()['config']->set('filesystems.cloud', 'secondMediaDisk');
 
-        $this->assertEquals($collectionName, $media->collection_name);
-        $this->assertEquals($diskName, $media->disk);
-        $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
-    }
-}
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollectionOnCloudDisk($collectionName);
+
+    $this->assertEquals($collectionName, $media->collection_name);
+    $this->assertEquals($diskName, $media->disk);
+    $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
+});

--- a/tests/Feature/FileAdder/MultipleDiskTest.php
+++ b/tests/Feature/FileAdder/MultipleDiskTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can add a file to a named collection on a specific disk', function () {
     $collectionName = 'images';

--- a/tests/Feature/FileAdder/MultipleDiskTest.php
+++ b/tests/Feature/FileAdder/MultipleDiskTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can add a file to a named collection on a specific disk', function () {
     $collectionName = 'images';

--- a/tests/Feature/FileAdder/MultipleDiskTest.php
+++ b/tests/Feature/FileAdder/MultipleDiskTest.php
@@ -13,8 +13,8 @@ it('can add a file to a named collection on a specific disk', function () {
         ->addMedia($this->getTestJpg())
         ->toMediaCollection($collectionName, $diskName);
 
-    $this->assertEquals($collectionName, $media->collection_name);
-    $this->assertEquals($diskName, $media->disk);
+    expect($media->collection_name)->toEqual($collectionName);
+    expect($media->disk)->toEqual($diskName);
     $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
 });
 
@@ -34,8 +34,8 @@ it('will save the derived images on the same disk as the original file', functio
         ->addMedia($this->getTestJpg())
         ->toMediaCollection($collectionName, $diskName);
 
-    $this->assertEquals($collectionName, $media->collection_name);
-    $this->assertEquals($diskName, $media->disk);
+    expect($media->collection_name)->toEqual($collectionName);
+    expect($media->disk)->toEqual($diskName);
     $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
     $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/conversions/test-thumb.jpg');
 });
@@ -45,8 +45,8 @@ it('can generate urls to media on an alternative disk', function () {
         ->addMedia($this->getTestJpg())
         ->toMediaCollection('', 'secondMediaDisk');
 
-    $this->assertEquals("/media2/{$media->id}/test.jpg", $media->getUrl());
-    $this->assertEquals("/media2/{$media->id}/conversions/test-thumb.jpg", $media->getUrl('thumb'));
+    expect($media->getUrl())->toEqual("/media2/{$media->id}/test.jpg");
+    expect($media->getUrl('thumb'))->toEqual("/media2/{$media->id}/conversions/test-thumb.jpg");
 });
 
 it('can put files on the cloud disk configured the filesystems config file', function () {
@@ -60,7 +60,7 @@ it('can put files on the cloud disk configured the filesystems config file', fun
         ->addMedia($this->getTestJpg())
         ->toMediaCollectionOnCloudDisk($collectionName);
 
-    $this->assertEquals($collectionName, $media->collection_name);
-    $this->assertEquals($diskName, $media->disk);
+    expect($media->collection_name)->toEqual($collectionName);
+    expect($media->disk)->toEqual($diskName);
     $this->assertFileExists($this->getTempDirectory('media2').'/'.$media->id.'/test.jpg');
 });

--- a/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
@@ -12,26 +12,26 @@ beforeEach(function () {
 });
 
 it('can clear a collection', function () {
-    $this->assertCount(3, $this->testModel->getMedia('default'));
-    $this->assertCount(3, $this->testModel->getMedia('images'));
+    expect($this->testModel->getMedia('default'))->toHaveCount(3);
+    expect($this->testModel->getMedia('images'))->toHaveCount(3);
 
     $this->testModel->clearMediaCollection('images');
 
-    $this->assertCount(3, $this->testModel->getMedia('default'));
-    $this->assertCount(0, $this->testModel->getMedia('images'));
+    expect($this->testModel->getMedia('default'))->toHaveCount(3);
+    expect($this->testModel->getMedia('images'))->toHaveCount(0);
 });
 
 it('will remove the files when clearing a collection', function () {
     $ids = $this->testModel->getMedia('images')->pluck('id');
 
     $ids->map(function ($id) {
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
     });
 
     $this->testModel->clearMediaCollection('images');
 
     $ids->map(function ($id) {
-        $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
     });
 });
 
@@ -39,13 +39,13 @@ it('will remove the files when deleting a subject', function () {
     $ids = $this->testModel->getMedia('images')->pluck('id');
 
     $ids->map(function ($id) {
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
     });
 
     $this->testModel->delete();
 
     $ids->map(function ($id) {
-        $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
     });
 });
 
@@ -58,18 +58,18 @@ it('will remove the files when using a custom model and deleting it', function (
 
     addMedia($testModel);
 
-    $this->assertInstanceOf(TestCustomMediaModel::class, $testModel->getFirstMedia());
+    expect($testModel->getFirstMedia())->toBeInstanceOf(TestCustomMediaModel::class);
 
     $ids = $testModel->getMedia('images')->pluck('id');
 
     $ids->map(function ($id) {
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
     });
 
     $testModel->delete();
 
     $ids->map(function ($id) {
-        $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
     });
 });
 
@@ -77,13 +77,13 @@ it('will not remove the files when deleting a subject and preserving media', fun
     $ids = $this->testModel->getMedia('images')->pluck('id');
 
     $ids->map(function ($id) {
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
     });
 
     $this->testModel->deletePreservingMedia();
 
     $ids->map(function ($id) {
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
     });
 });
 

--- a/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use File;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestCustomMediaModel;

--- a/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
@@ -5,7 +5,6 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestCustomMediaModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     addMedia($this->testModel);

--- a/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
@@ -1,120 +1,105 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\InteractsWithMedia;
-
 use File;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestCustomMediaModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-class DeleteMediaTest extends TestCase
+uses(TestCase::class);
+
+beforeEach(function () {
+    addMedia($this->testModel);
+});
+
+it('can clear a collection', function () {
+    $this->assertCount(3, $this->testModel->getMedia('default'));
+    $this->assertCount(3, $this->testModel->getMedia('images'));
+
+    $this->testModel->clearMediaCollection('images');
+
+    $this->assertCount(3, $this->testModel->getMedia('default'));
+    $this->assertCount(0, $this->testModel->getMedia('images'));
+});
+
+it('will remove the files when clearing a collection', function () {
+    $ids = $this->testModel->getMedia('images')->pluck('id');
+
+    $ids->map(function ($id) {
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+    });
+
+    $this->testModel->clearMediaCollection('images');
+
+    $ids->map(function ($id) {
+        $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
+    });
+});
+
+it('will remove the files when deleting a subject', function () {
+    $ids = $this->testModel->getMedia('images')->pluck('id');
+
+    $ids->map(function ($id) {
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+    });
+
+    $this->testModel->delete();
+
+    $ids->map(function ($id) {
+        $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
+    });
+});
+
+it('will remove the files when using a custom model and deleting it', function () {
+    config()->set('media-library.media_model', TestCustomMediaModel::class);
+
+    (new MediaLibraryServiceProvider(app()))->boot();
+
+    $testModel = TestModel::create(['name' => 'test']);
+
+    addMedia($testModel);
+
+    $this->assertInstanceOf(TestCustomMediaModel::class, $testModel->getFirstMedia());
+
+    $ids = $testModel->getMedia('images')->pluck('id');
+
+    $ids->map(function ($id) {
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+    });
+
+    $testModel->delete();
+
+    $ids->map(function ($id) {
+        $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
+    });
+});
+
+it('will not remove the files when deleting a subject and preserving media', function () {
+    $ids = $this->testModel->getMedia('images')->pluck('id');
+
+    $ids->map(function ($id) {
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+    });
+
+    $this->testModel->deletePreservingMedia();
+
+    $ids->map(function ($id) {
+        $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
+    });
+});
+
+// Helpers
+function addMedia(TestModel $model)
 {
-    public function setUp(): void
-    {
-        parent::setUp();
+    foreach (range(1, 3) as $index) {
+        $model
+            ->addMedia(test()->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection();
 
-        $this->addMedia($this->testModel);
-    }
-
-    /** @test */
-    public function it_can_clear_a_collection()
-    {
-        $this->assertCount(3, $this->testModel->getMedia('default'));
-        $this->assertCount(3, $this->testModel->getMedia('images'));
-
-        $this->testModel->clearMediaCollection('images');
-
-        $this->assertCount(3, $this->testModel->getMedia('default'));
-        $this->assertCount(0, $this->testModel->getMedia('images'));
-    }
-
-    /** @test */
-    public function it_will_remove_the_files_when_clearing_a_collection()
-    {
-        $ids = $this->testModel->getMedia('images')->pluck('id');
-
-        $ids->map(function ($id) {
-            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
-        });
-
-        $this->testModel->clearMediaCollection('images');
-
-        $ids->map(function ($id) {
-            $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
-        });
-    }
-
-    /** @test */
-    public function it_will_remove_the_files_when_deleting_a_subject()
-    {
-        $ids = $this->testModel->getMedia('images')->pluck('id');
-
-        $ids->map(function ($id) {
-            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
-        });
-
-        $this->testModel->delete();
-
-        $ids->map(function ($id) {
-            $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
-        });
-    }
-
-    /** @test */
-    public function it_will_remove_the_files_when_using_a_custom_model_and_deleting_it()
-    {
-        config()->set('media-library.media_model', TestCustomMediaModel::class);
-
-        (new MediaLibraryServiceProvider($this->app))->boot();
-
-        $testModel = TestModel::create(['name' => 'test']);
-
-        $this->addMedia($testModel);
-
-        $this->assertInstanceOf(TestCustomMediaModel::class, $testModel->getFirstMedia());
-
-        $ids = $testModel->getMedia('images')->pluck('id');
-
-        $ids->map(function ($id) {
-            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
-        });
-
-        $testModel->delete();
-
-        $ids->map(function ($id) {
-            $this->assertFalse(File::isDirectory($this->getMediaDirectory($id)));
-        });
-    }
-
-    /** @test */
-    public function it_will_not_remove_the_files_when_deleting_a_subject_and_preserving_media()
-    {
-        $ids = $this->testModel->getMedia('images')->pluck('id');
-
-        $ids->map(function ($id) {
-            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
-        });
-
-        $this->testModel->deletePreservingMedia();
-
-        $ids->map(function ($id) {
-            $this->assertTrue(File::isDirectory($this->getMediaDirectory($id)));
-        });
-    }
-
-    private function addMedia(TestModel $model)
-    {
-        foreach (range(1, 3) as $index) {
-            $model
-                ->addMedia($this->getTestJpg())
-                ->preservingOriginal()
-                ->toMediaCollection();
-
-            $model
-                ->addMedia($this->getTestJpg())
-                ->preservingOriginal()
-                ->toMediaCollection('images');
-        }
+        $model
+            ->addMedia(test()->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection('images');
     }
 }

--- a/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/DeleteMediaTest.php
@@ -1,10 +1,8 @@
 <?php
 
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestCustomMediaModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
-
 
 beforeEach(function () {
     addMedia($this->testModel);

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\InteractsWithMedia;
-
 use DB;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
@@ -9,351 +7,307 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-class GetMediaTest extends TestCase
+uses(TestCase::class);
+
+it('can handle an empty collection', function () {
+    $emptyCollection = $this->testModel->getMedia('images');
+    $this->assertInstanceOf(Collection::class, $emptyCollection);
+    $this->assertCount(0, $emptyCollection);
+});
+
+it('will only get media from the specified collection', function () {
+    $this->assertCount(0, $this->testModel->getMedia('images'));
+    $this->assertCount(0, $this->testModel->getMedia('downloads'));
+    $this->assertCount(0, $this->testModel->getMedia());
+
+    $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection('images');
+    $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection('downloads');
+    $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection();
+
+    $this->testModel = $this->testModel->fresh();
+
+    $this->assertCount(1, $this->testModel->getMedia('images'));
+    $this->assertCount(1, $this->testModel->getMedia('downloads'));
+    $this->assertCount(1, $this->testModel->getMedia());
+});
+
+it('will return media repository', function () {
+    $this->assertInstanceOf(MediaRepository::class, $this->testModel->getMediaRepository());
+});
+
+it('returns a media collection as a laravel collection', function () {
+    $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection();
+
+    $this->assertInstanceOf(Collection::class, $this->testModel->getMedia());
+});
+
+it('returns collections filled with media objects', function () {
+    $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection();
+
+    $this->assertInstanceOf(Media::class, $this->testModel->getMedia()->first());
+});
+
+it('can get multiple media from the default collection', function () {
+    $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
+    $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
+
+    $this->assertCount(2, $this->testModel->getMedia());
+});
+
+it('can get multiple media from the default collection empty', function () {
+    $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
+
+    $this->assertCount(1, $this->testModel->getMedia());
+    $this->assertCount(0, $this->testModel->getMedia(''));
+
+    $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('');
+
+    $this->assertCount(1, $this->testModel->refresh()->getMedia());
+    $this->assertCount(1, $this->testModel->refresh()->getMedia(''));
+});
+
+it('can get files from a named collection', function () {
+    $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
+    $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+    $this->assertCount(1, $this->testModel->getMedia('images'));
+    $this->assertEquals('images', $this->testModel->getMedia('images')[0]->collection_name);
+});
+
+it('can get files from a collection using a filter', function () {
+    $media1 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter1' => 'value1'])
+        ->toMediaCollection();
+
+    $media2 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter1' => 'value2'])
+        ->toMediaCollection('images');
+
+    $media3 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter2' => 'value1'])
+        ->toMediaCollection('images');
+
+    $media4 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter2' => 'value2'])
+        ->toMediaCollection('images');
+
+    $collection = $this->testModel->getMedia('images', ['filter2' => 'value1']);
+    $this->assertCount(1, $collection);
+    $this->assertSame($collection->first()->id, $media3->id);
+});
+
+it('can get files from a collection using a filter callback', function () {
+    $media1 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter1' => 'value1'])
+        ->toMediaCollection();
+
+    $media2 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter1' => 'value2'])
+        ->toMediaCollection('images');
+
+    $media3 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter2' => 'value1'])
+        ->toMediaCollection('images');
+
+    $media4 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter2' => 'value2'])
+        ->toMediaCollection('images');
+
+    $collection = $this->testModel->getMedia('images', fn (Media $media) => isset($media->custom_properties['filter1']));
+
+    $this->assertCount(1, $collection);
+    $this->assertSame($collection->first()->id, $media2->id);
+});
+
+it('can get the first media from a collection', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $media->name = 'first';
+    $media->save();
+
+    $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $media->name = 'second';
+    $media->save();
+
+    $this->assertEquals('first', $this->testModel->getFirstMedia('images')->name);
+});
+
+it('can get the first media from a collection using a filter', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withCustomProperties(['extra_property' => 'yes'])
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+    $media->name = 'first';
+    $media->save();
+
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+    $media->name = 'second';
+    $media->save();
+
+    $this->assertEquals('first', $this->testModel->getFirstMedia('images', ['extra_property' => 'yes'])->name);
+});
+
+it('can get the first media from a collection using a filter callback', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withCustomProperties(['extra_property' => 'yes'])
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+    $media->name = 'first';
+    $media->save();
+
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+    $media->name = 'second';
+    $media->save();
+
+    $firstMedia = $this->testModel->getFirstMedia('images', fn (Media $media) => isset($media->custom_properties['extra_property']));
+
+    $this->assertEquals('first', $firstMedia->name);
+});
+
+it('can get the url to first media in a collection', function () {
+    $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $firstMedia->save();
+
+    $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $secondMedia->save();
+
+    $this->assertEquals($firstMedia->getUrl(), $this->testModel->getFirstMediaUrl('images'));
+});
+
+it('can get the path to first media in a collection', function () {
+    $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $firstMedia->save();
+
+    $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $secondMedia->save();
+
+    $this->assertEquals($firstMedia->getPath(), $this->testModel->getFirstMediaPath('images'));
+});
+
+it('can get the default path to the first media in a collection', function () {
+    $this->assertEquals('/default.jpg', $this->testModel->getFirstMediaPath('avatar'));
+});
+
+it('can get the default url to the first media in a collection', function () {
+    $this->assertEquals('/default.jpg', $this->testModel->getFirstMediaUrl('avatar'));
+});
+
+it('can get the default path to the first media in a collection if conversion not marked as generated yet', function () {
+    $media = $this
+        ->testModelWithConversionQueued
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('avatar');
+
+    $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
+    unlink($avatarThumbConversion);
+    $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
+
+    $this->assertEquals($this->getMediaDirectory("{$media->id}/test.jpg"), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
+});
+
+it('can get the correct path to the converted media in a collection if conversion is marked as generated', function () {
+    $media = $this
+        ->testModelWithConversionQueued
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('avatar');
+
+    $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
+    unlink($avatarThumbConversion);
+    $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionGenerated('avatar_thumb');
+
+    $this->assertEquals($media->getPath('avatar_thumb'), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
+});
+
+it('can get the default url to the first media in a collection if conversion not marked as generated yet', function () {
+    $media = $this
+        ->testModelWithConversionQueued
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('avatar');
+
+    $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
+    unlink($avatarThumbConversion);
+    $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
+
+    $this->assertEquals("/media/{$media->id}/test.jpg", $this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'));
+});
+
+it('will return preloaded media sorting on order column', function () {
+    $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+    $preloadedTestModel = TestModel::with('media')
+        ->where('id', $this->testModel->id)
+        ->first();
+
+    $this->assertEquals([
+        1 => 1,
+        2 => 2,
+    ], $preloadedTestModel
+        ->getMedia('images')
+        ->pluck('order_column', 'id')
+        ->map(fn ($value) => (int)$value)
+        ->toArray());
+
+    $firstMedia->order_column = 3;
+    $firstMedia->save();
+
+    $preloadedTestModel = TestModel::with('media')
+        ->where('id', $this->testModel->id)
+        ->first();
+
+    $this->assertSame([
+        2 => 2,
+        1 => 3,
+    ], $preloadedTestModel
+        ->getMedia('images')
+        ->pluck('order_column', 'id')
+        ->map(fn ($value) => (int)$value)
+        ->toArray());
+});
+
+it('will cache loaded media', function () {
+    DB::enableQueryLog();
+
+    $this->assertFalse($this->testModel->relationLoaded('media'));
+    $this->assertCount(0, DB::getQueryLog());
+
+    $this->testModel->getMedia('images');
+
+    $this->assertTrue($this->testModel->relationLoaded('media'));
+    $this->assertCount(1, DB::getQueryLog());
+
+    $this->testModel->getMedia('images');
+
+    $this->assertCount(1, DB::getQueryLog());
+
+    DB::DisableQueryLog();
+});
+
+// Helpers
+function it_returns_false_when_getting_first_media_for_an_empty_collection()
 {
-    /** @test */
-    public function it_can_handle_an_empty_collection()
-    {
-        $emptyCollection = $this->testModel->getMedia('images');
-        $this->assertInstanceOf(Collection::class, $emptyCollection);
-        $this->assertCount(0, $emptyCollection);
-    }
-
-    /** @test */
-    public function it_will_only_get_media_from_the_specified_collection()
-    {
-        $this->assertCount(0, $this->testModel->getMedia('images'));
-        $this->assertCount(0, $this->testModel->getMedia('downloads'));
-        $this->assertCount(0, $this->testModel->getMedia());
-
-        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection('images');
-        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection('downloads');
-        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection();
-
-        $this->testModel = $this->testModel->fresh();
-
-        $this->assertCount(1, $this->testModel->getMedia('images'));
-        $this->assertCount(1, $this->testModel->getMedia('downloads'));
-        $this->assertCount(1, $this->testModel->getMedia());
-    }
-
-    /** @test */
-    public function it_will_return_media_repository()
-    {
-        $this->assertInstanceOf(MediaRepository::class, $this->testModel->getMediaRepository());
-    }
-
-    /** @test */
-    public function it_returns_a_media_collection_as_a_laravel_collection()
-    {
-        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection();
-
-        $this->assertInstanceOf(Collection::class, $this->testModel->getMedia());
-    }
-
-    /** @test */
-    public function it_returns_collections_filled_with_media_objects()
-    {
-        $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection();
-
-        $this->assertInstanceOf(Media::class, $this->testModel->getMedia()->first());
-    }
-
-    /** @test */
-    public function it_can_get_multiple_media_from_the_default_collection()
-    {
-        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
-        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
-
-        $this->assertCount(2, $this->testModel->getMedia());
-    }
-
-    /** @test */
-    public function it_can_get_multiple_media_from_the_default_collection_empty()
-    {
-        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
-
-        $this->assertCount(1, $this->testModel->getMedia());
-        $this->assertCount(0, $this->testModel->getMedia(''));
-
-        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('');
-
-        $this->assertCount(1, $this->testModel->refresh()->getMedia());
-        $this->assertCount(1, $this->testModel->refresh()->getMedia(''));
-    }
-
-    /** @test */
-    public function it_can_get_files_from_a_named_collection()
-    {
-        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
-        $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-
-        $this->assertCount(1, $this->testModel->getMedia('images'));
-        $this->assertEquals('images', $this->testModel->getMedia('images')[0]->collection_name);
-    }
-
-    /** @test */
-    public function it_can_get_files_from_a_collection_using_a_filter()
-    {
-        $media1 = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withCustomProperties(['filter1' => 'value1'])
-            ->toMediaCollection();
-
-        $media2 = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withCustomProperties(['filter1' => 'value2'])
-            ->toMediaCollection('images');
-
-        $media3 = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withCustomProperties(['filter2' => 'value1'])
-            ->toMediaCollection('images');
-
-        $media4 = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withCustomProperties(['filter2' => 'value2'])
-            ->toMediaCollection('images');
-
-        $collection = $this->testModel->getMedia('images', ['filter2' => 'value1']);
-        $this->assertCount(1, $collection);
-        $this->assertSame($collection->first()->id, $media3->id);
-    }
-
-    /** @test */
-    public function it_can_get_files_from_a_collection_using_a_filter_callback()
-    {
-        $media1 = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withCustomProperties(['filter1' => 'value1'])
-            ->toMediaCollection();
-
-        $media2 = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withCustomProperties(['filter1' => 'value2'])
-            ->toMediaCollection('images');
-
-        $media3 = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withCustomProperties(['filter2' => 'value1'])
-            ->toMediaCollection('images');
-
-        $media4 = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withCustomProperties(['filter2' => 'value2'])
-            ->toMediaCollection('images');
-
-        $collection = $this->testModel->getMedia('images', fn (Media $media) => isset($media->custom_properties['filter1']));
-
-        $this->assertCount(1, $collection);
-        $this->assertSame($collection->first()->id, $media2->id);
-    }
-
-    /** @test */
-    public function it_can_get_the_first_media_from_a_collection()
-    {
-        $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $media->name = 'first';
-        $media->save();
-
-        $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $media->name = 'second';
-        $media->save();
-
-        $this->assertEquals('first', $this->testModel->getFirstMedia('images')->name);
-    }
-
-    /** @test */
-    public function it_can_get_the_first_media_from_a_collection_using_a_filter()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->withCustomProperties(['extra_property' => 'yes'])
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-        $media->name = 'first';
-        $media->save();
-
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-        $media->name = 'second';
-        $media->save();
-
-        $this->assertEquals('first', $this->testModel->getFirstMedia('images', ['extra_property' => 'yes'])->name);
-    }
-
-    /** @test */
-    public function it_can_get_the_first_media_from_a_collection_using_a_filter_callback()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->withCustomProperties(['extra_property' => 'yes'])
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-        $media->name = 'first';
-        $media->save();
-
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('images');
-        $media->name = 'second';
-        $media->save();
-
-        $firstMedia = $this->testModel->getFirstMedia('images', fn (Media $media) => isset($media->custom_properties['extra_property']));
-
-        $this->assertEquals('first', $firstMedia->name);
-    }
-
-    public function it_returns_false_when_getting_first_media_for_an_empty_collection()
-    {
-        $this->assertFalse($this->testModel->getFirstMedia());
-    }
-
-    /** @test */
-    public function it_can_get_the_url_to_first_media_in_a_collection()
-    {
-        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $firstMedia->save();
-
-        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $secondMedia->save();
-
-        $this->assertEquals($firstMedia->getUrl(), $this->testModel->getFirstMediaUrl('images'));
-    }
-
-    /** @test */
-    public function it_can_get_the_path_to_first_media_in_a_collection()
-    {
-        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $firstMedia->save();
-
-        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $secondMedia->save();
-
-        $this->assertEquals($firstMedia->getPath(), $this->testModel->getFirstMediaPath('images'));
-    }
-
-    /** @test */
-    public function it_can_get_the_default_path_to_the_first_media_in_a_collection()
-    {
-        $this->assertEquals('/default.jpg', $this->testModel->getFirstMediaPath('avatar'));
-    }
-
-    /** @test */
-    public function it_can_get_the_default_url_to_the_first_media_in_a_collection()
-    {
-        $this->assertEquals('/default.jpg', $this->testModel->getFirstMediaUrl('avatar'));
-    }
-
-    /** @test */
-    public function it_can_get_the_default_path_to_the_first_media_in_a_collection_if_conversion_not_marked_as_generated_yet()
-    {
-        $media = $this
-            ->testModelWithConversionQueued
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('avatar');
-
-        $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
-        unlink($avatarThumbConversion);
-        $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
-
-        $this->assertEquals($this->getMediaDirectory("{$media->id}/test.jpg"), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
-    }
-
-    /** @test */
-    public function it_can_get_the_correct_path_to_the_converted_media_in_a_collection_if_conversion_is_marked_as_generated()
-    {
-        $media = $this
-            ->testModelWithConversionQueued
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('avatar');
-
-        $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
-        unlink($avatarThumbConversion);
-        $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionGenerated('avatar_thumb');
-
-        $this->assertEquals($media->getPath('avatar_thumb'), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
-    }
-
-    /** @test */
-    public function it_can_get_the_default_url_to_the_first_media_in_a_collection_if_conversion_not_marked_as_generated_yet()
-    {
-        $media = $this
-            ->testModelWithConversionQueued
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('avatar');
-
-        $avatarThumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-avatar_thumb.jpg");
-        unlink($avatarThumbConversion);
-        $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
-
-        $this->assertEquals("/media/{$media->id}/test.jpg", $this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'));
-    }
-
-    /** @test */
-    public function it_will_return_preloaded_media_sorting_on_order_column()
-    {
-        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-
-        $preloadedTestModel = TestModel::with('media')
-            ->where('id', $this->testModel->id)
-            ->first();
-
-        $this->assertEquals([
-            1 => 1,
-            2 => 2,
-        ], $preloadedTestModel
-            ->getMedia('images')
-            ->pluck('order_column', 'id')
-            ->map(fn ($value) => (int)$value)
-            ->toArray());
-
-        $firstMedia->order_column = 3;
-        $firstMedia->save();
-
-        $preloadedTestModel = TestModel::with('media')
-            ->where('id', $this->testModel->id)
-            ->first();
-
-        $this->assertSame([
-            2 => 2,
-            1 => 3,
-        ], $preloadedTestModel
-            ->getMedia('images')
-            ->pluck('order_column', 'id')
-            ->map(fn ($value) => (int)$value)
-            ->toArray());
-    }
-
-    /** @test */
-    public function it_will_cache_loaded_media()
-    {
-        DB::enableQueryLog();
-
-        $this->assertFalse($this->testModel->relationLoaded('media'));
-        $this->assertCount(0, DB::getQueryLog());
-
-        $this->testModel->getMedia('images');
-
-        $this->assertTrue($this->testModel->relationLoaded('media'));
-        $this->assertCount(1, DB::getQueryLog());
-
-        $this->testModel->getMedia('images');
-
-        $this->assertCount(1, DB::getQueryLog());
-
-        DB::DisableQueryLog();
-    }
+    test()->assertFalse(test()->testModel->getFirstMedia());
 }

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -3,9 +3,7 @@
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
-
 
 it('can handle an empty collection', function () {
     $emptyCollection = $this->testModel->getMedia('images');

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -6,7 +6,6 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-uses(TestCase::class);
 
 it('can handle an empty collection', function () {
     $emptyCollection = $this->testModel->getMedia('images');

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use DB;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -10,14 +10,14 @@ uses(TestCase::class);
 
 it('can handle an empty collection', function () {
     $emptyCollection = $this->testModel->getMedia('images');
-    $this->assertInstanceOf(Collection::class, $emptyCollection);
-    $this->assertCount(0, $emptyCollection);
+    expect($emptyCollection)->toBeInstanceOf(Collection::class);
+    expect($emptyCollection)->toHaveCount(0);
 });
 
 it('will only get media from the specified collection', function () {
-    $this->assertCount(0, $this->testModel->getMedia('images'));
-    $this->assertCount(0, $this->testModel->getMedia('downloads'));
-    $this->assertCount(0, $this->testModel->getMedia());
+    expect($this->testModel->getMedia('images'))->toHaveCount(0);
+    expect($this->testModel->getMedia('downloads'))->toHaveCount(0);
+    expect($this->testModel->getMedia())->toHaveCount(0);
 
     $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection('images');
     $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection('downloads');
@@ -25,52 +25,52 @@ it('will only get media from the specified collection', function () {
 
     $this->testModel = $this->testModel->fresh();
 
-    $this->assertCount(1, $this->testModel->getMedia('images'));
-    $this->assertCount(1, $this->testModel->getMedia('downloads'));
-    $this->assertCount(1, $this->testModel->getMedia());
+    expect($this->testModel->getMedia('images'))->toHaveCount(1);
+    expect($this->testModel->getMedia('downloads'))->toHaveCount(1);
+    expect($this->testModel->getMedia())->toHaveCount(1);
 });
 
 it('will return media repository', function () {
-    $this->assertInstanceOf(MediaRepository::class, $this->testModel->getMediaRepository());
+    expect($this->testModel->getMediaRepository())->toBeInstanceOf(MediaRepository::class);
 });
 
 it('returns a media collection as a laravel collection', function () {
     $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection();
 
-    $this->assertInstanceOf(Collection::class, $this->testModel->getMedia());
+    expect($this->testModel->getMedia())->toBeInstanceOf(Collection::class);
 });
 
 it('returns collections filled with media objects', function () {
     $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection();
 
-    $this->assertInstanceOf(Media::class, $this->testModel->getMedia()->first());
+    expect($this->testModel->getMedia()->first())->toBeInstanceOf(Media::class);
 });
 
 it('can get multiple media from the default collection', function () {
     $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
     $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
 
-    $this->assertCount(2, $this->testModel->getMedia());
+    expect($this->testModel->getMedia())->toHaveCount(2);
 });
 
 it('can get multiple media from the default collection empty', function () {
     $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
 
-    $this->assertCount(1, $this->testModel->getMedia());
-    $this->assertCount(0, $this->testModel->getMedia(''));
+    expect($this->testModel->getMedia())->toHaveCount(1);
+    expect($this->testModel->getMedia(''))->toHaveCount(0);
 
     $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('');
 
-    $this->assertCount(1, $this->testModel->refresh()->getMedia());
-    $this->assertCount(1, $this->testModel->refresh()->getMedia(''));
+    expect($this->testModel->refresh()->getMedia())->toHaveCount(1);
+    expect($this->testModel->refresh()->getMedia(''))->toHaveCount(1);
 });
 
 it('can get files from a named collection', function () {
     $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
     $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
-    $this->assertCount(1, $this->testModel->getMedia('images'));
-    $this->assertEquals('images', $this->testModel->getMedia('images')[0]->collection_name);
+    expect($this->testModel->getMedia('images'))->toHaveCount(1);
+    expect($this->testModel->getMedia('images')[0]->collection_name)->toEqual('images');
 });
 
 it('can get files from a collection using a filter', function () {
@@ -99,8 +99,8 @@ it('can get files from a collection using a filter', function () {
         ->toMediaCollection('images');
 
     $collection = $this->testModel->getMedia('images', ['filter2' => 'value1']);
-    $this->assertCount(1, $collection);
-    $this->assertSame($collection->first()->id, $media3->id);
+    expect($collection)->toHaveCount(1);
+    expect($media3->id)->toBe($collection->first()->id);
 });
 
 it('can get files from a collection using a filter callback', function () {
@@ -130,8 +130,8 @@ it('can get files from a collection using a filter callback', function () {
 
     $collection = $this->testModel->getMedia('images', fn (Media $media) => isset($media->custom_properties['filter1']));
 
-    $this->assertCount(1, $collection);
-    $this->assertSame($collection->first()->id, $media2->id);
+    expect($collection)->toHaveCount(1);
+    expect($media2->id)->toBe($collection->first()->id);
 });
 
 it('can get the first media from a collection', function () {
@@ -143,7 +143,7 @@ it('can get the first media from a collection', function () {
     $media->name = 'second';
     $media->save();
 
-    $this->assertEquals('first', $this->testModel->getFirstMedia('images')->name);
+    expect($this->testModel->getFirstMedia('images')->name)->toEqual('first');
 });
 
 it('can get the first media from a collection using a filter', function () {
@@ -162,7 +162,7 @@ it('can get the first media from a collection using a filter', function () {
     $media->name = 'second';
     $media->save();
 
-    $this->assertEquals('first', $this->testModel->getFirstMedia('images', ['extra_property' => 'yes'])->name);
+    expect($this->testModel->getFirstMedia('images', ['extra_property' => 'yes'])->name)->toEqual('first');
 });
 
 it('can get the first media from a collection using a filter callback', function () {
@@ -183,7 +183,7 @@ it('can get the first media from a collection using a filter callback', function
 
     $firstMedia = $this->testModel->getFirstMedia('images', fn (Media $media) => isset($media->custom_properties['extra_property']));
 
-    $this->assertEquals('first', $firstMedia->name);
+    expect($firstMedia->name)->toEqual('first');
 });
 
 it('can get the url to first media in a collection', function () {
@@ -193,7 +193,7 @@ it('can get the url to first media in a collection', function () {
     $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
     $secondMedia->save();
 
-    $this->assertEquals($firstMedia->getUrl(), $this->testModel->getFirstMediaUrl('images'));
+    expect($this->testModel->getFirstMediaUrl('images'))->toEqual($firstMedia->getUrl());
 });
 
 it('can get the path to first media in a collection', function () {
@@ -203,15 +203,15 @@ it('can get the path to first media in a collection', function () {
     $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
     $secondMedia->save();
 
-    $this->assertEquals($firstMedia->getPath(), $this->testModel->getFirstMediaPath('images'));
+    expect($this->testModel->getFirstMediaPath('images'))->toEqual($firstMedia->getPath());
 });
 
 it('can get the default path to the first media in a collection', function () {
-    $this->assertEquals('/default.jpg', $this->testModel->getFirstMediaPath('avatar'));
+    expect($this->testModel->getFirstMediaPath('avatar'))->toEqual('/default.jpg');
 });
 
 it('can get the default url to the first media in a collection', function () {
-    $this->assertEquals('/default.jpg', $this->testModel->getFirstMediaUrl('avatar'));
+    expect($this->testModel->getFirstMediaUrl('avatar'))->toEqual('/default.jpg');
 });
 
 it('can get the default path to the first media in a collection if conversion not marked as generated yet', function () {
@@ -224,7 +224,7 @@ it('can get the default path to the first media in a collection if conversion no
     unlink($avatarThumbConversion);
     $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
 
-    $this->assertEquals($this->getMediaDirectory("{$media->id}/test.jpg"), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
+    expect($this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'))->toEqual($this->getMediaDirectory("{$media->id}/test.jpg"));
 });
 
 it('can get the correct path to the converted media in a collection if conversion is marked as generated', function () {
@@ -237,7 +237,7 @@ it('can get the correct path to the converted media in a collection if conversio
     unlink($avatarThumbConversion);
     $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionGenerated('avatar_thumb');
 
-    $this->assertEquals($media->getPath('avatar_thumb'), $this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'));
+    expect($this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'))->toEqual($media->getPath('avatar_thumb'));
 });
 
 it('can get the default url to the first media in a collection if conversion not marked as generated yet', function () {
@@ -250,7 +250,7 @@ it('can get the default url to the first media in a collection if conversion not
     unlink($avatarThumbConversion);
     $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
 
-    $this->assertEquals("/media/{$media->id}/test.jpg", $this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'));
+    expect($this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'))->toEqual("/media/{$media->id}/test.jpg");
 });
 
 it('will return preloaded media sorting on order column', function () {
@@ -290,17 +290,17 @@ it('will return preloaded media sorting on order column', function () {
 it('will cache loaded media', function () {
     DB::enableQueryLog();
 
-    $this->assertFalse($this->testModel->relationLoaded('media'));
-    $this->assertCount(0, DB::getQueryLog());
+    expect($this->testModel->relationLoaded('media'))->toBeFalse();
+    expect(DB::getQueryLog())->toHaveCount(0);
 
     $this->testModel->getMedia('images');
 
-    $this->assertTrue($this->testModel->relationLoaded('media'));
-    $this->assertCount(1, DB::getQueryLog());
+    expect($this->testModel->relationLoaded('media'))->toBeTrue();
+    expect(DB::getQueryLog())->toHaveCount(1);
 
     $this->testModel->getMedia('images');
 
-    $this->assertCount(1, DB::getQueryLog());
+    expect(DB::getQueryLog())->toHaveCount(1);
 
     DB::DisableQueryLog();
 });
@@ -308,5 +308,5 @@ it('will cache loaded media', function () {
 // Helpers
 function it_returns_false_when_getting_first_media_for_an_empty_collection()
 {
-    test()->assertFalse(test()->testModel->getFirstMedia());
+    expect(test()->testModel->getFirstMedia())->toBeFalse();
 }

--- a/tests/Feature/InteractsWithMedia/HasMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/HasMediaTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 it('returns false for an empty collection', function () {

--- a/tests/Feature/InteractsWithMedia/HasMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/HasMediaTest.php
@@ -1,66 +1,49 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\InteractsWithMedia;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class HasMediaTest extends TestCase
-{
-    /** @test */
-    public function it_returns_false_for_an_empty_collection()
-    {
-        $this->assertFalse($this->testModel->hasMedia());
-    }
+uses(TestCase::class);
 
-    /** @test */
-    public function it_returns_true_for_a_non_empty_collection()
-    {
-        $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+it('returns false for an empty collection', function () {
+    $this->assertFalse($this->testModel->hasMedia());
+});
 
-        $this->assertTrue($this->testModel->hasMedia());
-    }
+it('returns true for a non empty collection', function () {
+    $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-    /** @test */
-    public function it_returns_true_for_a_non_empty_collection_in_an_unsaved_model()
-    {
-        $this->testUnsavedModel->addMedia($this->getTestJpg())->toMediaCollection();
+    $this->assertTrue($this->testModel->hasMedia());
+});
 
-        $this->assertTrue($this->testUnsavedModel->hasMedia());
-    }
+it('returns true for a non empty collection in an unsaved model', function () {
+    $this->testUnsavedModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-    /** @test */
-    public function it_returns_true_if_any_collection_is_not_empty()
-    {
-        $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $this->assertTrue($this->testUnsavedModel->hasMedia());
+});
 
-        $this->assertTrue($this->testModel->hasMedia('images'));
-    }
+it('returns true if any collection is not empty', function () {
+    $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    /** @test */
-    public function it_returns_false_for_an_empty_named_collection()
-    {
-        $this->assertFalse($this->testModel->hasMedia('images'));
-    }
+    $this->assertTrue($this->testModel->hasMedia('images'));
+});
 
-    /** @test */
-    public function it_returns_true_for_a_non_empty_named_collection()
-    {
-        $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+it('returns false for an empty named collection', function () {
+    $this->assertFalse($this->testModel->hasMedia('images'));
+});
 
-        $this->assertTrue($this->testModel->hasMedia('images'));
-        $this->assertFalse($this->testModel->hasMedia('downloads'));
-    }
+it('returns true for a non empty named collection', function () {
+    $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    /** @test */
-    public function it_returns_true_for_a_filtered_collection()
-    {
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->withCustomProperties(['test' => true])
-            ->toMediaCollection();
+    $this->assertTrue($this->testModel->hasMedia('images'));
+    $this->assertFalse($this->testModel->hasMedia('downloads'));
+});
 
-        $this->assertTrue($this->testModel->hasMedia('default'));
-        $this->assertTrue($this->testModel->hasMedia('default', ['test' => true]));
-        $this->assertFalse($this->testModel->hasMedia('default', ['test' => false]));
-    }
-}
+it('returns true for a filtered collection', function () {
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withCustomProperties(['test' => true])
+        ->toMediaCollection();
+
+    $this->assertTrue($this->testModel->hasMedia('default'));
+    $this->assertTrue($this->testModel->hasMedia('default', ['test' => true]));
+    $this->assertFalse($this->testModel->hasMedia('default', ['test' => false]));
+});

--- a/tests/Feature/InteractsWithMedia/HasMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/HasMediaTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('returns false for an empty collection', function () {
     expect($this->testModel->hasMedia())->toBeFalse();

--- a/tests/Feature/InteractsWithMedia/HasMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/HasMediaTest.php
@@ -5,36 +5,36 @@ use Spatie\MediaLibrary\Tests\TestCase;
 uses(TestCase::class);
 
 it('returns false for an empty collection', function () {
-    $this->assertFalse($this->testModel->hasMedia());
+    expect($this->testModel->hasMedia())->toBeFalse();
 });
 
 it('returns true for a non empty collection', function () {
     $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-    $this->assertTrue($this->testModel->hasMedia());
+    expect($this->testModel->hasMedia())->toBeTrue();
 });
 
 it('returns true for a non empty collection in an unsaved model', function () {
     $this->testUnsavedModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-    $this->assertTrue($this->testUnsavedModel->hasMedia());
+    expect($this->testUnsavedModel->hasMedia())->toBeTrue();
 });
 
 it('returns true if any collection is not empty', function () {
     $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    $this->assertTrue($this->testModel->hasMedia('images'));
+    expect($this->testModel->hasMedia('images'))->toBeTrue();
 });
 
 it('returns false for an empty named collection', function () {
-    $this->assertFalse($this->testModel->hasMedia('images'));
+    expect($this->testModel->hasMedia('images'))->toBeFalse();
 });
 
 it('returns true for a non empty named collection', function () {
     $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    $this->assertTrue($this->testModel->hasMedia('images'));
-    $this->assertFalse($this->testModel->hasMedia('downloads'));
+    expect($this->testModel->hasMedia('images'))->toBeTrue();
+    expect($this->testModel->hasMedia('downloads'))->toBeFalse();
 });
 
 it('returns true for a filtered collection', function () {
@@ -43,7 +43,7 @@ it('returns true for a filtered collection', function () {
         ->withCustomProperties(['test' => true])
         ->toMediaCollection();
 
-    $this->assertTrue($this->testModel->hasMedia('default'));
-    $this->assertTrue($this->testModel->hasMedia('default', ['test' => true]));
-    $this->assertFalse($this->testModel->hasMedia('default', ['test' => false]));
+    expect($this->testModel->hasMedia('default'))->toBeTrue();
+    expect($this->testModel->hasMedia('default', ['test' => true]))->toBeTrue();
+    expect($this->testModel->hasMedia('default', ['test' => false]))->toBeFalse();
 });

--- a/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $this->testModel->addMedia($this->getTestJpg())->usingName('test1')->preservingOriginal()->toMediaCollection();

--- a/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 beforeEach(function () {

--- a/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
@@ -1,88 +1,70 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\InteractsWithMedia;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class UpdateMediaTest extends TestCase
-{
-    public function setUp(): void
-    {
-        parent::setUp();
+uses(TestCase::class);
 
-        $this->testModel->addMedia($this->getTestJpg())->usingName('test1')->preservingOriginal()->toMediaCollection();
-        $this->testModel->addMedia($this->getTestJpg())->usingName('test2')->preservingOriginal()->toMediaCollection();
-    }
+beforeEach(function () {
+    $this->testModel->addMedia($this->getTestJpg())->usingName('test1')->preservingOriginal()->toMediaCollection();
+    $this->testModel->addMedia($this->getTestJpg())->usingName('test2')->preservingOriginal()->toMediaCollection();
+});
 
-    /** @test */
-    public function it_removes_a_media_item_if_its_not_in_the_update_array()
-    {
-        $mediaArray = $this->testModel->media->toArray();
-        unset($mediaArray[0]);
+it('removes a media item if its not in the update array', function () {
+    $mediaArray = $this->testModel->media->toArray();
+    unset($mediaArray[0]);
 
-        $this->testModel->updateMedia($mediaArray);
-        $this->testModel->load('media');
+    $this->testModel->updateMedia($mediaArray);
+    $this->testModel->load('media');
 
-        $this->assertCount(1, $this->testModel->media);
-        $this->assertEquals('test2', $this->testModel->getFirstMedia()->name);
-    }
+    $this->assertCount(1, $this->testModel->media);
+    $this->assertEquals('test2', $this->testModel->getFirstMedia()->name);
+});
 
-    /** @test */
-    public function it_removes_a_media_item_with_eager_loaded_relation()
-    {
-        $mediaArray = $this->testModel->media->toArray();
-        unset($mediaArray[0]);
+it('removes a media item with eager loaded relation', function () {
+    $mediaArray = $this->testModel->media->toArray();
+    unset($mediaArray[0]);
 
-        $this->testModel->load('media');
-        $this->testModel->updateMedia($mediaArray);
+    $this->testModel->load('media');
+    $this->testModel->updateMedia($mediaArray);
 
-        $this->assertCount(1, $this->testModel->media);
-        $this->assertEquals('test2', $this->testModel->getFirstMedia()->name);
-    }
+    $this->assertCount(1, $this->testModel->media);
+    $this->assertEquals('test2', $this->testModel->getFirstMedia()->name);
+});
 
-    /** @test */
-    public function it_renames_media_items()
-    {
-        $mediaArray = $this->testModel->media->toArray();
+it('renames media items', function () {
+    $mediaArray = $this->testModel->media->toArray();
 
-        $mediaArray[0]['name'] = 'testFoo';
-        $mediaArray[1]['name'] = 'testBar';
+    $mediaArray[0]['name'] = 'testFoo';
+    $mediaArray[1]['name'] = 'testBar';
 
-        $this->testModel->updateMedia($mediaArray);
-        $this->testModel->load('media');
+    $this->testModel->updateMedia($mediaArray);
+    $this->testModel->load('media');
 
-        $this->assertEquals('testFoo', $this->testModel->media[0]->name);
-        $this->assertEquals('testBar', $this->testModel->media[1]->name);
-    }
+    $this->assertEquals('testFoo', $this->testModel->media[0]->name);
+    $this->assertEquals('testBar', $this->testModel->media[1]->name);
+});
 
-    /** @test */
-    public function it_updates_media_item_custom_properties()
-    {
-        $mediaArray = $this->testModel->media->toArray();
+it('updates media item custom properties', function () {
+    $mediaArray = $this->testModel->media->toArray();
 
-        $mediaArray[0]['custom_properties']['foo'] = 'bar';
+    $mediaArray[0]['custom_properties']['foo'] = 'bar';
 
-        $this->testModel->updateMedia($mediaArray);
-        $this->testModel->load('media');
+    $this->testModel->updateMedia($mediaArray);
+    $this->testModel->load('media');
 
-        $this->assertEquals('bar', $this->testModel->media[0]->getCustomProperty('foo'));
-    }
+    $this->assertEquals('bar', $this->testModel->media[0]->getCustomProperty('foo'));
+});
 
-    /**
-     * @test
-     */
-    public function it_reorders_media_items()
-    {
-        $mediaArray = $this->testModel->media->toArray();
+it('reorders media items', function () {
+    $mediaArray = $this->testModel->media->toArray();
 
-        $differentOrder = array_reverse($mediaArray);
+    $differentOrder = array_reverse($mediaArray);
 
-        $this->testModel->updateMedia($differentOrder);
-        $this->testModel->load('media');
+    $this->testModel->updateMedia($differentOrder);
+    $this->testModel->load('media');
 
-        $orderedMedia = $this->testModel->media->sortBy('order_column');
+    $orderedMedia = $this->testModel->media->sortBy('order_column');
 
-        $this->assertEquals($mediaArray[0]['order_column'], $orderedMedia[1]->order_column);
-        $this->assertEquals($mediaArray[1]['order_column'], $orderedMedia[0]->order_column);
-    }
-}
+    $this->assertEquals($mediaArray[0]['order_column'], $orderedMedia[1]->order_column);
+    $this->assertEquals($mediaArray[1]['order_column'], $orderedMedia[0]->order_column);
+});

--- a/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
@@ -16,8 +16,8 @@ it('removes a media item if its not in the update array', function () {
     $this->testModel->updateMedia($mediaArray);
     $this->testModel->load('media');
 
-    $this->assertCount(1, $this->testModel->media);
-    $this->assertEquals('test2', $this->testModel->getFirstMedia()->name);
+    expect($this->testModel->media)->toHaveCount(1);
+    expect($this->testModel->getFirstMedia()->name)->toEqual('test2');
 });
 
 it('removes a media item with eager loaded relation', function () {
@@ -27,8 +27,8 @@ it('removes a media item with eager loaded relation', function () {
     $this->testModel->load('media');
     $this->testModel->updateMedia($mediaArray);
 
-    $this->assertCount(1, $this->testModel->media);
-    $this->assertEquals('test2', $this->testModel->getFirstMedia()->name);
+    expect($this->testModel->media)->toHaveCount(1);
+    expect($this->testModel->getFirstMedia()->name)->toEqual('test2');
 });
 
 it('renames media items', function () {
@@ -40,8 +40,8 @@ it('renames media items', function () {
     $this->testModel->updateMedia($mediaArray);
     $this->testModel->load('media');
 
-    $this->assertEquals('testFoo', $this->testModel->media[0]->name);
-    $this->assertEquals('testBar', $this->testModel->media[1]->name);
+    expect($this->testModel->media[0]->name)->toEqual('testFoo');
+    expect($this->testModel->media[1]->name)->toEqual('testBar');
 });
 
 it('updates media item custom properties', function () {
@@ -52,7 +52,7 @@ it('updates media item custom properties', function () {
     $this->testModel->updateMedia($mediaArray);
     $this->testModel->load('media');
 
-    $this->assertEquals('bar', $this->testModel->media[0]->getCustomProperty('foo'));
+    expect($this->testModel->media[0]->getCustomProperty('foo'))->toEqual('bar');
 });
 
 it('reorders media items', function () {
@@ -65,6 +65,6 @@ it('reorders media items', function () {
 
     $orderedMedia = $this->testModel->media->sortBy('order_column');
 
-    $this->assertEquals($mediaArray[0]['order_column'], $orderedMedia[1]->order_column);
-    $this->assertEquals($mediaArray[1]['order_column'], $orderedMedia[0]->order_column);
+    expect($orderedMedia[1]->order_column)->toEqual($mediaArray[0]['order_column']);
+    expect($orderedMedia[0]->order_column)->toEqual($mediaArray[1]['order_column']);
 });

--- a/tests/Feature/Media/CopyTest.php
+++ b/tests/Feature/Media/CopyTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-uses(TestCase::class);
 
 it('can copy media from one model to another', function () {
     /** @var TestModel $model */

--- a/tests/Feature/Media/CopyTest.php
+++ b/tests/Feature/Media/CopyTest.php
@@ -1,166 +1,153 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-class CopyTest extends TestCase
-{
-    /** @test */
-    public function it_can_copy_media_from_one_model_to_another()
-    {
-        /** @var TestModel $model */
-        $model = TestModel::create(['name' => 'test']);
+uses(TestCase::class);
 
-        /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
-        $media = $model
-            ->addMedia($this->getTestJpg())
-            ->usingName('custom-name')
-            ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
-            ->toMediaCollection();
+it('can copy media from one model to another', function () {
+    /** @var TestModel $model */
+    $model = TestModel::create(['name' => 'test']);
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    $media = $model
+        ->addMedia($this->getTestJpg())
+        ->usingName('custom-name')
+        ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
+        ->toMediaCollection();
 
-        $anotherModel = TestModel::create(['name' => 'another-test']);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
 
-        $movedMedia = $media->copy($anotherModel, 'images');
+    $anotherModel = TestModel::create(['name' => 'another-test']);
 
-        $movedMedia->refresh();
+    $movedMedia = $media->copy($anotherModel, 'images');
 
-        $this->assertCount(1, $model->getMedia('default'));
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+    $movedMedia->refresh();
 
-        $this->assertCount(1, $anotherModel->getMedia('images'));
-        $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/test.jpg'));
-        $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-        $this->assertEquals($movedMedia->name, 'custom-name');
-        $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+    $this->assertCount(1, $model->getMedia('default'));
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+
+    $this->assertCount(1, $anotherModel->getMedia('images'));
+    $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/test.jpg'));
+    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
+    $this->assertEquals($movedMedia->name, 'custom-name');
+    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+});
+
+it('can copy file without extension', function () {
+    if (! file_exists(storage_path('media-library/temp'))) {
+        mkdir(storage_path('media-library/temp'), 0777, true);
     }
 
-    /** @test */
-    public function it_can_copy_file_without_extension()
-    {
-        if (! file_exists(storage_path('media-library/temp'))) {
-            mkdir(storage_path('media-library/temp'), 0777, true);
-        }
+    config(['media-library.temporary_directory_path' => realpath(storage_path('media-library/temp'))]);
 
-        config(['media-library.temporary_directory_path' => realpath(storage_path('media-library/temp'))]);
+    /** @var TestModel $model */
+    $model = TestModel::create(['name' => 'test']);
 
-        /** @var TestModel $model */
-        $model = TestModel::create(['name' => 'test']);
+    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    $media = $model
+        ->addMedia($this->getTestImageWithoutExtension())
+        ->usingName('custom-name')
+        ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
+        ->toMediaCollection();
 
-        /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
-        $media = $model
-            ->addMedia($this->getTestImageWithoutExtension())
-            ->usingName('custom-name')
-            ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
-            ->toMediaCollection();
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/image'));
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/image'));
+    $anotherModel = TestModel::create(['name' => 'another-test']);
 
-        $anotherModel = TestModel::create(['name' => 'another-test']);
+    $movedMedia = $media->copy($anotherModel, 'images');
 
-        $movedMedia = $media->copy($anotherModel, 'images');
+    $movedMedia->refresh();
 
-        $movedMedia->refresh();
+    $this->assertCount(1, $model->getMedia('default'));
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/image'));
 
-        $this->assertCount(1, $model->getMedia('default'));
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/image'));
+    $this->assertCount(1, $anotherModel->getMedia('images'));
+    $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/image'));
+    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
+    $this->assertEquals($movedMedia->name, 'custom-name');
+    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+});
 
-        $this->assertCount(1, $anotherModel->getMedia('images'));
-        $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/image'));
-        $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-        $this->assertEquals($movedMedia->name, 'custom-name');
-        $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+it('can copy media from one model to another on a specific disk', function () {
+    $diskName = 'secondMediaDisk';
+
+    /** @var TestModel $model */
+    $model = TestModel::create(['name' => 'test']);
+
+    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    $media = $model
+        ->addMedia($this->getTestJpg())
+        ->usingName('custom-name')
+        ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
+        ->toMediaCollection();
+
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+
+    $anotherModel = TestModel::create(['name' => 'another-test']);
+
+    $movedMedia = $media->copy($anotherModel, 'images', $diskName);
+
+    $movedMedia->refresh();
+
+    $this->assertCount(1, $model->getMedia('default'));
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+
+    $this->assertCount(1, $anotherModel->getMedia('images'));
+    $this->assertFileExists($this->getTempDirectory('media2').'/'.$movedMedia->id.'/test.jpg');
+    $this->assertEquals($movedMedia->collection_name, 'images');
+    $this->assertEquals($movedMedia->disk, $diskName);
+    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
+    $this->assertEquals($movedMedia->name, 'custom-name');
+    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+});
+
+it('can copy file with accent', function () {
+    if (! file_exists(storage_path('media-library/temp'))) {
+        mkdir(storage_path('media-library/temp'), 0777, true);
     }
 
-    /** @test */
-    public function it_can_copy_media_from_one_model_to_another_on_a_specific_disk()
-    {
-        $diskName = 'secondMediaDisk';
+    config(['media-library.temporary_directory_path' => realpath(storage_path('media-library/temp'))]);
 
-        /** @var TestModel $model */
-        $model = TestModel::create(['name' => 'test']);
+    /** @var TestModel $model */
+    $model = TestModel::create(['name' => 'test']);
 
-        /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
-        $media = $model
-            ->addMedia($this->getTestJpg())
-            ->usingName('custom-name')
-            ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
-            ->toMediaCollection();
+    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    $media = $model
+        ->addMedia($this->getAntaresThumbJpgWithAccent())
+        ->usingName('custom-name')
+        ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
+        ->toMediaCollection();
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/antarèsthumb.jpg'));
 
-        $anotherModel = TestModel::create(['name' => 'another-test']);
+    $anotherModel = TestModel::create(['name' => 'another-test']);
 
-        $movedMedia = $media->copy($anotherModel, 'images', $diskName);
+    $movedMedia = $media->copy($anotherModel, 'images');
 
-        $movedMedia->refresh();
+    $movedMedia->refresh();
 
-        $this->assertCount(1, $model->getMedia('default'));
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+    $this->assertCount(1, $model->getMedia('default'));
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/antarèsthumb.jpg'));
 
-        $this->assertCount(1, $anotherModel->getMedia('images'));
-        $this->assertFileExists($this->getTempDirectory('media2').'/'.$movedMedia->id.'/test.jpg');
-        $this->assertEquals($movedMedia->collection_name, 'images');
-        $this->assertEquals($movedMedia->disk, $diskName);
-        $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-        $this->assertEquals($movedMedia->name, 'custom-name');
-        $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
-    }
+    $this->assertCount(1, $anotherModel->getMedia('images'));
+    $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/antarèsthumb.jpg'));
+    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
+    $this->assertEquals($movedMedia->name, 'custom-name');
+    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+});
 
-    /** @test */
-    public function it_can_copy_file_with_accent()
-    {
-        if (! file_exists(storage_path('media-library/temp'))) {
-            mkdir(storage_path('media-library/temp'), 0777, true);
-        }
+it('preserves original file on copy media item to model', function () {
+    $model = TestModel::create(['name' => 'original']);
 
-        config(['media-library.temporary_directory_path' => realpath(storage_path('media-library/temp'))]);
+    $media = $model
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
 
-        /** @var TestModel $model */
-        $model = TestModel::create(['name' => 'test']);
+    $anotherModel = TestModel::create(['name' => 'target']);
 
-        /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
-        $media = $model
-            ->addMedia($this->getAntaresThumbJpgWithAccent())
-            ->usingName('custom-name')
-            ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
-            ->toMediaCollection();
+    $anotherMedia = $media->copy($anotherModel);
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/antarèsthumb.jpg'));
-
-        $anotherModel = TestModel::create(['name' => 'another-test']);
-
-        $movedMedia = $media->copy($anotherModel, 'images');
-
-        $movedMedia->refresh();
-
-        $this->assertCount(1, $model->getMedia('default'));
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/antarèsthumb.jpg'));
-
-        $this->assertCount(1, $anotherModel->getMedia('images'));
-        $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/antarèsthumb.jpg'));
-        $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-        $this->assertEquals($movedMedia->name, 'custom-name');
-        $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
-    }
-
-    /** @test */
-    public function it_preserves_original_file_on_copy_media_item_to_model()
-    {
-        $model = TestModel::create(['name' => 'original']);
-
-        $media = $model
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
-
-        $anotherModel = TestModel::create(['name' => 'target']);
-
-        $anotherMedia = $media->copy($anotherModel);
-
-        $this->assertFileExists($media->getPath());
-        $this->assertFileExists($anotherMedia->getPath());
-    }
-}
+    $this->assertFileExists($media->getPath());
+    $this->assertFileExists($anotherMedia->getPath());
+});

--- a/tests/Feature/Media/CopyTest.php
+++ b/tests/Feature/Media/CopyTest.php
@@ -24,14 +24,14 @@ it('can copy media from one model to another', function () {
 
     $movedMedia->refresh();
 
-    $this->assertCount(1, $model->getMedia('default'));
+    expect($model->getMedia('default'))->toHaveCount(1);
     $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
 
-    $this->assertCount(1, $anotherModel->getMedia('images'));
+    expect($anotherModel->getMedia('images'))->toHaveCount(1);
     $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/test.jpg'));
-    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-    $this->assertEquals($movedMedia->name, 'custom-name');
-    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+    expect($anotherModel->id)->toEqual($movedMedia->model->id);
+    expect('custom-name')->toEqual($movedMedia->name);
+    expect('custom-property-value')->toEqual($movedMedia->getCustomProperty('custom-property-name'));
 });
 
 it('can copy file without extension', function () {
@@ -59,14 +59,14 @@ it('can copy file without extension', function () {
 
     $movedMedia->refresh();
 
-    $this->assertCount(1, $model->getMedia('default'));
+    expect($model->getMedia('default'))->toHaveCount(1);
     $this->assertFileExists($this->getMediaDirectory($media->id.'/image'));
 
-    $this->assertCount(1, $anotherModel->getMedia('images'));
+    expect($anotherModel->getMedia('images'))->toHaveCount(1);
     $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/image'));
-    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-    $this->assertEquals($movedMedia->name, 'custom-name');
-    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+    expect($anotherModel->id)->toEqual($movedMedia->model->id);
+    expect('custom-name')->toEqual($movedMedia->name);
+    expect('custom-property-value')->toEqual($movedMedia->getCustomProperty('custom-property-name'));
 });
 
 it('can copy media from one model to another on a specific disk', function () {
@@ -90,16 +90,16 @@ it('can copy media from one model to another on a specific disk', function () {
 
     $movedMedia->refresh();
 
-    $this->assertCount(1, $model->getMedia('default'));
+    expect($model->getMedia('default'))->toHaveCount(1);
     $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
 
-    $this->assertCount(1, $anotherModel->getMedia('images'));
+    expect($anotherModel->getMedia('images'))->toHaveCount(1);
     $this->assertFileExists($this->getTempDirectory('media2').'/'.$movedMedia->id.'/test.jpg');
-    $this->assertEquals($movedMedia->collection_name, 'images');
-    $this->assertEquals($movedMedia->disk, $diskName);
-    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-    $this->assertEquals($movedMedia->name, 'custom-name');
-    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+    expect('images')->toEqual($movedMedia->collection_name);
+    expect($diskName)->toEqual($movedMedia->disk);
+    expect($anotherModel->id)->toEqual($movedMedia->model->id);
+    expect('custom-name')->toEqual($movedMedia->name);
+    expect('custom-property-value')->toEqual($movedMedia->getCustomProperty('custom-property-name'));
 });
 
 it('can copy file with accent', function () {
@@ -127,14 +127,14 @@ it('can copy file with accent', function () {
 
     $movedMedia->refresh();
 
-    $this->assertCount(1, $model->getMedia('default'));
+    expect($model->getMedia('default'))->toHaveCount(1);
     $this->assertFileExists($this->getMediaDirectory($media->id.'/antarèsthumb.jpg'));
 
-    $this->assertCount(1, $anotherModel->getMedia('images'));
+    expect($anotherModel->getMedia('images'))->toHaveCount(1);
     $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/antarèsthumb.jpg'));
-    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-    $this->assertEquals($movedMedia->name, 'custom-name');
-    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+    expect($anotherModel->id)->toEqual($movedMedia->model->id);
+    expect('custom-name')->toEqual($movedMedia->name);
+    expect('custom-property-value')->toEqual($movedMedia->getCustomProperty('custom-property-name'));
 });
 
 it('preserves original file on copy media item to model', function () {
@@ -148,6 +148,6 @@ it('preserves original file on copy media item to model', function () {
 
     $anotherMedia = $media->copy($anotherModel);
 
-    $this->assertFileExists($media->getPath());
-    $this->assertFileExists($anotherMedia->getPath());
+    expect($media->getPath())->toBeFile();
+    expect($anotherMedia->getPath())->toBeFile();
 });

--- a/tests/Feature/Media/CopyTest.php
+++ b/tests/Feature/Media/CopyTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
-
 
 it('can copy media from one model to another', function () {
     /** @var TestModel $model */

--- a/tests/Feature/Media/CustomHeadersTest.php
+++ b/tests/Feature/Media/CustomHeadersTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 it('does not set empty custom headers when saved', function () {

--- a/tests/Feature/Media/CustomHeadersTest.php
+++ b/tests/Feature/Media/CustomHeadersTest.php
@@ -1,35 +1,28 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class CustomHeadersTest extends TestCase
-{
-    /** @test */
-    public function it_does_not_set_empty_custom_headers_when_saved()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
+uses(TestCase::class);
 
-        $this->assertFalse($media->hasCustomProperty('custom_headers'));
-        $this->assertEquals([], $media->getCustomHeaders());
-    }
+it('does not set empty custom headers when saved', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
 
-    /** @test */
-    public function it_can_set_and_retrieve_custom_headers_when_explicitly_added()
-    {
-        $headers = [
-            'Header' => 'Present',
-        ];
+    $this->assertFalse($media->hasCustomProperty('custom_headers'));
+    $this->assertEquals([], $media->getCustomHeaders());
+});
 
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection()
-            ->setCustomHeaders($headers);
+it('can set and retrieve custom headers when explicitly added', function () {
+    $headers = [
+        'Header' => 'Present',
+    ];
 
-        $this->assertTrue($media->hasCustomProperty('custom_headers'));
-        $this->assertEquals($headers, $media->getCustomHeaders());
-    }
-}
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection()
+        ->setCustomHeaders($headers);
+
+    $this->assertTrue($media->hasCustomProperty('custom_headers'));
+    $this->assertEquals($headers, $media->getCustomHeaders());
+});

--- a/tests/Feature/Media/CustomHeadersTest.php
+++ b/tests/Feature/Media/CustomHeadersTest.php
@@ -9,8 +9,8 @@ it('does not set empty custom headers when saved', function () {
         ->addMedia($this->getTestJpg())
         ->toMediaCollection();
 
-    $this->assertFalse($media->hasCustomProperty('custom_headers'));
-    $this->assertEquals([], $media->getCustomHeaders());
+    expect($media->hasCustomProperty('custom_headers'))->toBeFalse();
+    expect($media->getCustomHeaders())->toEqual([]);
 });
 
 it('can set and retrieve custom headers when explicitly added', function () {
@@ -23,6 +23,6 @@ it('can set and retrieve custom headers when explicitly added', function () {
         ->toMediaCollection()
         ->setCustomHeaders($headers);
 
-    $this->assertTrue($media->hasCustomProperty('custom_headers'));
-    $this->assertEquals($headers, $media->getCustomHeaders());
+    expect($media->hasCustomProperty('custom_headers'))->toBeTrue();
+    expect($media->getCustomHeaders())->toEqual($headers);
 });

--- a/tests/Feature/Media/CustomHeadersTest.php
+++ b/tests/Feature/Media/CustomHeadersTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('does not set empty custom headers when saved', function () {
     $media = $this->testModel

--- a/tests/Feature/Media/CustomPropertyTest.php
+++ b/tests/Feature/Media/CustomPropertyTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 beforeEach(function () {

--- a/tests/Feature/Media/CustomPropertyTest.php
+++ b/tests/Feature/Media/CustomPropertyTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $this->media = $this->testModel

--- a/tests/Feature/Media/CustomPropertyTest.php
+++ b/tests/Feature/Media/CustomPropertyTest.php
@@ -1,80 +1,60 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class CustomPropertyTest extends TestCase
-{
-    protected Media $media;
+uses(TestCase::class);
 
-    protected Media $mediaWithoutCustomProperty;
+beforeEach(function () {
+    $this->media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties([
+            'customName' => 'customValue',
+            'nested' => [
+                'customName' => 'nested customValue',
+            ],
+        ])
+        ->toMediaCollection('images');
+});
 
-    public function setUp(): void
-    {
-        parent::setUp();
+it('can determine if a media item has a custom property', function () {
+    $this->assertTrue($this->media->hasCustomProperty('customName'));
+    $this->assertTrue($this->media->hasCustomProperty('nested.customName'));
 
-        $this->media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withCustomProperties([
-                'customName' => 'customValue',
-                'nested' => [
-                    'customName' => 'nested customValue',
-                ],
-            ])
-            ->toMediaCollection('images');
-    }
+    $this->assertFalse($this->media->hasCustomProperty('nonExisting'));
+    $this->assertFalse($this->media->hasCustomProperty('nested.nonExisting'));
+});
 
-    /** @test */
-    public function it_can_determine_if_a_media_item_has_a_custom_property()
-    {
-        $this->assertTrue($this->media->hasCustomProperty('customName'));
-        $this->assertTrue($this->media->hasCustomProperty('nested.customName'));
+it('can get a custom property', function () {
+    $this->assertEquals('customValue', $this->media->getCustomProperty('customName'));
+    $this->assertEquals('nested customValue', $this->media->getCustomProperty('nested.customName'));
 
-        $this->assertFalse($this->media->hasCustomProperty('nonExisting'));
-        $this->assertFalse($this->media->hasCustomProperty('nested.nonExisting'));
-    }
+    $this->assertNull($this->media->getCustomProperty('nonExisting'));
+    $this->assertNull($this->media->getCustomProperty('nested.nonExisting'));
+});
 
-    /** @test */
-    public function it_can_get_a_custom_property()
-    {
-        $this->assertEquals('customValue', $this->media->getCustomProperty('customName'));
-        $this->assertEquals('nested customValue', $this->media->getCustomProperty('nested.customName'));
+it('can set a custom property', function () {
+    $this->media->setCustomProperty('anotherName', 'anotherValue');
 
-        $this->assertNull($this->media->getCustomProperty('nonExisting'));
-        $this->assertNull($this->media->getCustomProperty('nested.nonExisting'));
-    }
+    $this->assertEquals('anotherValue', $this->media->getCustomProperty('anotherName'));
+    $this->assertEquals('customValue', $this->media->getCustomProperty('customName'));
 
-    /** @test */
-    public function it_can_set_a_custom_property()
-    {
-        $this->media->setCustomProperty('anotherName', 'anotherValue');
+    $this->media->setCustomProperty('nested.anotherName', 'anotherValue');
+    $this->assertEquals('anotherValue', $this->media->getCustomProperty('nested.anotherName'));
+});
 
-        $this->assertEquals('anotherValue', $this->media->getCustomProperty('anotherName'));
-        $this->assertEquals('customValue', $this->media->getCustomProperty('customName'));
+it('can forget a custom property', function () {
+    $this->assertTrue($this->media->hasCustomProperty('customName'));
+    $this->assertTrue($this->media->hasCustomProperty('nested.customName'));
 
-        $this->media->setCustomProperty('nested.anotherName', 'anotherValue');
-        $this->assertEquals('anotherValue', $this->media->getCustomProperty('nested.anotherName'));
-    }
+    $this->media->forgetCustomProperty('customName');
+    $this->media->forgetCustomProperty('nested.customName');
 
-    /** @test */
-    public function it_can_forget_a_custom_property()
-    {
-        $this->assertTrue($this->media->hasCustomProperty('customName'));
-        $this->assertTrue($this->media->hasCustomProperty('nested.customName'));
+    $this->assertFalse($this->media->hasCustomProperty('customName'));
+    $this->assertFalse($this->media->hasCustomProperty('nested.customName'));
+});
 
-        $this->media->forgetCustomProperty('customName');
-        $this->media->forgetCustomProperty('nested.customName');
-
-        $this->assertFalse($this->media->hasCustomProperty('customName'));
-        $this->assertFalse($this->media->hasCustomProperty('nested.customName'));
-    }
-
-    /** @test */
-    public function it_returns_a_fallback_if_a_custom_property_isnt_set()
-    {
-        $this->assertEquals('foo', $this->media->getCustomProperty('imNotHere', 'foo'));
-    }
-}
+it('returns a fallback if a custom property isnt set', function () {
+    $this->assertEquals('foo', $this->media->getCustomProperty('imNotHere', 'foo'));
+});

--- a/tests/Feature/Media/CustomPropertyTest.php
+++ b/tests/Feature/Media/CustomPropertyTest.php
@@ -19,42 +19,42 @@ beforeEach(function () {
 });
 
 it('can determine if a media item has a custom property', function () {
-    $this->assertTrue($this->media->hasCustomProperty('customName'));
-    $this->assertTrue($this->media->hasCustomProperty('nested.customName'));
+    expect($this->media->hasCustomProperty('customName'))->toBeTrue();
+    expect($this->media->hasCustomProperty('nested.customName'))->toBeTrue();
 
-    $this->assertFalse($this->media->hasCustomProperty('nonExisting'));
-    $this->assertFalse($this->media->hasCustomProperty('nested.nonExisting'));
+    expect($this->media->hasCustomProperty('nonExisting'))->toBeFalse();
+    expect($this->media->hasCustomProperty('nested.nonExisting'))->toBeFalse();
 });
 
 it('can get a custom property', function () {
-    $this->assertEquals('customValue', $this->media->getCustomProperty('customName'));
-    $this->assertEquals('nested customValue', $this->media->getCustomProperty('nested.customName'));
+    expect($this->media->getCustomProperty('customName'))->toEqual('customValue');
+    expect($this->media->getCustomProperty('nested.customName'))->toEqual('nested customValue');
 
-    $this->assertNull($this->media->getCustomProperty('nonExisting'));
-    $this->assertNull($this->media->getCustomProperty('nested.nonExisting'));
+    expect($this->media->getCustomProperty('nonExisting'))->toBeNull();
+    expect($this->media->getCustomProperty('nested.nonExisting'))->toBeNull();
 });
 
 it('can set a custom property', function () {
     $this->media->setCustomProperty('anotherName', 'anotherValue');
 
-    $this->assertEquals('anotherValue', $this->media->getCustomProperty('anotherName'));
-    $this->assertEquals('customValue', $this->media->getCustomProperty('customName'));
+    expect($this->media->getCustomProperty('anotherName'))->toEqual('anotherValue');
+    expect($this->media->getCustomProperty('customName'))->toEqual('customValue');
 
     $this->media->setCustomProperty('nested.anotherName', 'anotherValue');
-    $this->assertEquals('anotherValue', $this->media->getCustomProperty('nested.anotherName'));
+    expect($this->media->getCustomProperty('nested.anotherName'))->toEqual('anotherValue');
 });
 
 it('can forget a custom property', function () {
-    $this->assertTrue($this->media->hasCustomProperty('customName'));
-    $this->assertTrue($this->media->hasCustomProperty('nested.customName'));
+    expect($this->media->hasCustomProperty('customName'))->toBeTrue();
+    expect($this->media->hasCustomProperty('nested.customName'))->toBeTrue();
 
     $this->media->forgetCustomProperty('customName');
     $this->media->forgetCustomProperty('nested.customName');
 
-    $this->assertFalse($this->media->hasCustomProperty('customName'));
-    $this->assertFalse($this->media->hasCustomProperty('nested.customName'));
+    expect($this->media->hasCustomProperty('customName'))->toBeFalse();
+    expect($this->media->hasCustomProperty('nested.customName'))->toBeFalse();
 });
 
 it('returns a fallback if a custom property isnt set', function () {
-    $this->assertEquals('foo', $this->media->getCustomProperty('imNotHere', 'foo'));
+    expect($this->media->getCustomProperty('imNotHere', 'foo'))->toEqual('foo');
 });

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -2,10 +2,8 @@
 
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestPathGenerator;
-
 
 it('will remove the files when deleting an object that has media', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -6,7 +6,6 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestPathGenerator;
 
-uses(TestCase::class);
 
 it('will remove the files when deleting an object that has media', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use File;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -11,21 +11,21 @@ uses(TestCase::class);
 it('will remove the files when deleting an object that has media', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeTrue();
 
     $this->testModel->delete();
 
-    $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeFalse();
 });
 
 it('will remove the files when deleting a media instance', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeTrue();
 
     $media->delete();
 
-    $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeFalse();
 });
 
 it('will remove files when deleting a media object with a custom path generator', function () {
@@ -36,11 +36,11 @@ it('will remove files when deleting a media object with a custom path generator'
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
     $path = $pathGenerator->getPath($media);
 
-    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeTrue();
 
     $this->testModel->delete();
 
-    $this->assertFalse(File::isDirectory($this->getTempDirectory($path)));
+    expect(File::isDirectory($this->getTempDirectory($path)))->toBeFalse();
 });
 
 it('will not remove the files when should delete preserving media returns true', function () {
@@ -78,7 +78,7 @@ it('will remove the files when should delete preserving media returns false', fu
 
     $testModel->delete();
 
-    $this->assertNull(Media::find($media->id));
+    expect(Media::find($media->id))->toBeNull();
 });
 
 it('will not remove the file when model uses softdelete', function () {
@@ -91,13 +91,13 @@ it('will not remove the file when model uses softdelete', function () {
 
     $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeTrue();
 
     $testModel = $testModel->fresh();
 
     $testModel->delete();
 
-    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeTrue();
 });
 
 it('will remove the file when model uses softdelete with force', function () {
@@ -110,11 +110,11 @@ it('will remove the file when model uses softdelete with force', function () {
 
     $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeTrue();
 
     $testModel = $testModel->fresh();
 
     $testModel->forceDelete();
 
-    $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeFalse();
 });

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use File;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -9,134 +7,115 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestPathGenerator;
 
-class DeleteTest extends TestCase
-{
-    /** @test */
-    public function it_will_remove_the_files_when_deleting_an_object_that_has_media()
-    {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+uses(TestCase::class);
 
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+it('will remove the files when deleting an object that has media', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-        $this->testModel->delete();
+    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
 
-        $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
-    }
+    $this->testModel->delete();
 
-    /** @test */
-    public function it_will_remove_the_files_when_deleting_a_media_instance()
-    {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
+});
 
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+it('will remove the files when deleting a media instance', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-        $media->delete();
+    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
 
-        $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
-    }
+    $media->delete();
 
-    /** @test */
-    public function it_will_remove_files_when_deleting_a_media_object_with_a_custom_path_generator()
-    {
-        config(['media-library.path_generator' => TestPathGenerator::class]);
+    $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
+});
 
-        $pathGenerator = new TestPathGenerator();
+it('will remove files when deleting a media object with a custom path generator', function () {
+    config(['media-library.path_generator' => TestPathGenerator::class]);
 
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
-        $path = $pathGenerator->getPath($media);
+    $pathGenerator = new TestPathGenerator();
 
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $path = $pathGenerator->getPath($media);
 
-        $this->testModel->delete();
+    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
 
-        $this->assertFalse(File::isDirectory($this->getTempDirectory($path)));
-    }
+    $this->testModel->delete();
 
-    /**
-     * @test
-     */
-    public function it_will_not_remove_the_files_when_shouldDeletePreservingMedia_returns_true()
-    {
-        $testModelClass = new class () extends TestModel {
-            public function shouldDeletePreservingMedia(): bool
-            {
-                return true;
-            }
-        };
+    $this->assertFalse(File::isDirectory($this->getTempDirectory($path)));
+});
 
-        $testModel = $testModelClass::find($this->testModel->id);
+it('will not remove the files when should delete preserving media returns true', function () {
+    $testModelClass = new class () extends TestModel {
+        public function shouldDeletePreservingMedia(): bool
+        {
+            return true;
+        }
+    };
 
-        $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $testModel = $testModelClass::find($this->testModel->id);
 
-        $testModel = $testModel->fresh();
+    $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-        $testModel->delete();
+    $testModel = $testModel->fresh();
 
-        $this->assertNotNull(Media::find($media->id));
-    }
+    $testModel->delete();
 
-    /**
-     * @test
-     */
-    public function it_will_remove_the_files_when_shouldDeletePreservingMedia_returns_false()
-    {
-        $testModelClass = new class () extends TestModel {
-            public function shouldDeletePreservingMedia(): bool
-            {
-                return false;
-            }
-        };
+    $this->assertNotNull(Media::find($media->id));
+});
 
-        $testModel = $testModelClass::find($this->testModel->id);
+it('will remove the files when should delete preserving media returns false', function () {
+    $testModelClass = new class () extends TestModel {
+        public function shouldDeletePreservingMedia(): bool
+        {
+            return false;
+        }
+    };
 
-        $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $testModel = $testModelClass::find($this->testModel->id);
 
-        $testModel = $testModel->fresh();
+    $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-        $testModel->delete();
+    $testModel = $testModel->fresh();
 
-        $this->assertNull(Media::find($media->id));
-    }
+    $testModel->delete();
 
-    /** @test */
-    public function it_will_not_remove_the_file_when_model_uses_softdelete()
-    {
-        $testModelClass = new class () extends TestModel {
-            use SoftDeletes;
-        };
+    $this->assertNull(Media::find($media->id));
+});
 
-        /** @var TestModel $testModel */
-        $testModel = $testModelClass::find($this->testModel->id);
+it('will not remove the file when model uses softdelete', function () {
+    $testModelClass = new class () extends TestModel {
+        use SoftDeletes;
+    };
 
-        $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    /** @var TestModel $testModel */
+    $testModel = $testModelClass::find($this->testModel->id);
 
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+    $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-        $testModel = $testModel->fresh();
+    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
 
-        $testModel->delete();
+    $testModel = $testModel->fresh();
 
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
-    }
+    $testModel->delete();
 
-    /** @test */
-    public function it_will_remove_the_file_when_model_uses_softdelete_with_force()
-    {
-        $testModelClass = new class () extends TestModel {
-            use SoftDeletes;
-        };
+    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+});
 
-        /** @var TestModel $testModel */
-        $testModel = $testModelClass::find($this->testModel->id);
+it('will remove the file when model uses softdelete with force', function () {
+    $testModelClass = new class () extends TestModel {
+        use SoftDeletes;
+    };
 
-        $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    /** @var TestModel $testModel */
+    $testModel = $testModelClass::find($this->testModel->id);
 
-        $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
+    $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-        $testModel = $testModel->fresh();
+    $this->assertTrue(File::isDirectory($this->getMediaDirectory($media->id)));
 
-        $testModel->forceDelete();
+    $testModel = $testModel->fresh();
 
-        $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
-    }
-}
+    $testModel->forceDelete();
+
+    $this->assertFalse(File::isDirectory($this->getMediaDirectory($media->id)));
+});

--- a/tests/Feature/Media/GetMediaConversionsTest.php
+++ b/tests/Feature/Media/GetMediaConversionsTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can get the names of registered conversions', function () {
     $media = $this->testModel

--- a/tests/Feature/Media/GetMediaConversionsTest.php
+++ b/tests/Feature/Media/GetMediaConversionsTest.php
@@ -10,12 +10,12 @@ it('can get the names of registered conversions', function () {
         ->preservingOriginal()
         ->toMediaCollection();
 
-    $this->assertSame([], $media->getMediaConversionNames());
+    expect($media->getMediaConversionNames())->toBe([]);
 
     $media = $this->testModelWithConversion
         ->addMedia($this->getTestJpg())
         ->preservingOriginal()
         ->toMediaCollection();
 
-    $this->assertSame(['thumb', 'keep_original_format'], $media->getMediaConversionNames());
+    expect($media->getMediaConversionNames())->toBe(['thumb', 'keep_original_format']);
 });

--- a/tests/Feature/Media/GetMediaConversionsTest.php
+++ b/tests/Feature/Media/GetMediaConversionsTest.php
@@ -1,26 +1,21 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class GetMediaConversionsTest extends TestCase
-{
-    /** @test */
-    public function it_can_get_the_names_of_registered_conversions()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection();
+uses(TestCase::class);
 
-        $this->assertSame([], $media->getMediaConversionNames());
+it('can get the names of registered conversions', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection();
 
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection();
+    $this->assertSame([], $media->getMediaConversionNames());
 
-        $this->assertSame(['thumb', 'keep_original_format'], $media->getMediaConversionNames());
-    }
-}
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection();
+
+    $this->assertSame(['thumb', 'keep_original_format'], $media->getMediaConversionNames());
+});

--- a/tests/Feature/Media/GetMediaConversionsTest.php
+++ b/tests/Feature/Media/GetMediaConversionsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 it('can get the names of registered conversions', function () {

--- a/tests/Feature/Media/GetOriginalUrlAttributeTest.php
+++ b/tests/Feature/Media/GetOriginalUrlAttributeTest.php
@@ -1,24 +1,17 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class GetOriginalUrlAttributeTest extends TestCase
-{
-    /** @test */
-    public function the_original_url_attribute_exists()
-    {
-        $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();
+uses(TestCase::class);
 
-        $this->assertArrayHasKey('original_url', $media->toArray());
-    }
+test('the original url attribute exists', function () {
+    $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();
 
-    /** @test */
-    public function it_can_get_url_of_original_image()
-    {
-        $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();
+    $this->assertArrayHasKey('original_url', $media->toArray());
+});
 
-        $this->assertEquals("/media/{$media->id}/test.jpg", $media->original_url);
-    }
-}
+it('can get url of original image', function () {
+    $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();
+
+    $this->assertEquals("/media/{$media->id}/test.jpg", $media->original_url);
+});

--- a/tests/Feature/Media/GetOriginalUrlAttributeTest.php
+++ b/tests/Feature/Media/GetOriginalUrlAttributeTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 test('the original url attribute exists', function () {

--- a/tests/Feature/Media/GetOriginalUrlAttributeTest.php
+++ b/tests/Feature/Media/GetOriginalUrlAttributeTest.php
@@ -13,5 +13,5 @@ test('the original url attribute exists', function () {
 it('can get url of original image', function () {
     $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();
 
-    $this->assertEquals("/media/{$media->id}/test.jpg", $media->original_url);
+    expect($media->original_url)->toEqual("/media/{$media->id}/test.jpg");
 });

--- a/tests/Feature/Media/GetOriginalUrlAttributeTest.php
+++ b/tests/Feature/Media/GetOriginalUrlAttributeTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 test('the original url attribute exists', function () {
     $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();

--- a/tests/Feature/Media/GetPathTest.php
+++ b/tests/Feature/Media/GetPathTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidConversion;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can get a path of an original item', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();

--- a/tests/Feature/Media/GetPathTest.php
+++ b/tests/Feature/Media/GetPathTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidConversion;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can get a path of an original item', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();

--- a/tests/Feature/Media/GetPathTest.php
+++ b/tests/Feature/Media/GetPathTest.php
@@ -12,7 +12,7 @@ it('can get a path of an original item', function () {
 
     $actual = $this->makePathOsSafe($media->getPath());
 
-    $this->assertEquals($expected, $actual);
+    expect($actual)->toEqual($expected);
 });
 
 it('can get a path of a derived image', function () {
@@ -24,7 +24,7 @@ it('can get a path of a derived image', function () {
 
     $actual = $this->makePathOsSafe($media->getPath($conversionName));
 
-    $this->assertEquals($expected, $actual);
+    expect($actual)->toEqual($expected);
 });
 
 it('returns an exception when getting a path for an unknown conversion', function () {
@@ -44,7 +44,7 @@ it('can get a path of an original item with prefix', function () {
 
     $actual = $this->makePathOsSafe($media->getPath());
 
-    $this->assertEquals($expected, $actual);
+    expect($actual)->toEqual($expected);
 });
 
 it('can get a path of a derived image with prefix', function () {
@@ -58,5 +58,5 @@ it('can get a path of a derived image with prefix', function () {
 
     $actual = $this->makePathOsSafe($media->getPath($conversionName));
 
-    $this->assertEquals($expected, $actual);
+    expect($actual)->toEqual($expected);
 });

--- a/tests/Feature/Media/GetPathTest.php
+++ b/tests/Feature/Media/GetPathTest.php
@@ -1,75 +1,62 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidConversion;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class GetPathTest extends TestCase
-{
-    /** @test */
-    public function it_can_get_a_path_of_an_original_item()
-    {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+uses(TestCase::class);
 
-        $expected = $this->makePathOsSafe($this->getMediaDirectory() . "/{$media->id}/test.jpg");
+it('can get a path of an original item', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $actual = $this->makePathOsSafe($media->getPath());
+    $expected = $this->makePathOsSafe($this->getMediaDirectory() . "/{$media->id}/test.jpg");
 
-        $this->assertEquals($expected, $actual);
-    }
+    $actual = $this->makePathOsSafe($media->getPath());
 
-    /** @test */
-    public function it_can_get_a_path_of_a_derived_image()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
+    $this->assertEquals($expected, $actual);
+});
 
-        $conversionName = 'thumb';
+it('can get a path of a derived image', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $expected = $this->makePathOsSafe($this->getMediaDirectory() . "/{$media->id}/conversions/test-{$conversionName}.jpg");
+    $conversionName = 'thumb';
 
-        $actual = $this->makePathOsSafe($media->getPath($conversionName));
+    $expected = $this->makePathOsSafe($this->getMediaDirectory() . "/{$media->id}/conversions/test-{$conversionName}.jpg");
 
-        $this->assertEquals($expected, $actual);
-    }
+    $actual = $this->makePathOsSafe($media->getPath($conversionName));
 
-    /** @test */
-    public function it_returns_an_exception_when_getting_a_path_for_an_unknown_conversion()
-    {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+    $this->assertEquals($expected, $actual);
+});
 
-        $this->expectException(InvalidConversion::class);
+it('returns an exception when getting a path for an unknown conversion', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $media->getPath('unknownConversionName');
-    }
+    $this->expectException(InvalidConversion::class);
 
-    /** @test */
-    public function it_can_get_a_path_of_an_original_item_with_prefix()
-    {
-        config(['media-library.prefix' => 'prefix']);
+    $media->getPath('unknownConversionName');
+});
 
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+it('can get a path of an original item with prefix', function () {
+    config(['media-library.prefix' => 'prefix']);
 
-        $expected = $this->makePathOsSafe($this->getMediaDirectory() . "/prefix/{$media->id}/test.jpg");
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $actual = $this->makePathOsSafe($media->getPath());
+    $expected = $this->makePathOsSafe($this->getMediaDirectory() . "/prefix/{$media->id}/test.jpg");
 
-        $this->assertEquals($expected, $actual);
-    }
+    $actual = $this->makePathOsSafe($media->getPath());
 
-    /** @test */
-    public function it_can_get_a_path_of_a_derived_image_with_prefix()
-    {
-        config(['media-library.prefix' => 'prefix']);
+    $this->assertEquals($expected, $actual);
+});
 
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
+it('can get a path of a derived image with prefix', function () {
+    config(['media-library.prefix' => 'prefix']);
 
-        $conversionName = 'thumb';
+    $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $expected = $this->makePathOsSafe($this->getMediaDirectory() . "/prefix/{$media->id}/conversions/test-{$conversionName}.jpg");
+    $conversionName = 'thumb';
 
-        $actual = $this->makePathOsSafe($media->getPath($conversionName));
+    $expected = $this->makePathOsSafe($this->getMediaDirectory() . "/prefix/{$media->id}/conversions/test-{$conversionName}.jpg");
 
-        $this->assertEquals($expected, $actual);
-    }
-}
+    $actual = $this->makePathOsSafe($media->getPath($conversionName));
+
+    $this->assertEquals($expected, $actual);
+});

--- a/tests/Feature/Media/GetPreviewUrlAttributeTest.php
+++ b/tests/Feature/Media/GetPreviewUrlAttributeTest.php
@@ -1,26 +1,19 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class GetPreviewUrlAttributeTest extends TestCase
-{
-    /** @test */
-    public function the_preview_url_attribute_exists()
-    {
-        $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();
+uses(TestCase::class);
 
-        $this->assertArrayHasKey('preview_url', $media->toArray());
-    }
+test('the preview url attribute exists', function () {
+    $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();
 
-    /** @test */
-    public function it_can_get_url_of_preview_image()
-    {
-        $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();
+    $this->assertArrayHasKey('preview_url', $media->toArray());
+});
 
-        $conversionName = 'preview';
+it('can get url of preview image', function () {
+    $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $this->assertEquals("/media/{$media->id}/conversions/test-{$conversionName}.jpg", $media->preview_url);
-    }
-}
+    $conversionName = 'preview';
+
+    $this->assertEquals("/media/{$media->id}/conversions/test-{$conversionName}.jpg", $media->preview_url);
+});

--- a/tests/Feature/Media/GetPreviewUrlAttributeTest.php
+++ b/tests/Feature/Media/GetPreviewUrlAttributeTest.php
@@ -15,5 +15,5 @@ it('can get url of preview image', function () {
 
     $conversionName = 'preview';
 
-    $this->assertEquals("/media/{$media->id}/conversions/test-{$conversionName}.jpg", $media->preview_url);
+    expect($media->preview_url)->toEqual("/media/{$media->id}/conversions/test-{$conversionName}.jpg");
 });

--- a/tests/Feature/Media/GetPreviewUrlAttributeTest.php
+++ b/tests/Feature/Media/GetPreviewUrlAttributeTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 test('the preview url attribute exists', function () {
     $media = $this->testModelWithPreviewConversion->addMedia($this->getTestJpg())->toMediaCollection();

--- a/tests/Feature/Media/GetPreviewUrlAttributeTest.php
+++ b/tests/Feature/Media/GetPreviewUrlAttributeTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 test('the preview url attribute exists', function () {

--- a/tests/Feature/Media/GetTypeTest.php
+++ b/tests/Feature/Media/GetTypeTest.php
@@ -1,16 +1,11 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class GetTypeTest extends TestCase
-{
-    /** @test */
-    public function it_can_return_the_file_mime()
-    {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+uses(TestCase::class);
 
-        $this->assertEquals('image/jpeg', $media->mime_type);
-    }
-}
+it('can return the file mime', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+
+    $this->assertEquals('image/jpeg', $media->mime_type);
+});

--- a/tests/Feature/Media/GetTypeTest.php
+++ b/tests/Feature/Media/GetTypeTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 it('can return the file mime', function () {

--- a/tests/Feature/Media/GetTypeTest.php
+++ b/tests/Feature/Media/GetTypeTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can return the file mime', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();

--- a/tests/Feature/Media/GetTypeTest.php
+++ b/tests/Feature/Media/GetTypeTest.php
@@ -7,5 +7,5 @@ uses(TestCase::class);
 it('can return the file mime', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-    $this->assertEquals('image/jpeg', $media->mime_type);
+    expect($media->mime_type)->toEqual('image/jpeg');
 });

--- a/tests/Feature/Media/GetUrlTest.php
+++ b/tests/Feature/Media/GetUrlTest.php
@@ -2,8 +2,6 @@
 
 use Carbon\Carbon;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidConversion;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can get an url of an original item', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();

--- a/tests/Feature/Media/GetUrlTest.php
+++ b/tests/Feature/Media/GetUrlTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Carbon\Carbon;
-use RuntimeException;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidConversion;
 use Spatie\MediaLibrary\Tests\TestCase;
 

--- a/tests/Feature/Media/GetUrlTest.php
+++ b/tests/Feature/Media/GetUrlTest.php
@@ -1,67 +1,52 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Carbon\Carbon;
 use RuntimeException;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidConversion;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class GetUrlTest extends TestCase
-{
-    /** @test */
-    public function it_can_get_an_url_of_an_original_item()
-    {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+uses(TestCase::class);
 
-        $this->assertEquals($media->getUrl(), "/media/{$media->id}/test.jpg");
-    }
+it('can get an url of an original item', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-    /** @test */
-    public function it_can_get_an_url_of_a_derived_image()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
+    $this->assertEquals($media->getUrl(), "/media/{$media->id}/test.jpg");
+});
 
-        $conversionName = 'thumb';
+it('can get an url of a derived image', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $this->assertEquals("/media/{$media->id}/conversions/test-{$conversionName}.jpg", $media->getUrl($conversionName));
-    }
+    $conversionName = 'thumb';
 
-    /** @test */
-    public function it_returns_an_exception_when_getting_an_url_for_an_unknown_conversion()
-    {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+    $this->assertEquals("/media/{$media->id}/conversions/test-{$conversionName}.jpg", $media->getUrl($conversionName));
+});
 
-        $this->expectException(InvalidConversion::class);
+it('returns an exception when getting an url for an unknown conversion', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $media->getUrl('unknownConversionName');
-    }
+    $this->expectException(InvalidConversion::class);
 
-    /** @test */
-    public function it_can_get_the_full_url_of_an_original_item()
-    {
-        $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+    $media->getUrl('unknownConversionName');
+});
 
-        $this->assertEquals($media->getFullUrl(), "http://localhost/media/{$media->id}/test.jpg");
-    }
+it('can get the full url of an original item', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-    /** @test */
-    public function it_can_get_the_full_url_of_a_derived_image()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
+    $this->assertEquals($media->getFullUrl(), "http://localhost/media/{$media->id}/test.jpg");
+});
 
-        $conversionName = 'thumb';
+it('can get the full url of a derived image', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $this->assertEquals("http://localhost/media/{$media->id}/conversions/test-{$conversionName}.jpg", $media->getFullUrl($conversionName));
-    }
+    $conversionName = 'thumb';
 
-    /** @test */
-    public function it_throws_an_exception_when_trying_to_get_a_temporary_url_on_local_disk()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
+    $this->assertEquals("http://localhost/media/{$media->id}/conversions/test-{$conversionName}.jpg", $media->getFullUrl($conversionName));
+});
 
-        $this->expectException(RuntimeException::class);
+it('throws an exception when trying to get a temporary url on local disk', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
 
-        $media->getTemporaryUrl(Carbon::now()->addMinutes(5));
-    }
-}
+    $this->expectException(RuntimeException::class);
+
+    $media->getTemporaryUrl(Carbon::now()->addMinutes(5));
+});

--- a/tests/Feature/Media/GetUrlTest.php
+++ b/tests/Feature/Media/GetUrlTest.php
@@ -9,7 +9,7 @@ uses(TestCase::class);
 it('can get an url of an original item', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-    $this->assertEquals($media->getUrl(), "/media/{$media->id}/test.jpg");
+    expect("/media/{$media->id}/test.jpg")->toEqual($media->getUrl());
 });
 
 it('can get an url of a derived image', function () {
@@ -17,7 +17,7 @@ it('can get an url of a derived image', function () {
 
     $conversionName = 'thumb';
 
-    $this->assertEquals("/media/{$media->id}/conversions/test-{$conversionName}.jpg", $media->getUrl($conversionName));
+    expect($media->getUrl($conversionName))->toEqual("/media/{$media->id}/conversions/test-{$conversionName}.jpg");
 });
 
 it('returns an exception when getting an url for an unknown conversion', function () {
@@ -31,7 +31,7 @@ it('returns an exception when getting an url for an unknown conversion', functio
 it('can get the full url of an original item', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
 
-    $this->assertEquals($media->getFullUrl(), "http://localhost/media/{$media->id}/test.jpg");
+    expect("http://localhost/media/{$media->id}/test.jpg")->toEqual($media->getFullUrl());
 });
 
 it('can get the full url of a derived image', function () {
@@ -39,7 +39,7 @@ it('can get the full url of a derived image', function () {
 
     $conversionName = 'thumb';
 
-    $this->assertEquals("http://localhost/media/{$media->id}/conversions/test-{$conversionName}.jpg", $media->getFullUrl($conversionName));
+    expect($media->getFullUrl($conversionName))->toEqual("http://localhost/media/{$media->id}/conversions/test-{$conversionName}.jpg");
 });
 
 it('throws an exception when trying to get a temporary url on local disk', function () {

--- a/tests/Feature/Media/GetUrlTest.php
+++ b/tests/Feature/Media/GetUrlTest.php
@@ -4,7 +4,6 @@ use Carbon\Carbon;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidConversion;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can get an url of an original item', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();

--- a/tests/Feature/Media/HasConversionTest.php
+++ b/tests/Feature/Media/HasConversionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 test('test', function () {

--- a/tests/Feature/Media/HasConversionTest.php
+++ b/tests/Feature/Media/HasConversionTest.php
@@ -7,5 +7,5 @@ uses(TestCase::class);
 test('test', function () {
     $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
 
-    $this->assertTrue($media->hasGeneratedConversion('thumb'));
+    expect($media->hasGeneratedConversion('thumb'))->toBeTrue();
 });

--- a/tests/Feature/Media/HasConversionTest.php
+++ b/tests/Feature/Media/HasConversionTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 test('test', function () {
     $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();

--- a/tests/Feature/Media/HasConversionTest.php
+++ b/tests/Feature/Media/HasConversionTest.php
@@ -1,16 +1,11 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class HasConversionTest extends TestCase
-{
-    /** @test */
-    public function test()
-    {
-        $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
+uses(TestCase::class);
 
-        $this->assertTrue($media->hasGeneratedConversion('thumb'));
-    }
-}
+test('test', function () {
+    $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection();
+
+    $this->assertTrue($media->hasGeneratedConversion('thumb'));
+});

--- a/tests/Feature/Media/MediaRepositoryTest.php
+++ b/tests/Feature/Media/MediaRepositoryTest.php
@@ -1,9 +1,7 @@
 <?php
 
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestCustomMediaModel;
-
 
 it('can use a custom media model', function () {
     $this->testModel

--- a/tests/Feature/Media/MediaRepositoryTest.php
+++ b/tests/Feature/Media/MediaRepositoryTest.php
@@ -16,7 +16,7 @@ it('can use a custom media model', function () {
 // Helpers
 function getEnvironmentSetUp($app)
 {
-    parent::getEnvironmentSetUp($app);
+    test()->getEnvironmentSetUp($app);
 
     $app['config']->set('media-library.media_model', TestCustomMediaModel::class);
 }

--- a/tests/Feature/Media/MediaRepositoryTest.php
+++ b/tests/Feature/Media/MediaRepositoryTest.php
@@ -4,7 +4,6 @@ use Spatie\MediaLibrary\MediaCollections\MediaRepository;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestCustomMediaModel;
 
-uses(TestCase::class);
 
 it('can use a custom media model', function () {
     $this->testModel

--- a/tests/Feature/Media/MediaRepositoryTest.php
+++ b/tests/Feature/Media/MediaRepositoryTest.php
@@ -13,7 +13,7 @@ it('can use a custom media model', function () {
 
     $mediaRepository = app(MediaRepository::class);
 
-    $this->assertEquals(TestCustomMediaModel::class, $mediaRepository->all()->getQueueableClass());
+    expect($mediaRepository->all()->getQueueableClass())->toEqual(TestCustomMediaModel::class);
 });
 
 // Helpers

--- a/tests/Feature/Media/MediaRepositoryTest.php
+++ b/tests/Feature/Media/MediaRepositoryTest.php
@@ -1,29 +1,25 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestCustomMediaModel;
 
-class MediaRepositoryTest extends TestCase
+uses(TestCase::class);
+
+it('can use a custom media model', function () {
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
+
+    $mediaRepository = app(MediaRepository::class);
+
+    $this->assertEquals(TestCustomMediaModel::class, $mediaRepository->all()->getQueueableClass());
+});
+
+// Helpers
+function getEnvironmentSetUp($app)
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        parent::getEnvironmentSetUp($app);
+    parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('media-library.media_model', TestCustomMediaModel::class);
-    }
-
-    /** @test */
-    public function it_can_use_a_custom_media_model()
-    {
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
-
-        $mediaRepository = app(MediaRepository::class);
-
-        $this->assertEquals(TestCustomMediaModel::class, $mediaRepository->all()->getQueueableClass());
-    }
+    $app['config']->set('media-library.media_model', TestCustomMediaModel::class);
 }

--- a/tests/Feature/Media/MoveTest.php
+++ b/tests/Feature/Media/MoveTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-uses(TestCase::class);
 
 it('can move media from one model to another', function () {
     $model = TestModel::create(['name' => 'test']);

--- a/tests/Feature/Media/MoveTest.php
+++ b/tests/Feature/Media/MoveTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
-
 
 it('can move media from one model to another', function () {
     $model = TestModel::create(['name' => 'test']);

--- a/tests/Feature/Media/MoveTest.php
+++ b/tests/Feature/Media/MoveTest.php
@@ -20,14 +20,14 @@ it('can move media from one model to another', function () {
 
     $movedMedia = $media->move($anotherModel, 'images');
 
-    $this->assertCount(0, $model->getMedia('default'));
+    expect($model->getMedia('default'))->toHaveCount(0);
     $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/test.jpg'));
 
-    $this->assertCount(1, $anotherModel->getMedia('images'));
+    expect($anotherModel->getMedia('images'))->toHaveCount(1);
     $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/test.jpg'));
-    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-    $this->assertEquals($movedMedia->name, 'custom-name');
-    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+    expect($anotherModel->id)->toEqual($movedMedia->model->id);
+    expect('custom-name')->toEqual($movedMedia->name);
+    expect('custom-property-value')->toEqual($movedMedia->getCustomProperty('custom-property-name'));
 });
 
 it('can move media from one model to another on a specific disk', function () {
@@ -47,14 +47,14 @@ it('can move media from one model to another on a specific disk', function () {
 
     $movedMedia = $media->move($anotherModel, 'images', $diskName);
 
-    $this->assertCount(0, $model->getMedia('default'));
+    expect($model->getMedia('default'))->toHaveCount(0);
     $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/test.jpg'));
 
-    $this->assertCount(1, $anotherModel->getMedia('images'));
+    expect($anotherModel->getMedia('images'))->toHaveCount(1);
     $this->assertFileExists($this->getTempDirectory('media2').'/'.$movedMedia->id.'/test.jpg');
-    $this->assertEquals($movedMedia->collection_name, 'images');
-    $this->assertEquals($movedMedia->disk, $diskName);
-    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-    $this->assertEquals($movedMedia->name, 'custom-name');
-    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+    expect('images')->toEqual($movedMedia->collection_name);
+    expect($diskName)->toEqual($movedMedia->disk);
+    expect($anotherModel->id)->toEqual($movedMedia->model->id);
+    expect('custom-name')->toEqual($movedMedia->name);
+    expect('custom-property-value')->toEqual($movedMedia->getCustomProperty('custom-property-name'));
 });

--- a/tests/Feature/Media/MoveTest.php
+++ b/tests/Feature/Media/MoveTest.php
@@ -1,67 +1,60 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-class MoveTest extends TestCase
-{
-    /** @test */
-    public function it_can_move_media_from_one_model_to_another()
-    {
-        $model = TestModel::create(['name' => 'test']);
+uses(TestCase::class);
 
-        $media = $model
-            ->addMedia($this->getTestJpg())
-            ->usingName('custom-name')
-            ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
-            ->toMediaCollection();
+it('can move media from one model to another', function () {
+    $model = TestModel::create(['name' => 'test']);
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+    $media = $model
+        ->addMedia($this->getTestJpg())
+        ->usingName('custom-name')
+        ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
+        ->toMediaCollection();
 
-        $anotherModel = TestModel::create(['name' => 'another-test']);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
 
-        $movedMedia = $media->move($anotherModel, 'images');
+    $anotherModel = TestModel::create(['name' => 'another-test']);
 
-        $this->assertCount(0, $model->getMedia('default'));
-        $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/test.jpg'));
+    $movedMedia = $media->move($anotherModel, 'images');
 
-        $this->assertCount(1, $anotherModel->getMedia('images'));
-        $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/test.jpg'));
-        $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-        $this->assertEquals($movedMedia->name, 'custom-name');
-        $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
-    }
+    $this->assertCount(0, $model->getMedia('default'));
+    $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/test.jpg'));
 
-    /** @test */
-    public function it_can_move_media_from_one_model_to_another_on_a_specific_disk()
-    {
-        $diskName = 'secondMediaDisk';
+    $this->assertCount(1, $anotherModel->getMedia('images'));
+    $this->assertFileExists($this->getMediaDirectory($movedMedia->id.'/test.jpg'));
+    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
+    $this->assertEquals($movedMedia->name, 'custom-name');
+    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+});
 
-        $model = TestModel::create(['name' => 'test']);
+it('can move media from one model to another on a specific disk', function () {
+    $diskName = 'secondMediaDisk';
 
-        $media = $model
-            ->addMedia($this->getTestJpg())
-            ->usingName('custom-name')
-            ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
-            ->toMediaCollection();
+    $model = TestModel::create(['name' => 'test']);
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+    $media = $model
+        ->addMedia($this->getTestJpg())
+        ->usingName('custom-name')
+        ->withCustomProperties(['custom-property-name' => 'custom-property-value'])
+        ->toMediaCollection();
 
-        $anotherModel = TestModel::create(['name' => 'another-test']);
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
 
-        $movedMedia = $media->move($anotherModel, 'images', $diskName);
+    $anotherModel = TestModel::create(['name' => 'another-test']);
 
-        $this->assertCount(0, $model->getMedia('default'));
-        $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/test.jpg'));
+    $movedMedia = $media->move($anotherModel, 'images', $diskName);
 
-        $this->assertCount(1, $anotherModel->getMedia('images'));
-        $this->assertFileExists($this->getTempDirectory('media2').'/'.$movedMedia->id.'/test.jpg');
-        $this->assertEquals($movedMedia->collection_name, 'images');
-        $this->assertEquals($movedMedia->disk, $diskName);
-        $this->assertEquals($movedMedia->model->id, $anotherModel->id);
-        $this->assertEquals($movedMedia->name, 'custom-name');
-        $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
-    }
-}
+    $this->assertCount(0, $model->getMedia('default'));
+    $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/test.jpg'));
+
+    $this->assertCount(1, $anotherModel->getMedia('images'));
+    $this->assertFileExists($this->getTempDirectory('media2').'/'.$movedMedia->id.'/test.jpg');
+    $this->assertEquals($movedMedia->collection_name, 'images');
+    $this->assertEquals($movedMedia->disk, $diskName);
+    $this->assertEquals($movedMedia->model->id, $anotherModel->id);
+    $this->assertEquals($movedMedia->name, 'custom-name');
+    $this->assertEquals($movedMedia->getCustomProperty('custom-property-name'), 'custom-property-value');
+});

--- a/tests/Feature/Media/RenameTest.php
+++ b/tests/Feature/Media/RenameTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 it('wil rename the file if it is changed on the media object', function () {

--- a/tests/Feature/Media/RenameTest.php
+++ b/tests/Feature/Media/RenameTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('wil rename the file if it is changed on the media object', function () {
     $testFile = $this->getTestFilesDirectory('test.jpg');

--- a/tests/Feature/Media/RenameTest.php
+++ b/tests/Feature/Media/RenameTest.php
@@ -50,6 +50,6 @@ it('keeps valid file name when renaming with missing conversions', function () {
     // Reload attributes from the database
     $media = $media->fresh();
 
-    $this->assertFileExists($media->getPath());
-    $this->assertEquals($new_filename, $media->file_name);
+    expect($media->getPath())->toBeFile();
+    expect($media->file_name)->toEqual($new_filename);
 });

--- a/tests/Feature/Media/RenameTest.php
+++ b/tests/Feature/Media/RenameTest.php
@@ -1,64 +1,55 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class RenameTest extends TestCase
-{
-    /** @test */
-    public function it_wil_rename_the_file_if_it_is_changed_on_the_media_object()
-    {
-        $testFile = $this->getTestFilesDirectory('test.jpg');
+uses(TestCase::class);
 
-        $media = $this->testModel->addMedia($testFile)->toMediaCollection();
+it('wil rename the file if it is changed on the media object', function () {
+    $testFile = $this->getTestFilesDirectory('test.jpg');
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
+    $media = $this->testModel->addMedia($testFile)->toMediaCollection();
 
-        $media->file_name = 'test-new-name.jpg';
-        $media->save();
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/test.jpg'));
 
-        $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/test.jpg'));
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/test-new-name.jpg'));
-    }
+    $media->file_name = 'test-new-name.jpg';
+    $media->save();
 
-    /** @test */
-    public function it_will_rename_conversions()
-    {
-        $testFile = $this->getTestFilesDirectory('test.jpg');
+    $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/test.jpg'));
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/test-new-name.jpg'));
+});
 
-        $media = $this->testModelWithConversion->addMedia($testFile)->toMediaCollection();
+it('will rename conversions', function () {
+    $testFile = $this->getTestFilesDirectory('test.jpg');
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
+    $media = $this->testModelWithConversion->addMedia($testFile)->toMediaCollection();
 
-        $media->file_name = 'test-new-name.jpg';
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg'));
 
-        $media->save();
+    $media->file_name = 'test-new-name.jpg';
 
-        $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/test-new-name-thumb.jpg'));
-    }
+    $media->save();
 
-    /** @test */
-    public function it_keeps_valid_file_name_when_renaming_with_missing_conversions()
-    {
-        $testFile = $this->getTestFilesDirectory('test.jpg');
+    $this->assertFileExists($this->getMediaDirectory($media->id.'/conversions/test-new-name-thumb.jpg'));
+});
 
-        $media = $this->testModelWithConversion->addMedia($testFile)->toMediaCollection();
+it('keeps valid file name when renaming with missing conversions', function () {
+    $testFile = $this->getTestFilesDirectory('test.jpg');
 
-        $this->assertFileExists(
-            $thumb_conversion = $this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg')
-        );
+    $media = $this->testModelWithConversion->addMedia($testFile)->toMediaCollection();
 
-        unlink($thumb_conversion);
+    $this->assertFileExists(
+        $thumb_conversion = $this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg')
+    );
 
-        $media->file_name = $new_filename = 'test-new-name.jpg';
+    unlink($thumb_conversion);
 
-        $media->save();
+    $media->file_name = $new_filename = 'test-new-name.jpg';
 
-        // Reload attributes from the database
-        $media = $media->fresh();
+    $media->save();
 
-        $this->assertFileExists($media->getPath());
-        $this->assertEquals($new_filename, $media->file_name);
-    }
-}
+    // Reload attributes from the database
+    $media = $media->fresh();
+
+    $this->assertFileExists($media->getPath());
+    $this->assertEquals($new_filename, $media->file_name);
+});

--- a/tests/Feature/Media/ResponsableTest.php
+++ b/tests/Feature/Media/ResponsableTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 it('can return an image as a response', function () {

--- a/tests/Feature/Media/ResponsableTest.php
+++ b/tests/Feature/Media/ResponsableTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can return an image as a response', function () {
     app()['router']->get('/upload', fn () => $this->testModel

--- a/tests/Feature/Media/ResponsableTest.php
+++ b/tests/Feature/Media/ResponsableTest.php
@@ -11,7 +11,7 @@ it('can return an image as a response', function () {
 
     $result = $this->call('get', 'upload');
 
-    $this->assertEquals(200, $result->getStatusCode());
+    expect($result->getStatusCode())->toEqual(200);
     $result->assertHeader('Content-Type', 'image/jpeg');
     $result->assertHeader('Content-Length', 29085);
 });
@@ -23,7 +23,7 @@ it('can return a text as a response', function () {
 
     $result = $this->call('get', 'upload');
 
-    $this->assertEquals(200, $result->getStatusCode());
+    expect($result->getStatusCode())->toEqual(200);
     $result->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
     $result->assertHeader('Content-Length', 45);
 });

--- a/tests/Feature/Media/ResponsableTest.php
+++ b/tests/Feature/Media/ResponsableTest.php
@@ -1,36 +1,29 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class ResponsableTest extends TestCase
-{
-    /** @test */
-    public function it_can_return_an_image_as_a_response()
-    {
-        $this->app['router']->get('/upload', fn () => $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection());
+uses(TestCase::class);
 
-        $result = $this->call('get', 'upload');
+it('can return an image as a response', function () {
+    app()['router']->get('/upload', fn () => $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection());
 
-        $this->assertEquals(200, $result->getStatusCode());
-        $result->assertHeader('Content-Type', 'image/jpeg');
-        $result->assertHeader('Content-Length', 29085);
-    }
+    $result = $this->call('get', 'upload');
 
-    /** @test */
-    public function it_can_return_a_text_as_a_response()
-    {
-        $this->app['router']->get('/upload', fn () => $this->testModel
-            ->addMedia($this->getTestFilesDirectory('test.txt'))
-            ->toMediaCollection());
+    $this->assertEquals(200, $result->getStatusCode());
+    $result->assertHeader('Content-Type', 'image/jpeg');
+    $result->assertHeader('Content-Length', 29085);
+});
 
-        $result = $this->call('get', 'upload');
+it('can return a text as a response', function () {
+    app()['router']->get('/upload', fn () => $this->testModel
+        ->addMedia($this->getTestFilesDirectory('test.txt'))
+        ->toMediaCollection());
 
-        $this->assertEquals(200, $result->getStatusCode());
-        $result->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
-        $result->assertHeader('Content-Length', 45);
-    }
-}
+    $result = $this->call('get', 'upload');
+
+    $this->assertEquals(200, $result->getStatusCode());
+    $result->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+    $result->assertHeader('Content-Length', 45);
+});

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -6,7 +6,6 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithCustomLoadingAttribute;
 use Spatie\Snapshots\MatchesSnapshots;
 
-uses(TestCase::class);
 uses(MatchesSnapshots::class);
 
 beforeEach(function () {

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithCustomLoadingAttribute;
 use Spatie\Snapshots\MatchesSnapshots;
 

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -1,156 +1,128 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithCustomLoadingAttribute;
 use Spatie\Snapshots\MatchesSnapshots;
 
-class ToHtmlTest extends TestCase
+uses(TestCase::class);
+uses(MatchesSnapshots::class);
+
+beforeEach(function () {
+    $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection();
+});
+
+it('can render itself as an image', function () {
+    $this->assertEquals(
+        '<img src="/media/1/test.jpg" alt="test">',
+        firstMedia()->img(),
+    );
+});
+
+it('can render a conversion of itself as an image', function () {
+    $this->assertEquals(
+        '<img src="/media/1/conversions/test-thumb.jpg" alt="test">',
+        firstMedia()->img('thumb')
+    );
+});
+
+it('can render extra attributes', function () {
+    $this->assertEquals(
+        '<img class="my-class" id="my-id" src="/media/1/conversions/test-thumb.jpg" alt="test">',
+        firstMedia()->img('thumb', ['class' => 'my-class', 'id' => 'my-id']),
+    );
+});
+
+test('a media instance is htmlable', function () {
+    $media = firstMedia();
+
+    $renderedView = $this->renderView('media', compact('media'));
+
+    $this->assertEquals(
+        '<img src="/media/1/test.jpg" alt="test"> <img src="/media/1/conversions/test-thumb.jpg" alt="test">',
+        $renderedView,
+    );
+});
+
+test('converting a non image to an image tag will not blow up', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestPdf())
+        ->toMediaCollection();
+
+    $this->assertEquals('', $media->img());
+});
+
+it('can render itself with responsive images and a placeholder', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->toMediaCollection();
+
+    $image = $media->refresh()->img();
+
+    $this->assertEquals(3, substr_count($image, '/media/2/responsive-images/'));
+    $this->assertTrue(Str::contains($image, 'data:image/svg+xml;base64,'));
+});
+
+it('can render itself with responsive images of a conversion and a placeholder', function () {
+    $media = $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
+
+    $image = $media->refresh()->img('thumb');
+
+    $this->assertStringContainsString('/media/2/responsive-images/', $image);
+    $this->assertStringContainsString('data:image/svg+xml;base64,', $image);
+});
+
+it('will not rendering extra javascript or including base64 svg when tiny placeholders are turned off', function () {
+    config()->set('media-library.responsive_images.use_tiny_placeholders', false);
+
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->toMediaCollection();
+
+    $imgTag = $media->refresh()->img();
+
+    $this->assertEquals('<img srcset="http://localhost/media/2/responsive-images/test___media_library_original_340_280.jpg 340w, http://localhost/media/2/responsive-images/test___media_library_original_284_233.jpg 284w, http://localhost/media/2/responsive-images/test___media_library_original_237_195.jpg 237w" src="/media/2/test.jpg" width="340" height="280">', $imgTag);
+});
+
+test('the loading attribute can be specified on the conversion', function () {
+    $media = TestModelWithCustomLoadingAttribute::create(['name' => 'test'])
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
+
+    $originalImgTag = $media->refresh()->img();
+    $this->assertEquals('<img src="/media/2/test.jpg" alt="test">', $originalImgTag);
+
+    $lazyConversionImageTag = $media->refresh()->img('lazy-conversion');
+    $this->assertEquals('<img loading="lazy" src="/media/2/conversions/test-lazy-conversion.jpg" alt="test">', $lazyConversionImageTag);
+
+    $eagerConversionImageTag = $media->refresh()->img('eager-conversion');
+    $this->assertEquals('<img loading="eager" src="/media/2/conversions/test-eager-conversion.jpg" alt="test">', $eagerConversionImageTag);
+});
+
+it('has a shorthand function to use lazy loading', function () {
+    $this->assertEquals(
+        '<img loading="lazy" src="/media/1/test.jpg" alt="test">',
+        firstMedia()->img()->lazy()
+    );
+});
+
+it('can set extra attributes', function () {
+    $this->assertEquals(
+        '<img extra="value" src="/media/1/test.jpg" alt="test">',
+        (string) firstMedia()->img()->attributes(['extra' => 'value'])
+    );
+});
+
+// Helpers
+function firstMedia(): Media
 {
-    use MatchesSnapshots;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection();
-    }
-
-    /** @test */
-    public function it_can_render_itself_as_an_image()
-    {
-        $this->assertEquals(
-            '<img src="/media/1/test.jpg" alt="test">',
-            $this->firstMedia()->img(),
-        );
-    }
-
-    /** @test */
-    public function it_can_render_a_conversion_of_itself_as_an_image()
-    {
-        $this->assertEquals(
-            '<img src="/media/1/conversions/test-thumb.jpg" alt="test">',
-            $this->firstMedia()->img('thumb')
-        );
-    }
-
-    /** @test */
-    public function it_can_render_extra_attributes()
-    {
-        $this->assertEquals(
-            '<img class="my-class" id="my-id" src="/media/1/conversions/test-thumb.jpg" alt="test">',
-            $this->firstMedia()->img('thumb', ['class' => 'my-class', 'id' => 'my-id']),
-        );
-    }
-
-    /** @test */
-    public function a_media_instance_is_htmlable()
-    {
-        $media = $this->firstMedia();
-
-        $renderedView = $this->renderView('media', compact('media'));
-
-        $this->assertEquals(
-            '<img src="/media/1/test.jpg" alt="test"> <img src="/media/1/conversions/test-thumb.jpg" alt="test">',
-            $renderedView,
-        );
-    }
-
-    /** @test */
-    public function converting_a_non_image_to_an_image_tag_will_not_blow_up()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestPdf())
-            ->toMediaCollection();
-
-        $this->assertEquals('', $media->img());
-    }
-
-    /** @test */
-    public function it_can_render_itself_with_responsive_images_and_a_placeholder()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->withResponsiveImages()
-            ->toMediaCollection();
-
-        $image = $media->refresh()->img();
-
-        $this->assertEquals(3, substr_count($image, '/media/2/responsive-images/'));
-        $this->assertTrue(Str::contains($image, 'data:image/svg+xml;base64,'));
-    }
-
-    /** @test */
-    public function it_can_render_itself_with_responsive_images_of_a_conversion_and_a_placeholder()
-    {
-        $media = $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
-
-        $image = $media->refresh()->img('thumb');
-
-        $this->assertStringContainsString('/media/2/responsive-images/', $image);
-        $this->assertStringContainsString('data:image/svg+xml;base64,', $image);
-    }
-
-    /** @test */
-    public function it_will_not_rendering_extra_javascript_or_including_base64_svg_when_tiny_placeholders_are_turned_off()
-    {
-        config()->set('media-library.responsive_images.use_tiny_placeholders', false);
-
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->withResponsiveImages()
-            ->toMediaCollection();
-
-        $imgTag = $media->refresh()->img();
-
-        $this->assertEquals('<img srcset="http://localhost/media/2/responsive-images/test___media_library_original_340_280.jpg 340w, http://localhost/media/2/responsive-images/test___media_library_original_284_233.jpg 284w, http://localhost/media/2/responsive-images/test___media_library_original_237_195.jpg 237w" src="/media/2/test.jpg" width="340" height="280">', $imgTag);
-    }
-
-    /** @test */
-    public function the_loading_attribute_can_be_specified_on_the_conversion()
-    {
-        $media = TestModelWithCustomLoadingAttribute::create(['name' => 'test'])
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection();
-
-        $originalImgTag = $media->refresh()->img();
-        $this->assertEquals('<img src="/media/2/test.jpg" alt="test">', $originalImgTag);
-
-        $lazyConversionImageTag = $media->refresh()->img('lazy-conversion');
-        $this->assertEquals('<img loading="lazy" src="/media/2/conversions/test-lazy-conversion.jpg" alt="test">', $lazyConversionImageTag);
-
-        $eagerConversionImageTag = $media->refresh()->img('eager-conversion');
-        $this->assertEquals('<img loading="eager" src="/media/2/conversions/test-eager-conversion.jpg" alt="test">', $eagerConversionImageTag);
-    }
-
-    /** @test */
-    public function it_has_a_shorthand_function_to_use_lazy_loading()
-    {
-        $this->assertEquals(
-            '<img loading="lazy" src="/media/1/test.jpg" alt="test">',
-            $this->firstMedia()->img()->lazy()
-        );
-    }
-
-    /** @test */
-    public function it_can_set_extra_attributes()
-    {
-        $this->assertEquals(
-            '<img extra="value" src="/media/1/test.jpg" alt="test">',
-            (string) $this->firstMedia()->img()->attributes(['extra' => 'value'])
-        );
-    }
-
-    protected function firstMedia(): Media
-    {
-        return Media::first();
-    }
+    return Media::first();
 }

--- a/tests/Feature/Media/ToHtmlTest.php
+++ b/tests/Feature/Media/ToHtmlTest.php
@@ -53,7 +53,7 @@ test('converting a non image to an image tag will not blow up', function () {
         ->addMedia($this->getTestPdf())
         ->toMediaCollection();
 
-    $this->assertEquals('', $media->img());
+    expect($media->img())->toEqual('');
 });
 
 it('can render itself with responsive images and a placeholder', function () {
@@ -64,8 +64,8 @@ it('can render itself with responsive images and a placeholder', function () {
 
     $image = $media->refresh()->img();
 
-    $this->assertEquals(3, substr_count($image, '/media/2/responsive-images/'));
-    $this->assertTrue(Str::contains($image, 'data:image/svg+xml;base64,'));
+    expect(substr_count($image, '/media/2/responsive-images/'))->toEqual(3);
+    expect(Str::contains($image, 'data:image/svg+xml;base64,'))->toBeTrue();
 });
 
 it('can render itself with responsive images of a conversion and a placeholder', function () {
@@ -75,8 +75,8 @@ it('can render itself with responsive images of a conversion and a placeholder',
 
     $image = $media->refresh()->img('thumb');
 
-    $this->assertStringContainsString('/media/2/responsive-images/', $image);
-    $this->assertStringContainsString('data:image/svg+xml;base64,', $image);
+    expect($image)->toContain('/media/2/responsive-images/');
+    expect($image)->toContain('data:image/svg+xml;base64,');
 });
 
 it('will not rendering extra javascript or including base64 svg when tiny placeholders are turned off', function () {
@@ -89,7 +89,7 @@ it('will not rendering extra javascript or including base64 svg when tiny placeh
 
     $imgTag = $media->refresh()->img();
 
-    $this->assertEquals('<img srcset="http://localhost/media/2/responsive-images/test___media_library_original_340_280.jpg 340w, http://localhost/media/2/responsive-images/test___media_library_original_284_233.jpg 284w, http://localhost/media/2/responsive-images/test___media_library_original_237_195.jpg 237w" src="/media/2/test.jpg" width="340" height="280">', $imgTag);
+    expect($imgTag)->toEqual('<img srcset="http://localhost/media/2/responsive-images/test___media_library_original_340_280.jpg 340w, http://localhost/media/2/responsive-images/test___media_library_original_284_233.jpg 284w, http://localhost/media/2/responsive-images/test___media_library_original_237_195.jpg 237w" src="/media/2/test.jpg" width="340" height="280">');
 });
 
 test('the loading attribute can be specified on the conversion', function () {
@@ -98,13 +98,13 @@ test('the loading attribute can be specified on the conversion', function () {
         ->toMediaCollection();
 
     $originalImgTag = $media->refresh()->img();
-    $this->assertEquals('<img src="/media/2/test.jpg" alt="test">', $originalImgTag);
+    expect($originalImgTag)->toEqual('<img src="/media/2/test.jpg" alt="test">');
 
     $lazyConversionImageTag = $media->refresh()->img('lazy-conversion');
-    $this->assertEquals('<img loading="lazy" src="/media/2/conversions/test-lazy-conversion.jpg" alt="test">', $lazyConversionImageTag);
+    expect($lazyConversionImageTag)->toEqual('<img loading="lazy" src="/media/2/conversions/test-lazy-conversion.jpg" alt="test">');
 
     $eagerConversionImageTag = $media->refresh()->img('eager-conversion');
-    $this->assertEquals('<img loading="eager" src="/media/2/conversions/test-eager-conversion.jpg" alt="test">', $eagerConversionImageTag);
+    expect($eagerConversionImageTag)->toEqual('<img loading="eager" src="/media/2/conversions/test-eager-conversion.jpg" alt="test">');
 });
 
 it('has a shorthand function to use lazy loading', function () {

--- a/tests/Feature/Media/ToResponseTest.php
+++ b/tests/Feature/Media/ToResponseTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
-uses(TestCase::class);
 
 test('to response sends the content', function () {
     $media = $this->testModel->addMedia($testPdf = $this->getTestPdf())->preservingOriginal()->toMediaCollection();

--- a/tests/Feature/Media/ToResponseTest.php
+++ b/tests/Feature/Media/ToResponseTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
-
 
 test('to response sends the content', function () {
     $media = $this->testModel->addMedia($testPdf = $this->getTestPdf())->preservingOriginal()->toMediaCollection();

--- a/tests/Feature/Media/ToResponseTest.php
+++ b/tests/Feature/Media/ToResponseTest.php
@@ -1,45 +1,36 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
-class ToResponseTest extends TestCase
-{
-    /** @test */
-    public function test_to_response_sends_the_content()
-    {
-        $media = $this->testModel->addMedia($testPdf = $this->getTestPdf())->preservingOriginal()->toMediaCollection();
+uses(TestCase::class);
 
-        ob_start();
-        @$media->toResponse(request())->sendContent();
-        $content = ob_get_contents();
-        ob_end_clean();
+test('to response sends the content', function () {
+    $media = $this->testModel->addMedia($testPdf = $this->getTestPdf())->preservingOriginal()->toMediaCollection();
 
-        $temporaryDirectory = (new TemporaryDirectory())->create();
-        file_put_contents($temporaryDirectory->path('response.pdf'), $content);
+    ob_start();
+    @$media->toResponse(request())->sendContent();
+    $content = ob_get_contents();
+    ob_end_clean();
 
-        $this->assertFileEquals($testPdf, $temporaryDirectory->path('response.pdf'));
-    }
+    $temporaryDirectory = (new TemporaryDirectory())->create();
+    file_put_contents($temporaryDirectory->path('response.pdf'), $content);
 
-    /** @test */
-    public function test_to_response_sends_correct_attachment_header()
-    {
-        $media = $this->testModel->addMedia($this->getTestPdf())->preservingOriginal()->toMediaCollection();
+    $this->assertFileEquals($testPdf, $temporaryDirectory->path('response.pdf'));
+});
 
-        $response = $media->toResponse(request());
+test('to response sends correct attachment header', function () {
+    $media = $this->testModel->addMedia($this->getTestPdf())->preservingOriginal()->toMediaCollection();
 
-        $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
-    }
+    $response = $media->toResponse(request());
 
-    /** @test */
-    public function test_to_inline_response_sends_correct_attachment_header()
-    {
-        $media = $this->testModel->addMedia($this->getTestPdf())->preservingOriginal()->toMediaCollection();
+    $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+});
 
-        $response = $media->toInlineResponse(request());
+test('to inline response sends correct attachment header', function () {
+    $media = $this->testModel->addMedia($this->getTestPdf())->preservingOriginal()->toMediaCollection();
 
-        $this->assertEquals('inline; filename="test.pdf"', $response->headers->get('Content-Disposition'));
-    }
-}
+    $response = $media->toInlineResponse(request());
+
+    $this->assertEquals('inline; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+});

--- a/tests/Feature/Media/ToResponseTest.php
+++ b/tests/Feature/Media/ToResponseTest.php
@@ -24,7 +24,7 @@ test('to response sends correct attachment header', function () {
 
     $response = $media->toResponse(request());
 
-    $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+    expect($response->headers->get('Content-Disposition'))->toEqual('attachment; filename="test.pdf"');
 });
 
 test('to inline response sends correct attachment header', function () {
@@ -32,5 +32,5 @@ test('to inline response sends correct attachment header', function () {
 
     $response = $media->toInlineResponse(request());
 
-    $this->assertEquals('inline; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+    expect($response->headers->get('Content-Disposition'))->toEqual('inline; filename="test.pdf"');
 });

--- a/tests/Feature/Media/UpdateManipulationsTest.php
+++ b/tests/Feature/Media/UpdateManipulationsTest.php
@@ -33,7 +33,7 @@ it('will create derived files when manipulations have changed', function () {
 
     $modificationTimeAfterManipulationChanged = filemtime($media->getPath('update_test'));
 
-    $this->assertGreaterThan($conversionModificationTime, $modificationTimeAfterManipulationChanged);
+    expect($modificationTimeAfterManipulationChanged)->toBeGreaterThan($conversionModificationTime);
 });
 
 it('will not create derived files when manipulations have not changed', function () {
@@ -72,5 +72,5 @@ it('will not create derived files when manipulations have not changed', function
 
     $modificationTimeAfterManipulationChanged = filemtime($media->getPath('update_test'));
 
-    $this->assertEquals($conversionModificationTime, $modificationTimeAfterManipulationChanged);
+    expect($modificationTimeAfterManipulationChanged)->toEqual($conversionModificationTime);
 });

--- a/tests/Feature/Media/UpdateManipulationsTest.php
+++ b/tests/Feature/Media/UpdateManipulationsTest.php
@@ -5,7 +5,7 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
 it('will create derived files when manipulations have changed', function () {
     $testModelClass = new class () extends TestModel {
-        public function registerMediaConversions(Media $media = null)
+        public function registerMediaConversions(Media $media = null): void
         {
             $this->addMediaConversion('update_test');
         }
@@ -36,7 +36,7 @@ it('will create derived files when manipulations have changed', function () {
 
 it('will not create derived files when manipulations have not changed', function () {
     $testModelClass = new class () extends TestModel {
-        public function registerMediaConversions(Media $media = null)
+        public function registerMediaConversions(Media $media = null): void
         {
             $this->addMediaConversion('update_test');
         }

--- a/tests/Feature/Media/UpdateManipulationsTest.php
+++ b/tests/Feature/Media/UpdateManipulationsTest.php
@@ -5,7 +5,8 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
 it('will create derived files when manipulations have changed', function () {
     $testModelClass = new class () extends TestModel {
-        public function registerMediaConversions(Media $media = null) {
+        public function registerMediaConversions(Media $media = null)
+        {
             $this->addMediaConversion('update_test');
         }
     };
@@ -35,7 +36,8 @@ it('will create derived files when manipulations have changed', function () {
 
 it('will not create derived files when manipulations have not changed', function () {
     $testModelClass = new class () extends TestModel {
-        public function registerMediaConversions(Media $media = null) {
+        public function registerMediaConversions(Media $media = null)
+        {
             $this->addMediaConversion('update_test');
         }
     };

--- a/tests/Feature/Media/UpdateManipulationsTest.php
+++ b/tests/Feature/Media/UpdateManipulationsTest.php
@@ -1,9 +1,7 @@
 <?php
 
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
-
 
 it('will create derived files when manipulations have changed', function () {
     $testModelClass = new class () extends TestModel {

--- a/tests/Feature/Media/UpdateManipulationsTest.php
+++ b/tests/Feature/Media/UpdateManipulationsTest.php
@@ -4,7 +4,6 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-uses(TestCase::class);
 
 it('will create derived files when manipulations have changed', function () {
     $testModelClass = new class () extends TestModel {

--- a/tests/Feature/Media/UpdateManipulationsTest.php
+++ b/tests/Feature/Media/UpdateManipulationsTest.php
@@ -1,85 +1,76 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Media;
-
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
-class UpdateManipulationsTest extends TestCase
-{
-    /** @test */
-    public function it_will_create_derived_files_when_manipulations_have_changed()
-    {
-        $testModelClass = new class () extends TestModel {
-            public function registerMediaConversions(Media $media = null): void
-            {
-                $this->addMediaConversion('update_test');
-            }
-        };
+uses(TestCase::class);
 
-        $testModel = $testModelClass::find($this->testModel->id);
+it('will create derived files when manipulations have changed', function () {
+    $testModelClass = new class () extends TestModel {
+        public function registerMediaConversions(Media $media = null) {
+            $this->addMediaConversion('update_test');
+        }
+    };
 
-        /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
-        $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $testModel = $testModelClass::find($this->testModel->id);
 
-        touch($media->getPath('update_test'), time() - 1);
+    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-        $conversionModificationTime = filemtime($media->getPath('update_test'));
+    touch($media->getPath('update_test'), time() - 1);
 
-        $media->manipulations = [
-            'update_test' => [
-                'width' => 1,
-                'height' => 1,
-            ],
-        ];
+    $conversionModificationTime = filemtime($media->getPath('update_test'));
 
-        $media->save();
+    $media->manipulations = [
+        'update_test' => [
+            'width' => 1,
+            'height' => 1,
+        ],
+    ];
 
-        $modificationTimeAfterManipulationChanged = filemtime($media->getPath('update_test'));
+    $media->save();
 
-        $this->assertGreaterThan($conversionModificationTime, $modificationTimeAfterManipulationChanged);
-    }
+    $modificationTimeAfterManipulationChanged = filemtime($media->getPath('update_test'));
 
-    /** @test */
-    public function it_will_not_create_derived_files_when_manipulations_have_not_changed()
-    {
-        $testModelClass = new class () extends TestModel {
-            public function registerMediaConversions(Media $media = null): void
-            {
-                $this->addMediaConversion('update_test');
-            }
-        };
+    $this->assertGreaterThan($conversionModificationTime, $modificationTimeAfterManipulationChanged);
+});
 
-        $testModel = $testModelClass::find($this->testModel->id);
+it('will not create derived files when manipulations have not changed', function () {
+    $testModelClass = new class () extends TestModel {
+        public function registerMediaConversions(Media $media = null) {
+            $this->addMediaConversion('update_test');
+        }
+    };
 
-        /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
-        $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $testModel = $testModelClass::find($this->testModel->id);
 
-        $media->manipulations = [
-            'update_test' => [
-                'width' => 1,
-                'height' => 1,
-            ], ];
+    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
-        $media->save();
+    $media->manipulations = [
+        'update_test' => [
+            'width' => 1,
+            'height' => 1,
+        ], ];
 
-        touch($media->getPath('update_test'), time() - 1);
+    $media->save();
 
-        $conversionModificationTime = filemtime($media->getPath('update_test'));
+    touch($media->getPath('update_test'), time() - 1);
 
-        $media->manipulations = [
-            'update_test' => [
-                'width' => 1,
-                'height' => 1,
-            ], ];
+    $conversionModificationTime = filemtime($media->getPath('update_test'));
 
-        $media->updated_at = now()->addSecond();
+    $media->manipulations = [
+        'update_test' => [
+            'width' => 1,
+            'height' => 1,
+        ], ];
 
-        $media->save();
+    $media->updated_at = now()->addSecond();
 
-        $modificationTimeAfterManipulationChanged = filemtime($media->getPath('update_test'));
+    $media->save();
 
-        $this->assertEquals($conversionModificationTime, $modificationTimeAfterManipulationChanged);
-    }
-}
+    $modificationTimeAfterManipulationChanged = filemtime($media->getPath('update_test'));
+
+    $this->assertEquals($conversionModificationTime, $modificationTimeAfterManipulationChanged);
+});

--- a/tests/Feature/Performance/PerformanceTest.php
+++ b/tests/Feature/Performance/PerformanceTest.php
@@ -19,5 +19,5 @@ it('can use eagerly loaded media', function () {
         $testModel->getFirstMediaUrl('images', 'thumb');
     }
 
-    $this->assertCount(2, DB::getQueryLog());
+    expect(DB::getQueryLog())->toHaveCount(2);
 });

--- a/tests/Feature/Performance/PerformanceTest.php
+++ b/tests/Feature/Performance/PerformanceTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can use eagerly loaded media', function () {
     foreach (range(1, 10) as $index) {

--- a/tests/Feature/Performance/PerformanceTest.php
+++ b/tests/Feature/Performance/PerformanceTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use DB;
 use Spatie\MediaLibrary\Tests\TestCase;
 
 uses(TestCase::class);

--- a/tests/Feature/Performance/PerformanceTest.php
+++ b/tests/Feature/Performance/PerformanceTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 it('can use eagerly loaded media', function () {

--- a/tests/Feature/Performance/PerformanceTest.php
+++ b/tests/Feature/Performance/PerformanceTest.php
@@ -1,29 +1,24 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\Performance;
-
 use DB;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class PerformanceTest extends TestCase
-{
-    /** @test */
-    public function it_can_use_eagerly_loaded_media()
-    {
-        foreach (range(1, 10) as $index) {
-            $testModel = $this->testModelWithConversion->create(['name' => "test{$index}"]);
-            $testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
-        }
+uses(TestCase::class);
 
-        DB::connection()->enableQueryLog();
-
-        $testModels = $this->testModelWithConversion->get();
-        $testModels->load('media');
-
-        foreach ($testModels as $testModel) {
-            $testModel->getFirstMediaUrl('images', 'thumb');
-        }
-
-        $this->assertCount(2, DB::getQueryLog());
+it('can use eagerly loaded media', function () {
+    foreach (range(1, 10) as $index) {
+        $testModel = $this->testModelWithConversion->create(['name' => "test{$index}"]);
+        $testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
     }
-}
+
+    DB::connection()->enableQueryLog();
+
+    $testModels = $this->testModelWithConversion->get();
+    $testModels->load('media');
+
+    foreach ($testModels as $testModel) {
+        $testModel->getFirstMediaUrl('images', 'thumb');
+    }
+
+    $this->assertCount(2, DB::getQueryLog());
+});

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -6,9 +6,7 @@ use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\Support\MediaStream;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
-
 
 beforeEach(function () {
     if (! canTestS3()) {

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -9,7 +9,6 @@ use Spatie\MediaLibrary\Support\MediaStream;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     if (! canTestS3()) {

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -171,7 +171,7 @@ it('can get the temporary url to first media in a collection', function () {
     $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images', 's3_disk');
     $secondMedia->save();
 
-    $this->assertEquals($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5)), $this->testModel->getFirstTemporaryUrl(Carbon::now()->addMinutes(5), 'images'));
+    expect($this->testModel->getFirstTemporaryUrl(Carbon::now()->addMinutes(5), 'images'))->toEqual($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5)));
 });
 
 it('retrieves a temporary media conversion url from s3', function () {
@@ -201,7 +201,7 @@ test('custom headers are used for all conversions', function () {
         'Key' => $media->getPath(),
     ]));
 
-    $this->assertEquals('READ', $responseForMainItem->get('Grants')[1]['Permission'] ?? null);
+    expect($responseForMainItem->get('Grants')[1]['Permission'] ?? null)->toEqual('READ');
 
     /** @var \Aws\Result $responseForConversion */
     $responseForConversion = $client->execute($client->getCommand('GetObjectAcl', [
@@ -209,7 +209,7 @@ test('custom headers are used for all conversions', function () {
         'Key' => $media->getPath('thumb'),
     ]));
 
-    $this->assertEquals('READ', $responseForConversion->get('Grants')[1]['Permission'] ?? null);
+    expect($responseForConversion->get('Grants')[1]['Permission'] ?? null)->toEqual('READ');
 });
 
 test('custom headers are used for all conversions when adding private media from same s3 disk', function () {
@@ -234,7 +234,7 @@ test('custom headers are used for all conversions when adding private media from
         'Key' => $media->getPath(),
     ]));
 
-    $this->assertEquals('READ', $responseForMainItem->get('Grants')[1]['Permission'] ?? null);
+    expect($responseForMainItem->get('Grants')[1]['Permission'] ?? null)->toEqual('READ');
 
     /** @var \Aws\Result $responseForConversion */
     $responseForConversion = $client->execute($client->getCommand('GetObjectAcl', [
@@ -242,7 +242,7 @@ test('custom headers are used for all conversions when adding private media from
         'Key' => $media->getPath('thumb'),
     ]));
 
-    $this->assertEquals('READ', $responseForConversion->get('Grants')[1]['Permission'] ?? null);
+    expect($responseForConversion->get('Grants')[1]['Permission'] ?? null)->toEqual('READ');
 });
 
 test('extra headers are used for all conversions when adding private media from same s3 disk', function () {
@@ -268,7 +268,7 @@ test('extra headers are used for all conversions when adding private media from 
         'Key' => $media->getPath(),
     ]));
 
-    $this->assertEquals('READ', $responseForMainItem->get('Grants')[1]['Permission'] ?? null);
+    expect($responseForMainItem->get('Grants')[1]['Permission'] ?? null)->toEqual('READ');
 
     /** @var \Aws\Result $responseForConversion */
     $responseForConversion = $client->execute($client->getCommand('GetObjectAcl', [
@@ -276,7 +276,7 @@ test('extra headers are used for all conversions when adding private media from 
         'Key' => $media->getPath('thumb'),
     ]));
 
-    $this->assertEquals('READ', $responseForConversion->get('Grants')[1]['Permission'] ?? null);
+    expect($responseForConversion->get('Grants')[1]['Permission'] ?? null)->toEqual('READ');
 });
 
 it('can regenerate only missing with s3 disk', function () {
@@ -308,8 +308,8 @@ it('can regenerate only missing with s3 disk', function () {
 
     assertS3FileExists($derivedMissingImage);
 
-    $this->assertSame($existsCreatedAt, Storage::disk('s3_disk')->lastModified($derivedImageExists));
-    $this->assertGreaterThan($missingCreatedAt, Storage::disk('s3_disk')->lastModified($derivedMissingImage));
+    expect(Storage::disk('s3_disk')->lastModified($derivedImageExists))->toBe($existsCreatedAt);
+    expect(Storage::disk('s3_disk')->lastModified($derivedMissingImage))->toBeGreaterThan($missingCreatedAt);
 });
 
 it('can regenerate only missing files of named conversions with s3 disk', function () {
@@ -345,8 +345,8 @@ it('can regenerate only missing files of named conversions with s3 disk', functi
 
     assertS3FileExists($derivedMissingImage);
     assertS3FileNotExists($derivedMissingImageOriginal);
-    $this->assertSame($existsCreatedAt, Storage::disk('s3_disk')->lastModified($derivedImageExists));
-    $this->assertGreaterThan($missingCreatedAt, Storage::disk('s3_disk')->lastModified($derivedMissingImage));
+    expect(Storage::disk('s3_disk')->lastModified($derivedImageExists))->toBe($existsCreatedAt);
+    expect(Storage::disk('s3_disk')->lastModified($derivedMissingImage))->toBeGreaterThan($missingCreatedAt);
 });
 
 it('can retrieve a zip with s3 disk', function () {
@@ -388,12 +388,12 @@ function getS3Client(): S3Client
 
 function assertS3FileExists(string $filePath)
 {
-    test()->assertTrue(Storage::disk('s3_disk')->has($filePath));
+    expect(Storage::disk('s3_disk')->has($filePath))->toBeTrue();
 }
 
 function assertS3FileNotExists(string $filePath)
 {
-    test()->assertFalse(Storage::disk('s3_disk')->has($filePath));
+    expect(Storage::disk('s3_disk')->has($filePath))->toBeFalse();
 }
 
 function canTestS3(): bool

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Feature\S3Integration;
-
 use Aws\S3\S3Client;
 use Carbon\Carbon;
 use Illuminate\Contracts\Filesystem\Factory;
@@ -11,454 +9,410 @@ use Spatie\MediaLibrary\Support\MediaStream;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
-class S3IntegrationTest extends TestCase
-{
-    protected string $s3BaseDirectory;
+uses(TestCase::class);
 
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        if (! $this->canTestS3()) {
-            $this->markTestSkipped('Skipping S3 tests because no S3 env variables found');
-        }
-
-        $this->s3BaseDirectory = self::getS3BaseTestDirectory();
-
-        $this->app['config']->set('media-library.path_generator', S3TestPathGenerator::class);
+beforeEach(function () {
+    if (! canTestS3()) {
+        $this->markTestSkipped('Skipping S3 tests because no S3 env variables found');
     }
 
-    public function tearDown(): void
-    {
-        $this->cleanUpS3();
+    $this->s3BaseDirectory = getS3BaseTestDirectory();
 
-        $this->app['config']->set('media-library.path_generator', null);
+    app()['config']->set('media-library.path_generator', S3TestPathGenerator::class);
+});
 
-        parent::tearDown();
-    }
+afterEach(function () {
+    cleanUpS3();
 
-    /** @test */
-    public function it_can_add_media_from_a_disk_to_s3()
-    {
-        $randomNumber = rand();
+    app()['config']->set('media-library.path_generator', null);
+});
 
-        $fileName = "test{$randomNumber}.jpg";
+it('can add media from a disk to s3', function () {
+    $randomNumber = rand();
 
-        Storage::disk('s3_disk')->put("tmp/{$fileName}", file_get_contents($this->getTestJpg()));
+    $fileName = "test{$randomNumber}.jpg";
 
-        $media = $this->testModel
-            ->addMediaFromDisk("tmp/{$fileName}", 's3_disk')
-            ->toMediaCollection('default', 's3_disk');
+    Storage::disk('s3_disk')->put("tmp/{$fileName}", file_get_contents($this->getTestJpg()));
 
-        $this->assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/{$fileName}");
-    }
+    $media = $this->testModel
+        ->addMediaFromDisk("tmp/{$fileName}", 's3_disk')
+        ->toMediaCollection('default', 's3_disk');
 
-    /** @test */
-    public function it_can_store_a_file_on_s3()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('default', 's3_disk');
+    assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/{$fileName}");
+});
 
-        $this->assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
-    }
+it('can store a file on s3', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('default', 's3_disk');
 
-    /** @test */
-    public function it_can_store_a_file_and_its_conversion_on_s3()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('default', 's3_disk');
+    assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
+});
 
-        $this->assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
-        $this->assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg");
-    }
+it('can store a file and its conversion on s3', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('default', 's3_disk');
 
-    /** @test */
-    public function it_can_delete_a_file_on_s3()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('default', 's3_disk');
+    assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
+    assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg");
+});
 
-        $this->assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
+it('can delete a file on s3', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('default', 's3_disk');
 
-        $media->delete();
+    assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
 
-        $this->assertS3FileNotExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
-    }
+    $media->delete();
 
-    /** @test */
-    public function it_deletes_file_conversions_on_s3()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('default', 's3_disk');
+    assertS3FileNotExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
+});
 
-        $this->assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
-        $this->assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg");
+it('deletes file conversions on s3', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('default', 's3_disk');
 
-        $media->delete();
+    assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
+    assertS3FileExists("{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg");
 
-        $this->assertS3FileNotExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
-        $this->assertS3FileNotExists("{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg");
-    }
+    $media->delete();
 
-    /** @test */
-    public function it_retrieve_a_media_url_from_s3()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('default', 's3_disk');
+    assertS3FileNotExists("{$this->s3BaseDirectory}/{$media->id}/test.jpg");
+    assertS3FileNotExists("{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg");
+});
 
-        $this->assertEquals(
-            $this->s3BaseUrl()."/{$this->s3BaseDirectory}/{$media->id}/test.jpg",
-            $media->getUrl()
-        );
+it('retrieve a media url from s3', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('default', 's3_disk');
 
-        $this->assertEquals(
-            sha1(file_get_contents($this->getTestJpg())),
-            sha1(file_get_contents($media->getUrl()))
-        );
-    }
+    $this->assertEquals(
+        s3BaseUrl()."/{$this->s3BaseDirectory}/{$media->id}/test.jpg",
+        $media->getUrl()
+    );
 
-    /** @test */
-    public function it_retrieve_a_media_conversion_url_from_s3()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('default', 's3_disk');
+    $this->assertEquals(
+        sha1(file_get_contents($this->getTestJpg())),
+        sha1(file_get_contents($media->getUrl()))
+    );
+});
 
-        $this->assertEquals(
-            $this->s3BaseUrl()."/{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg",
-            $media->getUrl('thumb')
-        );
-    }
+it('retrieve a media conversion url from s3', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('default', 's3_disk');
 
-    /** @test */
-    public function it_retrieve_a_media_responsive_urls_from_s3()
-    {
-        $media = $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestJpg())
-            ->withResponsiveImages()
-            ->toMediaCollection('default', 's3_disk');
+    $this->assertEquals(
+        s3BaseUrl()."/{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg",
+        $media->getUrl('thumb')
+    );
+});
 
-        $this->assertEquals([
-            $this->s3BaseUrl()."/{$this->s3BaseDirectory}/{$media->id}/responsive-images/test___thumb_50_41.jpg",
-        ], $media->getResponsiveImageUrls('thumb'));
-    }
+it('retrieve a media responsive urls from s3', function () {
+    $media = $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->toMediaCollection('default', 's3_disk');
 
-    /** @test */
-    public function it_retrieves_a_temporary_media_url_from_s3()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('default', 's3_disk');
+    $this->assertEquals([
+        s3BaseUrl()."/{$this->s3BaseDirectory}/{$media->id}/responsive-images/test___thumb_50_41.jpg",
+    ], $media->getResponsiveImageUrls('thumb'));
+});
 
-        $this->assertStringContainsString(
-            "/{$this->s3BaseDirectory}/{$media->id}/test.jpg",
-            $media->getTemporaryUrl(Carbon::now()->addMinutes(5))
-        );
+it('retrieves a temporary media url from s3', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('default', 's3_disk');
 
-        $this->assertEquals(
-            sha1(file_get_contents($this->getTestJpg())),
-            sha1(file_get_contents($media->getTemporaryUrl(Carbon::now()->addMinutes(5))))
-        );
-    }
+    $this->assertStringContainsString(
+        "/{$this->s3BaseDirectory}/{$media->id}/test.jpg",
+        $media->getTemporaryUrl(Carbon::now()->addMinutes(5))
+    );
 
-    /** @test */
-    public function it_retrieves_a_temporary_media_url_from_s3_when_s3_root_not_empty()
-    {
-        config()->set('filesystems.disks.s3_disk.root', 'test-root');
+    $this->assertEquals(
+        sha1(file_get_contents($this->getTestJpg())),
+        sha1(file_get_contents($media->getTemporaryUrl(Carbon::now()->addMinutes(5))))
+    );
+});
 
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection('default', 's3_disk');
+it('retrieves a temporary media url from s3 when s3 root not empty', function () {
+    config()->set('filesystems.disks.s3_disk.root', 'test-root');
 
-        $this->assertStringContainsString(
-            "/{$this->s3BaseDirectory}/{$media->id}/test.jpg",
-            $media->getTemporaryUrl(Carbon::now()->addMinutes(5))
-        );
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('default', 's3_disk');
 
-        $this->assertStringNotContainsString(
-            '/test-root/test-root',
-            $media->getTemporaryUrl(Carbon::now()->addMinutes(5))
-        );
+    $this->assertStringContainsString(
+        "/{$this->s3BaseDirectory}/{$media->id}/test.jpg",
+        $media->getTemporaryUrl(Carbon::now()->addMinutes(5))
+    );
 
-        $this->assertEquals(
-            sha1(file_get_contents($this->getTestJpg())),
-            sha1(file_get_contents($media->getTemporaryUrl(Carbon::now()->addMinutes(5))))
-        );
-    }
+    $this->assertStringNotContainsString(
+        '/test-root/test-root',
+        $media->getTemporaryUrl(Carbon::now()->addMinutes(5))
+    );
 
-    /** @test */
-    public function it_can_get_the_temporary_url_to_first_media_in_a_collection()
-    {
-        $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images', 's3_disk');
-        $firstMedia->save();
+    $this->assertEquals(
+        sha1(file_get_contents($this->getTestJpg())),
+        sha1(file_get_contents($media->getTemporaryUrl(Carbon::now()->addMinutes(5))))
+    );
+});
 
-        $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images', 's3_disk');
-        $secondMedia->save();
+it('can get the temporary url to first media in a collection', function () {
+    $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images', 's3_disk');
+    $firstMedia->save();
 
-        $this->assertEquals($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5)), $this->testModel->getFirstTemporaryUrl(Carbon::now()->addMinutes(5), 'images'));
-    }
+    $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images', 's3_disk');
+    $secondMedia->save();
 
-    /** @test */
-    public function it_retrieves_a_temporary_media_conversion_url_from_s3()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('default', 's3_disk');
+    $this->assertEquals($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5)), $this->testModel->getFirstTemporaryUrl(Carbon::now()->addMinutes(5), 'images'));
+});
 
-        $this->assertStringContainsString(
-            "/{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg",
-            $media->getTemporaryUrl(Carbon::now()->addMinutes(5), 'thumb')
-        );
-    }
+it('retrieves a temporary media conversion url from s3', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('default', 's3_disk');
 
-    /** @test */
-    public function custom_headers_are_used_for_all_conversions()
-    {
-        $media = $this->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->addCustomHeaders([
-                'ACL' => 'public-read',
-            ])
-            ->toMediaCollection('default', 's3_disk');
+    $this->assertStringContainsString(
+        "/{$this->s3BaseDirectory}/{$media->id}/conversions/test-thumb.jpg",
+        $media->getTemporaryUrl(Carbon::now()->addMinutes(5), 'thumb')
+    );
+});
 
-        $client = $this->getS3Client();
-
-        /** @var \Aws\Result $responseForMainItem */
-        $responseForMainItem = $client->execute($client->getCommand('GetObjectAcl', [
-            'Bucket' => getenv('AWS_BUCKET'),
-            'Key' => $media->getPath(),
-        ]));
-
-        $this->assertEquals('READ', $responseForMainItem->get('Grants')[1]['Permission'] ?? null);
-
-        /** @var \Aws\Result $responseForConversion */
-        $responseForConversion = $client->execute($client->getCommand('GetObjectAcl', [
-            'Bucket' => getenv('AWS_BUCKET'),
-            'Key' => $media->getPath('thumb'),
-        ]));
-
-        $this->assertEquals('READ', $responseForConversion->get('Grants')[1]['Permission'] ?? null);
-    }
-
-    /** @test */
-    public function custom_headers_are_used_for_all_conversions_when_adding_private_media_from_same_s3_disk()
-    {
-        $randomNumber = rand();
-
-        $fileName = "test{$randomNumber}.jpg";
-
-        Storage::disk('s3_disk')->put("tmp/{$fileName}", file_get_contents($this->getTestJpg()));
-
-        $media = $this->testModelWithConversion
-            ->addMediaFromDisk("tmp/{$fileName}", 's3_disk')
-            ->addCustomHeaders([
-                'ACL' => 'public-read',
-            ])
-            ->toMediaCollection('default', 's3_disk');
-
-        $client = $this->getS3Client();
-
-        /** @var \Aws\Result $responseForMainItem */
-        $responseForMainItem = $client->execute($client->getCommand('GetObjectAcl', [
-            'Bucket' => getenv('AWS_BUCKET'),
-            'Key' => $media->getPath(),
-        ]));
-
-        $this->assertEquals('READ', $responseForMainItem->get('Grants')[1]['Permission'] ?? null);
-
-        /** @var \Aws\Result $responseForConversion */
-        $responseForConversion = $client->execute($client->getCommand('GetObjectAcl', [
-            'Bucket' => getenv('AWS_BUCKET'),
-            'Key' => $media->getPath('thumb'),
-        ]));
-
-        $this->assertEquals('READ', $responseForConversion->get('Grants')[1]['Permission'] ?? null);
-    }
-
-    /** @test */
-    public function extra_headers_are_used_for_all_conversions_when_adding_private_media_from_same_s3_disk()
-    {
-        config()->set('media-library.remote.extra_headers', [
+test('custom headers are used for all conversions', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->addCustomHeaders([
             'ACL' => 'public-read',
-        ]);
+        ])
+        ->toMediaCollection('default', 's3_disk');
 
-        $randomNumber = random_int(0, mt_getrandmax());
+    $client = getS3Client();
 
-        $fileName = "test{$randomNumber}.jpg";
+    /** @var \Aws\Result $responseForMainItem */
+    $responseForMainItem = $client->execute($client->getCommand('GetObjectAcl', [
+        'Bucket' => getenv('AWS_BUCKET'),
+        'Key' => $media->getPath(),
+    ]));
 
-        Storage::disk('s3_disk')->put("tmp/{$fileName}", file_get_contents($this->getTestJpg()));
+    $this->assertEquals('READ', $responseForMainItem->get('Grants')[1]['Permission'] ?? null);
 
-        $media = $this->testModelWithConversion
-            ->addMediaFromDisk("tmp/{$fileName}", 's3_disk')
-            ->toMediaCollection('default', 's3_disk');
+    /** @var \Aws\Result $responseForConversion */
+    $responseForConversion = $client->execute($client->getCommand('GetObjectAcl', [
+        'Bucket' => getenv('AWS_BUCKET'),
+        'Key' => $media->getPath('thumb'),
+    ]));
 
-        $client = $this->getS3Client();
+    $this->assertEquals('READ', $responseForConversion->get('Grants')[1]['Permission'] ?? null);
+});
 
-        /** @var \Aws\Result $responseForMainItem */
-        $responseForMainItem = $client->execute($client->getCommand('GetObjectAcl', [
-            'Bucket' => getenv('AWS_BUCKET'),
-            'Key' => $media->getPath(),
-        ]));
+test('custom headers are used for all conversions when adding private media from same s3 disk', function () {
+    $randomNumber = rand();
 
-        $this->assertEquals('READ', $responseForMainItem->get('Grants')[1]['Permission'] ?? null);
+    $fileName = "test{$randomNumber}.jpg";
 
-        /** @var \Aws\Result $responseForConversion */
-        $responseForConversion = $client->execute($client->getCommand('GetObjectAcl', [
-            'Bucket' => getenv('AWS_BUCKET'),
-            'Key' => $media->getPath('thumb'),
-        ]));
+    Storage::disk('s3_disk')->put("tmp/{$fileName}", file_get_contents($this->getTestJpg()));
 
-        $this->assertEquals('READ', $responseForConversion->get('Grants')[1]['Permission'] ?? null);
+    $media = $this->testModelWithConversion
+        ->addMediaFromDisk("tmp/{$fileName}", 's3_disk')
+        ->addCustomHeaders([
+            'ACL' => 'public-read',
+        ])
+        ->toMediaCollection('default', 's3_disk');
+
+    $client = getS3Client();
+
+    /** @var \Aws\Result $responseForMainItem */
+    $responseForMainItem = $client->execute($client->getCommand('GetObjectAcl', [
+        'Bucket' => getenv('AWS_BUCKET'),
+        'Key' => $media->getPath(),
+    ]));
+
+    $this->assertEquals('READ', $responseForMainItem->get('Grants')[1]['Permission'] ?? null);
+
+    /** @var \Aws\Result $responseForConversion */
+    $responseForConversion = $client->execute($client->getCommand('GetObjectAcl', [
+        'Bucket' => getenv('AWS_BUCKET'),
+        'Key' => $media->getPath('thumb'),
+    ]));
+
+    $this->assertEquals('READ', $responseForConversion->get('Grants')[1]['Permission'] ?? null);
+});
+
+test('extra headers are used for all conversions when adding private media from same s3 disk', function () {
+    config()->set('media-library.remote.extra_headers', [
+        'ACL' => 'public-read',
+    ]);
+
+    $randomNumber = random_int(0, mt_getrandmax());
+
+    $fileName = "test{$randomNumber}.jpg";
+
+    Storage::disk('s3_disk')->put("tmp/{$fileName}", file_get_contents($this->getTestJpg()));
+
+    $media = $this->testModelWithConversion
+        ->addMediaFromDisk("tmp/{$fileName}", 's3_disk')
+        ->toMediaCollection('default', 's3_disk');
+
+    $client = getS3Client();
+
+    /** @var \Aws\Result $responseForMainItem */
+    $responseForMainItem = $client->execute($client->getCommand('GetObjectAcl', [
+        'Bucket' => getenv('AWS_BUCKET'),
+        'Key' => $media->getPath(),
+    ]));
+
+    $this->assertEquals('READ', $responseForMainItem->get('Grants')[1]['Permission'] ?? null);
+
+    /** @var \Aws\Result $responseForConversion */
+    $responseForConversion = $client->execute($client->getCommand('GetObjectAcl', [
+        'Bucket' => getenv('AWS_BUCKET'),
+        'Key' => $media->getPath('thumb'),
+    ]));
+
+    $this->assertEquals('READ', $responseForConversion->get('Grants')[1]['Permission'] ?? null);
+});
+
+it('can regenerate only missing with s3 disk', function () {
+    $mediaExists = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('default', 's3_disk');
+
+    $mediaMissing = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestPng())
+        ->toMediaCollection('default', 's3_disk');
+
+    $derivedImageExists = "{$this->s3BaseDirectory}/{$mediaExists->id}/conversions/test-thumb.jpg";
+    $derivedMissingImage = "{$this->s3BaseDirectory}/{$mediaMissing->id}/conversions/test-thumb.jpg";
+
+    $existsCreatedAt = Storage::disk('s3_disk')->lastModified($derivedImageExists);
+    $missingCreatedAt = Storage::disk('s3_disk')->lastModified($derivedMissingImage);
+
+    Storage::disk('s3_disk')->delete($derivedMissingImage);
+
+    assertS3FileNotExists($derivedMissingImage);
+
+    sleep(1);
+
+    $this->artisan('media-library:regenerate', [
+        '--only-missing' => true,
+    ]);
+
+    assertS3FileExists($derivedMissingImage);
+
+    $this->assertSame($existsCreatedAt, Storage::disk('s3_disk')->lastModified($derivedImageExists));
+    $this->assertGreaterThan($missingCreatedAt, Storage::disk('s3_disk')->lastModified($derivedMissingImage));
+});
+
+it('can regenerate only missing files of named conversions with s3 disk', function () {
+    $mediaExists = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('images', 's3_disk');
+
+    $mediaMissing = $this
+        ->testModelWithConversion
+        ->addMedia($this->getTestPng())
+        ->toMediaCollection('images', 's3_disk');
+
+    $derivedImageExists = "{$this->s3BaseDirectory}/{$mediaExists->id}/conversions/test-thumb.jpg";
+    $derivedMissingImage = "{$this->s3BaseDirectory}/{$mediaMissing->id}/conversions/test-thumb.jpg";
+    $derivedMissingImageOriginal = "{$this->s3BaseDirectory}/{$mediaMissing->id}/conversions/test-keep_original_format.png";
+
+    $existsCreatedAt = Storage::disk('s3_disk')->lastModified($derivedImageExists);
+    $missingCreatedAt = Storage::disk('s3_disk')->lastModified($derivedMissingImage);
+
+    Storage::disk('s3_disk')->delete($derivedMissingImage);
+    Storage::disk('s3_disk')->delete($derivedMissingImageOriginal);
+
+    assertS3FileNotExists($derivedMissingImage);
+    assertS3FileNotExists($derivedMissingImageOriginal);
+
+    sleep(1);
+
+    $this->artisan('media-library:regenerate', [
+        '--only-missing' => true,
+        '--only' => 'thumb',
+    ]);
+
+    assertS3FileExists($derivedMissingImage);
+    assertS3FileNotExists($derivedMissingImageOriginal);
+    $this->assertSame($existsCreatedAt, Storage::disk('s3_disk')->lastModified($derivedImageExists));
+    $this->assertGreaterThan($missingCreatedAt, Storage::disk('s3_disk')->lastModified($derivedMissingImage));
+});
+
+it('can retrieve a zip with s3 disk', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('default', 's3_disk');
+
+    $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia($media);
+
+    ob_start();
+    @$zipStreamResponse->toResponse(request())->sendContent();
+    $content = ob_get_contents();
+    ob_end_clean();
+
+    $temporaryDirectory = (new TemporaryDirectory())->create();
+    file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+    $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');
+});
+
+// Helpers
+function cleanUpS3()
+{
+    collect(Storage::disk('s3_disk')->allDirectories(getS3BaseTestDirectory()))->each(function ($directory) {
+        Storage::disk('s3_disk')->deleteDirectory($directory);
+    });
+}
+
+function getS3Client(): S3Client
+{
+    /** @var \Illuminate\Filesystem\FilesystemAdapter $disk */
+    $disk = app(Factory::class)->disk('s3_disk');
+
+    /** @var \Aws\S3\S3Client $client */
+    $client = $disk->getDriver()->getAdapter()->getClient();
+
+    return $client;
+}
+
+function assertS3FileExists(string $filePath)
+{
+    test()->assertTrue(Storage::disk('s3_disk')->has($filePath));
+}
+
+function assertS3FileNotExists(string $filePath)
+{
+    test()->assertFalse(Storage::disk('s3_disk')->has($filePath));
+}
+
+function canTestS3(): bool
+{
+    return ! empty(getenv('AWS_ACCESS_KEY_ID'));
+}
+
+function getS3BaseTestDirectory(): string
+{
+    static $uuid = null;
+
+    if (is_null($uuid)) {
+        $uuid = Str::uuid();
     }
 
-    /** @test */
-    public function it_can_regenerate_only_missing_with_s3_disk()
-    {
-        $mediaExists = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('default', 's3_disk');
+    return $uuid;
+}
 
-        $mediaMissing = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestPng())
-            ->toMediaCollection('default', 's3_disk');
-
-        $derivedImageExists = "{$this->s3BaseDirectory}/{$mediaExists->id}/conversions/test-thumb.jpg";
-        $derivedMissingImage = "{$this->s3BaseDirectory}/{$mediaMissing->id}/conversions/test-thumb.jpg";
-
-        $existsCreatedAt = Storage::disk('s3_disk')->lastModified($derivedImageExists);
-        $missingCreatedAt = Storage::disk('s3_disk')->lastModified($derivedMissingImage);
-
-        Storage::disk('s3_disk')->delete($derivedMissingImage);
-
-        $this->assertS3FileNotExists($derivedMissingImage);
-
-        sleep(1);
-
-        $this->artisan('media-library:regenerate', [
-            '--only-missing' => true,
-        ]);
-
-        $this->assertS3FileExists($derivedMissingImage);
-
-        $this->assertSame($existsCreatedAt, Storage::disk('s3_disk')->lastModified($derivedImageExists));
-        $this->assertGreaterThan($missingCreatedAt, Storage::disk('s3_disk')->lastModified($derivedMissingImage));
-    }
-
-    /** @test */
-    public function it_can_regenerate_only_missing_files_of_named_conversions_with_s3_disk()
-    {
-        $mediaExists = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('images', 's3_disk');
-
-        $mediaMissing = $this
-            ->testModelWithConversion
-            ->addMedia($this->getTestPng())
-            ->toMediaCollection('images', 's3_disk');
-
-        $derivedImageExists = "{$this->s3BaseDirectory}/{$mediaExists->id}/conversions/test-thumb.jpg";
-        $derivedMissingImage = "{$this->s3BaseDirectory}/{$mediaMissing->id}/conversions/test-thumb.jpg";
-        $derivedMissingImageOriginal = "{$this->s3BaseDirectory}/{$mediaMissing->id}/conversions/test-keep_original_format.png";
-
-        $existsCreatedAt = Storage::disk('s3_disk')->lastModified($derivedImageExists);
-        $missingCreatedAt = Storage::disk('s3_disk')->lastModified($derivedMissingImage);
-
-        Storage::disk('s3_disk')->delete($derivedMissingImage);
-        Storage::disk('s3_disk')->delete($derivedMissingImageOriginal);
-
-        $this->assertS3FileNotExists($derivedMissingImage);
-        $this->assertS3FileNotExists($derivedMissingImageOriginal);
-
-        sleep(1);
-
-        $this->artisan('media-library:regenerate', [
-            '--only-missing' => true,
-            '--only' => 'thumb',
-        ]);
-
-        $this->assertS3FileExists($derivedMissingImage);
-        $this->assertS3FileNotExists($derivedMissingImageOriginal);
-        $this->assertSame($existsCreatedAt, Storage::disk('s3_disk')->lastModified($derivedImageExists));
-        $this->assertGreaterThan($missingCreatedAt, Storage::disk('s3_disk')->lastModified($derivedMissingImage));
-    }
-
-    /** @test */
-    public function it_can_retrieve_a_zip_with_s3_disk()
-    {
-        $media = $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->toMediaCollection('default', 's3_disk');
-
-        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia($media);
-
-        ob_start();
-        @$zipStreamResponse->toResponse(request())->sendContent();
-        $content = ob_get_contents();
-        ob_end_clean();
-
-        $temporaryDirectory = (new TemporaryDirectory())->create();
-        file_put_contents($temporaryDirectory->path('response.zip'), $content);
-
-        $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');
-    }
-
-    protected function cleanUpS3()
-    {
-        collect(Storage::disk('s3_disk')->allDirectories(self::getS3BaseTestDirectory()))->each(function ($directory) {
-            Storage::disk('s3_disk')->deleteDirectory($directory);
-        });
-    }
-
-    protected function getS3Client(): S3Client
-    {
-        /** @var \Illuminate\Filesystem\FilesystemAdapter $disk */
-        $disk = app(Factory::class)->disk('s3_disk');
-
-        /** @var \Aws\S3\S3Client $client */
-        $client = $disk->getDriver()->getAdapter()->getClient();
-
-        return $client;
-    }
-
-    protected function assertS3FileExists(string $filePath)
-    {
-        $this->assertTrue(Storage::disk('s3_disk')->has($filePath));
-    }
-
-    protected function assertS3FileNotExists(string $filePath)
-    {
-        $this->assertFalse(Storage::disk('s3_disk')->has($filePath));
-    }
-
-    public function canTestS3(): bool
-    {
-        return ! empty(getenv('AWS_ACCESS_KEY_ID'));
-    }
-
-    public static function getS3BaseTestDirectory(): string
-    {
-        static $uuid = null;
-
-        if (is_null($uuid)) {
-            $uuid = Str::uuid();
-        }
-
-        return $uuid;
-    }
-
-    public function s3BaseUrl(): string
-    {
-        return 'https://laravel-medialibrary-tests.s3.eu-west-1.amazonaws.com';
-    }
+function s3BaseUrl(): string
+{
+    return 'https://laravel-medialibrary-tests.s3.eu-west-1.amazonaws.com';
 }

--- a/tests/Image/ImageFactoryTest.php
+++ b/tests/Image/ImageFactoryTest.php
@@ -18,5 +18,5 @@ test('loading an image uses the correct driver', function () {
 
     $imageDriverValue = $imageDriver->getValue($image);
 
-    $this->assertEquals('imagick', $imageDriverValue);
+    expect($imageDriverValue)->toEqual('imagick');
 });

--- a/tests/Image/ImageFactoryTest.php
+++ b/tests/Image/ImageFactoryTest.php
@@ -1,28 +1,23 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Image;
-
 use ReflectionClass;
 use Spatie\MediaLibrary\Support\ImageFactory;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class ImageFactoryTest extends TestCase
-{
-    /** @test */
-    public function loading_an_image_uses_the_correct_driver()
-    {
-        config(['media-library.image_driver' => 'imagick']);
+uses(TestCase::class);
 
-        $image = ImageFactory::load($this->getTestJpg());
+test('loading an image uses the correct driver', function () {
+    config(['media-library.image_driver' => 'imagick']);
 
-        $reflection = new ReflectionClass($image);
+    $image = ImageFactory::load($this->getTestJpg());
 
-        $imageDriver = $reflection->getProperty('imageDriver');
+    $reflection = new ReflectionClass($image);
 
-        $imageDriver->setAccessible(true);
+    $imageDriver = $reflection->getProperty('imageDriver');
 
-        $imageDriverValue = $imageDriver->getValue($image);
+    $imageDriver->setAccessible(true);
 
-        $this->assertEquals('imagick', $imageDriverValue);
-    }
-}
+    $imageDriverValue = $imageDriver->getValue($image);
+
+    $this->assertEquals('imagick', $imageDriverValue);
+});

--- a/tests/Image/ImageFactoryTest.php
+++ b/tests/Image/ImageFactoryTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Support\ImageFactory;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 test('loading an image uses the correct driver', function () {
     config(['media-library.image_driver' => 'imagick']);

--- a/tests/Image/ImageFactoryTest.php
+++ b/tests/Image/ImageFactoryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use ReflectionClass;
 use Spatie\MediaLibrary\Support\ImageFactory;
 use Spatie\MediaLibrary\Tests\TestCase;
 

--- a/tests/Image/ImageFactoryTest.php
+++ b/tests/Image/ImageFactoryTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\Support\ImageFactory;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 test('loading an image uses the correct driver', function () {
     config(['media-library.image_driver' => 'imagick']);

--- a/tests/MediaCollections/EventTest.php
+++ b/tests/MediaCollections/EventTest.php
@@ -2,8 +2,6 @@
 
 use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenAdded;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 beforeEach(function () {
     parent::setup();

--- a/tests/MediaCollections/EventTest.php
+++ b/tests/MediaCollections/EventTest.php
@@ -4,7 +4,6 @@ use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenAdded;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     parent::setup();

--- a/tests/MediaCollections/EventTest.php
+++ b/tests/MediaCollections/EventTest.php
@@ -1,25 +1,19 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\MediaCollections;
-
 use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenAdded;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class EventTest extends TestCase
-{
-    public function setUp(): void
-    {
-        parent::setup();
+uses(TestCase::class);
 
-        Event::fake();
-    }
+beforeEach(function () {
+    parent::setup();
 
-    /** @test */
-    public function it_will_fire_the_media_added_event()
-    {
-        $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+    Event::fake();
+});
 
-        Event::assertDispatched(MediaHasBeenAdded::class);
-    }
-}
+it('will fire the media added event', function () {
+    $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+
+    Event::assertDispatched(MediaHasBeenAdded::class);
+});

--- a/tests/MediaCollections/FileSystem/FileSystemTest.php
+++ b/tests/MediaCollections/FileSystem/FileSystemTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $this->filesystem = app()->make(Filesystem::class);

--- a/tests/MediaCollections/FileSystem/FileSystemTest.php
+++ b/tests/MediaCollections/FileSystem/FileSystemTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\MediaCollections\Filesystem;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 beforeEach(function () {
     $this->filesystem = app()->make(Filesystem::class);

--- a/tests/MediaCollections/FileSystem/FileSystemTest.php
+++ b/tests/MediaCollections/FileSystem/FileSystemTest.php
@@ -1,69 +1,55 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\MediaCollections\FileSystem;
-
 use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class FileSystemTest extends TestCase
-{
-    protected Filesystem $filesystem;
+uses(TestCase::class);
 
-    public function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    $this->filesystem = app()->make(Filesystem::class);
+});
 
-        $this->filesystem = $this->app->make(Filesystem::class);
-    }
+it('can determine the header for file that will be copied to an external filesytem', function () {
+    $expectedHeaders = [
+        'ContentType' => 'image/jpeg',
+        'CacheControl' => 'max-age=604800',
+    ];
 
-    /** @test */
-    public function it_can_determine_the_header_for_file_that_will_be_copied_to_an_external_filesytem()
-    {
-        $expectedHeaders = [
-            'ContentType' => 'image/jpeg',
-            'CacheControl' => 'max-age=604800',
-        ];
+    $this->assertEquals(
+        $expectedHeaders,
+        $this->filesystem->getRemoteHeadersForFile($this->getTestJpg())
+    );
+});
 
-        $this->assertEquals(
-            $expectedHeaders,
-            $this->filesystem->getRemoteHeadersForFile($this->getTestJpg())
-        );
-    }
+it('can add custom headers for file that will be copied to an external filesytem', function () {
+    $this->filesystem->addCustomRemoteHeaders([
+        'ACL' => 'public-read',
+    ]);
 
-    /** @test */
-    public function it_can_add_custom_headers_for_file_that_will_be_copied_to_an_external_filesytem()
-    {
-        $this->filesystem->addCustomRemoteHeaders([
-            'ACL' => 'public-read',
-        ]);
+    $expectedHeaders = [
+        'ContentType' => 'image/jpeg',
+        'CacheControl' => 'max-age=604800',
+        'ACL' => 'public-read',
+    ];
 
-        $expectedHeaders = [
-            'ContentType' => 'image/jpeg',
-            'CacheControl' => 'max-age=604800',
-            'ACL' => 'public-read',
-        ];
+    $this->assertEquals(
+        $expectedHeaders,
+        $this->filesystem->getRemoteHeadersForFile($this->getTestJpg())
+    );
+});
 
-        $this->assertEquals(
-            $expectedHeaders,
-            $this->filesystem->getRemoteHeadersForFile($this->getTestJpg())
-        );
-    }
+it('can use custom headers when copying the media to an external filesystem', function () {
+    $this->filesystem->addCustomRemoteHeaders([
+        'CacheControl' => 'max-age=302400',
+    ]);
 
-    /** @test */
-    public function it_can_use_custom_headers_when_copying_the_media_to_an_external_filesystem()
-    {
-        $this->filesystem->addCustomRemoteHeaders([
-            'CacheControl' => 'max-age=302400',
-        ]);
+    $expectedHeaders = [
+        'ContentType' => 'image/jpeg',
+        'CacheControl' => 'max-age=302400',
+    ];
 
-        $expectedHeaders = [
-            'ContentType' => 'image/jpeg',
-            'CacheControl' => 'max-age=302400',
-        ];
-
-        $this->assertEquals(
-            $expectedHeaders,
-            $this->filesystem->getRemoteHeadersForFile($this->getTestJpg())
-        );
-    }
-}
+    $this->assertEquals(
+        $expectedHeaders,
+        $this->filesystem->getRemoteHeadersForFile($this->getTestJpg())
+    );
+});

--- a/tests/MediaCollections/MediaCollectionTest.php
+++ b/tests/MediaCollections/MediaCollectionTest.php
@@ -1,98 +1,87 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\MediaCollections;
-
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\MediaCollections\MediaCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestUuidPathGenerator;
 
-class MediaCollectionTest extends TestCase
-{
-    /** @test */
-    public function it_can_get_the_sum_of_all_media_item_sizes()
-    {
-        $mediaItem = $this
-            ->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection();
-        $this->assertGreaterThan(0, $mediaItem->size);
+uses(TestCase::class);
 
-        $anotherMediaItem = $this
-            ->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection();
-        $this->assertGreaterThan(0, $anotherMediaItem->size);
+it('can get the sum of all media item sizes', function () {
+    $mediaItem = $this
+        ->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection();
+    $this->assertGreaterThan(0, $mediaItem->size);
 
-        $mediaCollection = Media::get();
+    $anotherMediaItem = $this
+        ->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection();
+    $this->assertGreaterThan(0, $anotherMediaItem->size);
 
-        $totalSize = $mediaCollection->totalSizeInBytes();
+    $mediaCollection = Media::get();
 
-        $this->assertEquals($mediaItem->size + $anotherMediaItem->size, $totalSize);
-    }
+    $totalSize = $mediaCollection->totalSizeInBytes();
 
-    /** @test */
-    public function it_can_get_registered_media_collections()
-    {
-        // the 'avatar' media collection is registered in
-        // \Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel->registerMediaCollections()
-        $collections = $this->testModel->getRegisteredMediaCollections();
+    $this->assertEquals($mediaItem->size + $anotherMediaItem->size, $totalSize);
+});
 
-        $this->assertCount(1, $collections);
-        $this->assertInstanceOf(MediaCollection::class, $collections->first());
-        $this->assertEquals('avatar', $collections->first()->name);
-    }
+it('can get registered media collections', function () {
+    // the 'avatar' media collection is registered in
+    // \Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel->registerMediaCollections()
+    $collections = $this->testModel->getRegisteredMediaCollections();
 
-    /** @test */
-    public function it_doesnt_move_media_on_change()
-    {
-        config([
-            'media-library.path_generator' => TestUuidPathGenerator::class,
-            'media-library.moves_media_on_update' => false,
-        ]);
+    $this->assertCount(1, $collections);
+    $this->assertInstanceOf(MediaCollection::class, $collections->first());
+    $this->assertEquals('avatar', $collections->first()->name);
+});
 
-        $mediaItem = $this
-            ->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection();
+it('doesnt move media on change', function () {
+    config([
+        'media-library.path_generator' => TestUuidPathGenerator::class,
+        'media-library.moves_media_on_update' => false,
+    ]);
 
-        $oldMediaPath = $mediaItem->getPath();
+    $mediaItem = $this
+        ->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection();
 
-        $this->assertFileExists($oldMediaPath);
+    $oldMediaPath = $mediaItem->getPath();
 
-        $mediaItem->update(['uuid' => Str::uuid()]);
+    $this->assertFileExists($oldMediaPath);
 
-        $this->assertNotEquals($oldMediaPath, $mediaItem->getPath());
-        $this->assertFileExists($oldMediaPath);
-        $this->assertFileDoesNotExist($mediaItem->getPath());
-    }
+    $mediaItem->update(['uuid' => Str::uuid()]);
 
-    /** @test */
-    public function it_moves_media_on_change()
-    {
-        config([
-            'media-library.path_generator' => TestUuidPathGenerator::class,
-            'media-library.moves_media_on_update' => true,
-        ]);
+    $this->assertNotEquals($oldMediaPath, $mediaItem->getPath());
+    $this->assertFileExists($oldMediaPath);
+    $this->assertFileDoesNotExist($mediaItem->getPath());
+});
 
-        $mediaItem = $this
-            ->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection();
+it('moves media on change', function () {
+    config([
+        'media-library.path_generator' => TestUuidPathGenerator::class,
+        'media-library.moves_media_on_update' => true,
+    ]);
 
-        $oldMediaPath = $mediaItem->getPath();
+    $mediaItem = $this
+        ->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection();
 
-        $this->assertFileExists($oldMediaPath);
+    $oldMediaPath = $mediaItem->getPath();
 
-        $mediaItem->update(['uuid' => Str::uuid()]);
+    $this->assertFileExists($oldMediaPath);
 
-        $this->assertNotEquals($oldMediaPath, $mediaItem->getPath());
-        $this->assertFileDoesNotExist($oldMediaPath);
-        $this->assertFileExists($mediaItem->getPath());
-    }
-}
+    $mediaItem->update(['uuid' => Str::uuid()]);
+
+    $this->assertNotEquals($oldMediaPath, $mediaItem->getPath());
+    $this->assertFileDoesNotExist($oldMediaPath);
+    $this->assertFileExists($mediaItem->getPath());
+});

--- a/tests/MediaCollections/MediaCollectionTest.php
+++ b/tests/MediaCollections/MediaCollectionTest.php
@@ -14,20 +14,20 @@ it('can get the sum of all media item sizes', function () {
         ->addMedia($this->getTestJpg())
         ->preservingOriginal()
         ->toMediaCollection();
-    $this->assertGreaterThan(0, $mediaItem->size);
+    expect($mediaItem->size)->toBeGreaterThan(0);
 
     $anotherMediaItem = $this
         ->testModel
         ->addMedia($this->getTestJpg())
         ->preservingOriginal()
         ->toMediaCollection();
-    $this->assertGreaterThan(0, $anotherMediaItem->size);
+    expect($anotherMediaItem->size)->toBeGreaterThan(0);
 
     $mediaCollection = Media::get();
 
     $totalSize = $mediaCollection->totalSizeInBytes();
 
-    $this->assertEquals($mediaItem->size + $anotherMediaItem->size, $totalSize);
+    expect($totalSize)->toEqual($mediaItem->size + $anotherMediaItem->size);
 });
 
 it('can get registered media collections', function () {
@@ -35,9 +35,9 @@ it('can get registered media collections', function () {
     // \Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel->registerMediaCollections()
     $collections = $this->testModel->getRegisteredMediaCollections();
 
-    $this->assertCount(1, $collections);
-    $this->assertInstanceOf(MediaCollection::class, $collections->first());
-    $this->assertEquals('avatar', $collections->first()->name);
+    expect($collections)->toHaveCount(1);
+    expect($collections->first())->toBeInstanceOf(MediaCollection::class);
+    expect($collections->first()->name)->toEqual('avatar');
 });
 
 it('doesnt move media on change', function () {
@@ -54,12 +54,12 @@ it('doesnt move media on change', function () {
 
     $oldMediaPath = $mediaItem->getPath();
 
-    $this->assertFileExists($oldMediaPath);
+    expect($oldMediaPath)->toBeFile();
 
     $mediaItem->update(['uuid' => Str::uuid()]);
 
     $this->assertNotEquals($oldMediaPath, $mediaItem->getPath());
-    $this->assertFileExists($oldMediaPath);
+    expect($oldMediaPath)->toBeFile();
     $this->assertFileDoesNotExist($mediaItem->getPath());
 });
 
@@ -77,11 +77,11 @@ it('moves media on change', function () {
 
     $oldMediaPath = $mediaItem->getPath();
 
-    $this->assertFileExists($oldMediaPath);
+    expect($oldMediaPath)->toBeFile();
 
     $mediaItem->update(['uuid' => Str::uuid()]);
 
     $this->assertNotEquals($oldMediaPath, $mediaItem->getPath());
     $this->assertFileDoesNotExist($oldMediaPath);
-    $this->assertFileExists($mediaItem->getPath());
+    expect($mediaItem->getPath())->toBeFile();
 });

--- a/tests/MediaCollections/MediaCollectionTest.php
+++ b/tests/MediaCollections/MediaCollectionTest.php
@@ -6,7 +6,6 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestUuidPathGenerator;
 
-uses(TestCase::class);
 
 it('can get the sum of all media item sizes', function () {
     $mediaItem = $this

--- a/tests/MediaCollections/MediaCollectionTest.php
+++ b/tests/MediaCollections/MediaCollectionTest.php
@@ -3,9 +3,7 @@
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\MediaCollections\MediaCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\MediaLibrary\Tests\TestSupport\TestUuidPathGenerator;
-
 
 it('can get the sum of all media item sizes', function () {
     $mediaItem = $this

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/underlying-test-case */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/expectations#custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/helpers */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+uses(\Spatie\MediaLibrary\Tests\TestCase::class)->in('tests', 'Conversions', 'Feature', 'Image', 'MediaCollections', 'ResponsiveImages', 'Support', 'TestSupport');
+
 /*
 |--------------------------------------------------------------------------
 | Test Case

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,8 @@
 <?php
 
-uses(\Spatie\MediaLibrary\Tests\TestCase::class)->in('tests', 'Conversions', 'Feature', 'Image', 'MediaCollections', 'ResponsiveImages', 'Support', 'TestSupport');
+use Spatie\MediaLibrary\Tests\TestCase;
+
+uses(TestCase::class)->in('tests', 'Conversions', 'Feature', 'Image', 'MediaCollections', 'ResponsiveImages', 'Support', 'TestSupport');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/ResponsiveImages/FileSizeOptimizedWidthCalculatorTest.php
+++ b/tests/ResponsiveImages/FileSizeOptimizedWidthCalculatorTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can calculate the optimized widths from a file', function () {
     $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidthsFromFile($this->getTestJpg());

--- a/tests/ResponsiveImages/FileSizeOptimizedWidthCalculatorTest.php
+++ b/tests/ResponsiveImages/FileSizeOptimizedWidthCalculatorTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can calculate the optimized widths from a file', function () {
     $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidthsFromFile($this->getTestJpg());

--- a/tests/ResponsiveImages/FileSizeOptimizedWidthCalculatorTest.php
+++ b/tests/ResponsiveImages/FileSizeOptimizedWidthCalculatorTest.php
@@ -1,92 +1,85 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\ResponsiveImages;
-
 use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class FileSizeOptimizedWidthCalculatorTest extends TestCase
-{
-    /** @test */
-    public function it_can_calculate_the_optimized_widths_from_a_file()
-    {
-        $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidthsFromFile($this->getTestJpg());
+uses(TestCase::class);
 
-        $this->assertEquals([
-            0 => 340,
-            1 => 284,
-            2 => 237,
-        ], $dimensions->toArray());
+it('can calculate the optimized widths from a file', function () {
+    $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidthsFromFile($this->getTestJpg());
 
-        $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidthsFromFile($this->getSmallTestJpg());
+    $this->assertEquals([
+        0 => 340,
+        1 => 284,
+        2 => 237,
+    ], $dimensions->toArray());
 
-        $this->assertEquals([
-            0 => 150,
-        ], $dimensions->toArray());
-    }
+    $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidthsFromFile($this->getSmallTestJpg());
 
-    /** @test */
-    public function it_can_calculate_the_optimized_widths_for_different_dimensions()
-    {
-        $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidths(300 * 1024, 300, 200);
+    $this->assertEquals([
+        0 => 150,
+    ], $dimensions->toArray());
+});
 
-        $this->assertEquals([
-            0 => 300,
-            1 => 250,
-            2 => 210,
-            3 => 175,
-            4 => 147,
-            5 => 122,
-            6 => 102,
-            7 => 86,
-            8 => 72,
-            9 => 60,
-        ], $dimensions->toArray());
+it('can calculate the optimized widths for different dimensions', function () {
+    $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidths(300 * 1024, 300, 200);
 
-        $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidths(3000 * 1024, 2400, 1800);
+    $this->assertEquals([
+        0 => 300,
+        1 => 250,
+        2 => 210,
+        3 => 175,
+        4 => 147,
+        5 => 122,
+        6 => 102,
+        7 => 86,
+        8 => 72,
+        9 => 60,
+    ], $dimensions->toArray());
 
-        $this->assertEquals([
-            0 => 2400,
-            1 => 2007,
-            2 => 1680,
-            3 => 1405,
-            4 => 1176,
-            5 => 983,
-            6 => 823,
-            7 => 688,
-            8 => 576,
-            9 => 482,
-            10 => 403,
-            11 => 337,
-            12 => 282,
-            13 => 236,
-            14 => 197,
-            15 => 165,
-        ], $dimensions->toArray());
+    $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidths(3000 * 1024, 2400, 1800);
 
-        $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidths(12000 * 1024, 8200, 5500);
+    $this->assertEquals([
+        0 => 2400,
+        1 => 2007,
+        2 => 1680,
+        3 => 1405,
+        4 => 1176,
+        5 => 983,
+        6 => 823,
+        7 => 688,
+        8 => 576,
+        9 => 482,
+        10 => 403,
+        11 => 337,
+        12 => 282,
+        13 => 236,
+        14 => 197,
+        15 => 165,
+    ], $dimensions->toArray());
 
-        $this->assertEquals([
-            0 => 8200,
-            1 => 6860,
-            2 => 5740,
-            3 => 4802,
-            4 => 4017,
-            5 => 3361,
-            6 => 2812,
-            7 => 2353,
-            8 => 1968,
-            9 => 1647,
-            10 => 1378,
-            11 => 1153,
-            12 => 964,
-            13 => 807,
-            14 => 675,
-            15 => 565,
-            16 => 472,
-            17 => 395,
-            18 => 330,
-            19 => 276,
-        ], $dimensions->toArray());
-    }
-}
+    $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidths(12000 * 1024, 8200, 5500);
+
+    $this->assertEquals([
+        0 => 8200,
+        1 => 6860,
+        2 => 5740,
+        3 => 4802,
+        4 => 4017,
+        5 => 3361,
+        6 => 2812,
+        7 => 2353,
+        8 => 1968,
+        9 => 1647,
+        10 => 1378,
+        11 => 1153,
+        12 => 964,
+        13 => 807,
+        14 => 675,
+        15 => 565,
+        16 => 472,
+        17 => 395,
+        18 => 330,
+        19 => 276,
+    ], $dimensions->toArray());
+});

--- a/tests/ResponsiveImages/RegisteredResponsiveImagesTest.php
+++ b/tests/ResponsiveImages/RegisteredResponsiveImagesTest.php
@@ -1,49 +1,42 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\ResponsiveImages;
-
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class RegisteredResponsiveImagesTest extends TestCase
-{
-    /** @test */
-    public function it_will_register_generated_responsive_images_in_the_db()
-    {
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->withResponsiveImages()
-            ->toMediaCollection();
+uses(TestCase::class);
 
-        $media = $this->testModel->getFirstMedia();
+it('will register generated responsive images in the db', function () {
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->toMediaCollection();
 
-        $this->assertEquals([
-            'test___media_library_original_340_280.jpg',
-            'test___media_library_original_284_233.jpg',
-            'test___media_library_original_237_195.jpg',
-        ], $media->responsive_images['media_library_original']['urls']);
-    }
+    $media = $this->testModel->getFirstMedia();
 
-    /** @test */
-    public function it_can_render_a_srcset_when_the_base64svg_is_not_rendered_yet()
-    {
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->withResponsiveImages()
-            ->toMediaCollection();
+    $this->assertEquals([
+        'test___media_library_original_340_280.jpg',
+        'test___media_library_original_284_233.jpg',
+        'test___media_library_original_237_195.jpg',
+    ], $media->responsive_images['media_library_original']['urls']);
+});
 
-        $media = $this->testModel->getFirstMedia();
+it('can render a srcset when the base64svg is not rendered yet', function () {
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->toMediaCollection();
 
-        $responsiveImages = $media->responsive_images;
+    $media = $this->testModel->getFirstMedia();
 
-        unset($responsiveImages['media_library_original']['base64svg']);
+    $responsiveImages = $media->responsive_images;
 
-        $media->responsive_images = $responsiveImages;
+    unset($responsiveImages['media_library_original']['base64svg']);
 
-        $registeredResponsiveImage = new RegisteredResponsiveImages($media);
+    $media->responsive_images = $responsiveImages;
 
-        $this->assertNull($registeredResponsiveImage->getPlaceholderSvg());
+    $registeredResponsiveImage = new RegisteredResponsiveImages($media);
 
-        $this->assertNotEmpty($registeredResponsiveImage->getSrcset());
-    }
-}
+    $this->assertNull($registeredResponsiveImage->getPlaceholderSvg());
+
+    $this->assertNotEmpty($registeredResponsiveImage->getSrcset());
+});

--- a/tests/ResponsiveImages/RegisteredResponsiveImagesTest.php
+++ b/tests/ResponsiveImages/RegisteredResponsiveImagesTest.php
@@ -36,7 +36,7 @@ it('can render a srcset when the base64svg is not rendered yet', function () {
 
     $registeredResponsiveImage = new RegisteredResponsiveImages($media);
 
-    $this->assertNull($registeredResponsiveImage->getPlaceholderSvg());
+    expect($registeredResponsiveImage->getPlaceholderSvg())->toBeNull();
 
     $this->assertNotEmpty($registeredResponsiveImage->getSrcset());
 });

--- a/tests/ResponsiveImages/RegisteredResponsiveImagesTest.php
+++ b/tests/ResponsiveImages/RegisteredResponsiveImagesTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('will register generated responsive images in the db', function () {
     $this->testModel

--- a/tests/ResponsiveImages/RegisteredResponsiveImagesTest.php
+++ b/tests/ResponsiveImages/RegisteredResponsiveImagesTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('will register generated responsive images in the db', function () {
     $this->testModel

--- a/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
@@ -1,18 +1,13 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\ResponsiveImages;
-
 use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
 
-class ResponsiveImageFileNamerTest extends ResponsiveImageTest
-{
-    public function setUp(): void
-    {
-        parent::setUp();
+uses(ResponsiveImageTest::class);
 
-        config()->set("media-library.file_namer", TestFileNamer::class);
+beforeEach(function () {
+    config()->set("media-library.file_namer", TestFileNamer::class);
 
-        $this->fileName = "prefix_test_suffix";
-        $this->fileNameWithUnderscore = "prefix_test__suffix";
-    }
-}
+    $this->fileName = "prefix_test_suffix";
+    $this->fileNameWithUnderscore = "prefix_test__suffix";
+});
+

--- a/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
@@ -2,8 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
 
-uses(ResponsiveImageTest::class);
-
 beforeEach(function () {
     config()->set("media-library.file_namer", TestFileNamer::class);
 

--- a/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageFileNamerTest.php
@@ -10,4 +10,3 @@ beforeEach(function () {
     $this->fileName = "prefix_test_suffix";
     $this->fileNameWithUnderscore = "prefix_test__suffix";
 });
-

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
@@ -1,17 +1,12 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\ResponsiveImages;
-
 use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
 
-class ResponsiveImageGeneratorFileNamerTest extends ResponsiveImageGeneratorTest
-{
-    public function setUp(): void
-    {
-        parent::setUp();
+uses(ResponsiveImageGeneratorTest::class);
 
-        config()->set("media-library.file_namer", TestFileNamer::class);
+beforeEach(function () {
+    config()->set("media-library.file_namer", TestFileNamer::class);
 
-        $this->fileName = "prefix_test_suffix";
-    }
-}
+    $this->fileName = "prefix_test_suffix";
+});
+

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
@@ -2,8 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestSupport\TestFileNamer;
 
-uses(ResponsiveImageGeneratorTest::class);
-
 beforeEach(function () {
     config()->set("media-library.file_namer", TestFileNamer::class);
 

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorFileNamerTest.php
@@ -9,4 +9,3 @@ beforeEach(function () {
 
     $this->fileName = "prefix_test_suffix";
 });
-

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -2,8 +2,6 @@
 
 use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\ResponsiveImages\Events\ResponsiveImagesGenerated;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can generate responsive images', function () {
     $this->testModel

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -1,117 +1,96 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\ResponsiveImages;
-
 use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\ResponsiveImages\Events\ResponsiveImagesGenerated;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class ResponsiveImageGeneratorTest extends TestCase
-{
-    public string $fileName = "test";
+uses(TestCase::class);
 
-    /** @test */
-    public function it_can_generate_responsive_images()
-    {
-        $this->testModel
-                ->addMedia($this->getTestJpg())
-                ->withResponsiveImages()
-                ->toMediaCollection();
-
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg"));
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg"));
-    }
-
-    /** @test */
-    public function it_will_generate_responsive_images_if_withResponsiveImagesIf_returns_true()
-    {
-        $this->testModel
-                ->addMedia($this->getTestJpg())
-                ->withResponsiveImagesIf(fn () => true)
-                ->toMediaCollection();
-
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg"));
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg"));
-    }
-
-    /** @test */
-    public function it_will_not_generate_responsive_images_if_withResponsiveImagesIf_returns_false()
-    {
-        $this->testModel
-                ->addMedia($this->getTestJpg())
-                ->withResponsiveImagesIf(fn () => false)
-                ->toMediaCollection();
-
-        $this->assertFileDoesNotExist($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
-    }
-
-    /** @test */
-    public function its_conversions_can_have_responsive_images()
-    {
-        $this->testModelWithResponsiveImages
-                    ->addMedia($this->getTestJpg())
-                    ->withResponsiveImages()
-                    ->toMediaCollection();
-
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg"));
-    }
-
-    /** @test */
-    public function its_conversions_can_have_responsive_images_and_change_format()
-    {
-        $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestPng())
-            ->withResponsiveImages()
-            ->toMediaCollection();
-
-        $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___pngtojpg_700_883.jpg"));
-    }
-
-    /** @test */
-    public function it_triggers_an_event_when_the_responsive_images_are_generated()
-    {
-        Event::fake(ResponsiveImagesGenerated::class);
-
-        $this->testModelWithResponsiveImages
+it('can generate responsive images', function () {
+    $this->testModel
             ->addMedia($this->getTestJpg())
             ->withResponsiveImages()
             ->toMediaCollection();
 
-        Event::assertDispatched(ResponsiveImagesGenerated::class);
-    }
+    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
+    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg"));
+    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg"));
+});
 
-    /** @test */
-    public function it_cleans_the_responsive_images_urls_from_the_db_before_regeneration()
-    {
-        $media = $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestFilesDirectory("test.jpg"))
-            ->withResponsiveImages()
+it('will generate responsive images if with responsive images if returns true', function () {
+    $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->withResponsiveImagesIf(fn () => true)
             ->toMediaCollection();
 
-        $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
+    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
+    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg"));
+    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg"));
+});
 
-        $this->artisan("media-library:regenerate");
-        $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
-    }
-
-    /** @test */
-    public function it_will_add_responsive_image_entries_when_there_were_none_when_regenerating()
-    {
-        $media = $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestFilesDirectory("test.jpg"))
-            ->withResponsiveImages()
+it('will not generate responsive images if with responsive images if returns false', function () {
+    $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->withResponsiveImagesIf(fn () => false)
             ->toMediaCollection();
 
-        // remove all responsive image db entries
-        $responsiveImages = $media->responsive_images;
-        $responsiveImages["thumb"]["urls"] = [];
-        $media->responsive_images = $responsiveImages;
-        $media->save();
-        $this->assertCount(0, $media->fresh()->responsive_images["thumb"]["urls"]);
+    $this->assertFileDoesNotExist($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
+});
 
-        $this->artisan("media-library:regenerate");
-        $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
-    }
-}
+test('its conversions can have responsive images', function () {
+    $this->testModelWithResponsiveImages
+                ->addMedia($this->getTestJpg())
+                ->withResponsiveImages()
+                ->toMediaCollection();
+
+    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg"));
+});
+
+test('its conversions can have responsive images and change format', function () {
+    $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestPng())
+        ->withResponsiveImages()
+        ->toMediaCollection();
+
+    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___pngtojpg_700_883.jpg"));
+});
+
+it('triggers an event when the responsive images are generated', function () {
+    Event::fake(ResponsiveImagesGenerated::class);
+
+    $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->toMediaCollection();
+
+    Event::assertDispatched(ResponsiveImagesGenerated::class);
+});
+
+it('cleans the responsive images urls from the db before regeneration', function () {
+    $media = $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestFilesDirectory("test.jpg"))
+        ->withResponsiveImages()
+        ->toMediaCollection();
+
+    $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
+
+    $this->artisan("media-library:regenerate");
+    $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
+});
+
+it('will add responsive image entries when there were none when regenerating', function () {
+    $media = $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestFilesDirectory("test.jpg"))
+        ->withResponsiveImages()
+        ->toMediaCollection();
+
+    // remove all responsive image db entries
+    $responsiveImages = $media->responsive_images;
+    $responsiveImages["thumb"]["urls"] = [];
+    $media->responsive_images = $responsiveImages;
+    $media->save();
+    $this->assertCount(0, $media->fresh()->responsive_images["thumb"]["urls"]);
+
+    $this->artisan("media-library:regenerate");
+    $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
+});

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -3,8 +3,8 @@
 use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\ResponsiveImages\Events\ResponsiveImagesGenerated;
 
-beforeEach(function() {
-   $this->fileName = 'test';
+beforeEach(function () {
+    $this->fileName = 'test';
 });
 
 it('can generate responsive images', function () {

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -4,7 +4,6 @@ use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\ResponsiveImages\Events\ResponsiveImagesGenerated;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can generate responsive images', function () {
     $this->testModel

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -12,9 +12,9 @@ it('can generate responsive images', function () {
             ->withResponsiveImages()
             ->toMediaCollection();
 
-    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
-    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg"));
-    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg"));
+    expect($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"))->toBeFile();
+    expect($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg"))->toBeFile();
+    expect($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg"))->toBeFile();
 });
 
 it('will generate responsive images if with responsive images if returns true', function () {
@@ -23,9 +23,9 @@ it('will generate responsive images if with responsive images if returns true', 
             ->withResponsiveImagesIf(fn () => true)
             ->toMediaCollection();
 
-    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"));
-    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg"));
-    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg"));
+    expect($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg"))->toBeFile();
+    expect($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg"))->toBeFile();
+    expect($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg"))->toBeFile();
 });
 
 it('will not generate responsive images if with responsive images if returns false', function () {
@@ -43,7 +43,7 @@ test('its conversions can have responsive images', function () {
                 ->withResponsiveImages()
                 ->toMediaCollection();
 
-    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg"));
+    expect($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg"))->toBeFile();
 });
 
 test('its conversions can have responsive images and change format', function () {
@@ -52,7 +52,7 @@ test('its conversions can have responsive images and change format', function ()
         ->withResponsiveImages()
         ->toMediaCollection();
 
-    $this->assertFileExists($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___pngtojpg_700_883.jpg"));
+    expect($this->getTempDirectory("media/1/responsive-images/{$this->fileName}___pngtojpg_700_883.jpg"))->toBeFile();
 });
 
 it('triggers an event when the responsive images are generated', function () {
@@ -72,10 +72,10 @@ it('cleans the responsive images urls from the db before regeneration', function
         ->withResponsiveImages()
         ->toMediaCollection();
 
-    $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
+    expect($media->fresh()->responsive_images["thumb"]["urls"])->toHaveCount(1);
 
     $this->artisan("media-library:regenerate");
-    $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
+    expect($media->fresh()->responsive_images["thumb"]["urls"])->toHaveCount(1);
 });
 
 it('will add responsive image entries when there were none when regenerating', function () {
@@ -89,8 +89,8 @@ it('will add responsive image entries when there were none when regenerating', f
     $responsiveImages["thumb"]["urls"] = [];
     $media->responsive_images = $responsiveImages;
     $media->save();
-    $this->assertCount(0, $media->fresh()->responsive_images["thumb"]["urls"]);
+    expect($media->fresh()->responsive_images["thumb"]["urls"])->toHaveCount(0);
 
     $this->artisan("media-library:regenerate");
-    $this->assertCount(1, $media->fresh()->responsive_images["thumb"]["urls"]);
+    expect($media->fresh()->responsive_images["thumb"]["urls"])->toHaveCount(1);
 });

--- a/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageGeneratorTest.php
@@ -3,6 +3,10 @@
 use Illuminate\Support\Facades\Event;
 use Spatie\MediaLibrary\ResponsiveImages\Events\ResponsiveImagesGenerated;
 
+beforeEach(function() {
+   $this->fileName = 'test';
+});
+
 it('can generate responsive images', function () {
     $this->testModel
             ->addMedia($this->getTestJpg())

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -1,7 +1,5 @@
 <?php
 
-
-
 test('a media instance can get responsive image urls', function () {
     $this
         ->testModelWithResponsiveImages

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -1,131 +1,113 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\ResponsiveImages;
-
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class ResponsiveImageTest extends TestCase
-{
-    public string $fileName = 'test';
-    public string $fileNameWithUnderscore = 'test_';
+uses(TestCase::class);
 
-    /** @test */
-    public function a_media_instance_can_get_responsive_image_urls()
-    {
-        $this
-            ->testModelWithResponsiveImages
-            ->addMedia($this->getTestJpg())
-            ->withResponsiveImages()
-            ->toMediaCollection();
+test('a media instance can get responsive image urls', function () {
+    $this
+        ->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->toMediaCollection();
 
-        $media = $this->testModelWithResponsiveImages->getFirstMedia();
+    $media = $this->testModelWithResponsiveImages->getFirstMedia();
 
-        $this->assertEquals([
-            "http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg",
-            "http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg",
-            "http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg",
-        ], $media->getResponsiveImageUrls());
+    $this->assertEquals([
+        "http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg",
+        "http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg",
+        "http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg",
+    ], $media->getResponsiveImageUrls());
 
-        $this->assertEquals([
-            "http://localhost/media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg",
-        ], $media->getResponsiveImageUrls("thumb"));
+    $this->assertEquals([
+        "http://localhost/media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg",
+    ], $media->getResponsiveImageUrls("thumb"));
 
-        $this->assertEquals([], $media->getResponsiveImageUrls("non-existing-conversion"));
-    }
+    $this->assertEquals([], $media->getResponsiveImageUrls("non-existing-conversion"));
+});
 
-    /** @test */
-    public function a_media_instance_can_generate_the_contents_of_scrset()
-    {
-        $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestJpg())
-            ->withResponsiveImages()
-            ->toMediaCollection();
+test('a media instance can generate the contents of scrset', function () {
+    $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->toMediaCollection();
 
-        $media = $this->testModelWithResponsiveImages->getFirstMedia();
+    $media = $this->testModelWithResponsiveImages->getFirstMedia();
 
-        $this->assertStringContainsString(
-            "http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg 340w, http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg 284w, http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg 237w",
-            $media->getSrcset()
-        );
-        $this->assertStringContainsString("data:image/svg+xml;base64", $media->getSrcset());
+    $this->assertStringContainsString(
+        "http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg 340w, http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg 284w, http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg 237w",
+        $media->getSrcset()
+    );
+    $this->assertStringContainsString("data:image/svg+xml;base64", $media->getSrcset());
 
-        $this->assertStringContainsString(
-            "http://localhost/media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg 50w",
-            $media->getSrcset("thumb")
-        );
-        $this->assertStringContainsString("data:image/svg+xml;base64,", $media->getSrcset("thumb"));
-    }
+    $this->assertStringContainsString(
+        "http://localhost/media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg 50w",
+        $media->getSrcset("thumb")
+    );
+    $this->assertStringContainsString("data:image/svg+xml;base64,", $media->getSrcset("thumb"));
+});
 
-    /** @test */
-    public function a_responsive_image_can_return_some_properties()
-    {
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->withResponsiveImages()
-            ->toMediaCollection();
+test('a responsive image can return some properties', function () {
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->toMediaCollection();
 
-        $media = $this->testModel->getFirstMedia();
+    $media = $this->testModel->getFirstMedia();
 
-        $responsiveImage = $media->responsiveImages()->files->first();
+    $responsiveImage = $media->responsiveImages()->files->first();
 
-        $this->assertEquals("media_library_original", $responsiveImage->generatedFor());
+    $this->assertEquals("media_library_original", $responsiveImage->generatedFor());
 
-        $this->assertEquals(340, $responsiveImage->width());
+    $this->assertEquals(340, $responsiveImage->width());
 
-        $this->assertEquals(280, $responsiveImage->height());
-    }
+    $this->assertEquals(280, $responsiveImage->height());
+});
 
-    /** @test */
-    public function responsive_image_generation_respects_the_conversion_quality_setting()
-    {
-        $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->toMediaCollection("default");
+test('responsive image generation respects the conversion quality setting', function () {
+    $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection("default");
 
-        $standardQualityResponsiveConversion = $this->getTempDirectory("media/1/responsive-images/{$this->fileName}___standardQuality_340_280.jpg");
-        $lowerQualityResponsiveConversion = $this->getTempDirectory("media/1/responsive-images/{$this->fileName}___lowerQuality_340_280.jpg");
+    $standardQualityResponsiveConversion = $this->getTempDirectory("media/1/responsive-images/{$this->fileName}___standardQuality_340_280.jpg");
+    $lowerQualityResponsiveConversion = $this->getTempDirectory("media/1/responsive-images/{$this->fileName}___lowerQuality_340_280.jpg");
 
-        $this->assertLessThan(filesize($standardQualityResponsiveConversion), filesize($lowerQualityResponsiveConversion));
-    }
+    $this->assertLessThan(filesize($standardQualityResponsiveConversion), filesize($lowerQualityResponsiveConversion));
+});
 
-    /** @test */
-    public function a_media_instance_can_get_responsive_image_urls_with_conversions_stored_on_second_media_disk()
-    {
-        $this->testModelWithResponsiveImages
-            ->addMedia($this->getTestJpg())
-            ->withResponsiveImages()
-            ->storingConversionsOnDisk("secondMediaDisk")
-            ->toMediaCollection();
+test('a media instance can get responsive image urls with conversions stored on second media disk', function () {
+    $this->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->storingConversionsOnDisk("secondMediaDisk")
+        ->toMediaCollection();
 
-        $media = $this->testModelWithResponsiveImages->getFirstMedia();
+    $media = $this->testModelWithResponsiveImages->getFirstMedia();
 
-        $this->assertEquals([
-            "http://localhost/media2/1/responsive-images/{$this->fileName}___thumb_50_41.jpg",
-        ], $media->getResponsiveImageUrls("thumb"));
-    }
+    $this->assertEquals([
+        "http://localhost/media2/1/responsive-images/{$this->fileName}___thumb_50_41.jpg",
+    ], $media->getResponsiveImageUrls("thumb"));
+});
 
-    /** @test  */
-    public function it_can_handle_file_names_with_underscore()
-    {
-        $this
-            ->testModelWithResponsiveImages
-            ->addMedia($this->getTestImageEndingWithUnderscore())
-            ->withResponsiveImages()
-            ->toMediaCollection();
+it('can handle file names with underscore', function () {
+    $this
+        ->testModelWithResponsiveImages
+        ->addMedia($this->getTestImageEndingWithUnderscore())
+        ->withResponsiveImages()
+        ->toMediaCollection();
 
-        $media = $this->testModelWithResponsiveImages->getFirstMedia();
+    $media = $this->testModelWithResponsiveImages->getFirstMedia();
 
-        $this->assertSame([
-            "http://localhost/media/1/responsive-images/{$this->fileNameWithUnderscore}___media_library_original_340_280.jpg",
-            "http://localhost/media/1/responsive-images/{$this->fileNameWithUnderscore}___media_library_original_284_233.jpg",
-            "http://localhost/media/1/responsive-images/{$this->fileNameWithUnderscore}___media_library_original_237_195.jpg",
-        ], $media->getResponsiveImageUrls());
+    $this->assertSame([
+        "http://localhost/media/1/responsive-images/{$this->fileNameWithUnderscore}___media_library_original_340_280.jpg",
+        "http://localhost/media/1/responsive-images/{$this->fileNameWithUnderscore}___media_library_original_284_233.jpg",
+        "http://localhost/media/1/responsive-images/{$this->fileNameWithUnderscore}___media_library_original_237_195.jpg",
+    ], $media->getResponsiveImageUrls());
 
-        $this->assertSame([
-            "http://localhost/media/1/responsive-images/{$this->fileNameWithUnderscore}___thumb_50_41.jpg",
-        ], $media->getResponsiveImageUrls("thumb"));
+    $this->assertSame([
+        "http://localhost/media/1/responsive-images/{$this->fileNameWithUnderscore}___thumb_50_41.jpg",
+    ], $media->getResponsiveImageUrls("thumb"));
 
-        $this->assertSame([], $media->getResponsiveImageUrls("non-existing-conversion"));
-    }
-}
+    $this->assertSame([], $media->getResponsiveImageUrls("non-existing-conversion"));
+});

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -1,5 +1,10 @@
 <?php
 
+beforeEach(function() {
+    $this->fileName = 'test';
+    $this->fileNameWithUnderscore = 'test_';
+});
+
 test('a media instance can get responsive image urls', function () {
     $this
         ->testModelWithResponsiveImages

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 test('a media instance can get responsive image urls', function () {
     $this

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -23,7 +23,7 @@ test('a media instance can get responsive image urls', function () {
         "http://localhost/media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg",
     ], $media->getResponsiveImageUrls("thumb"));
 
-    $this->assertEquals([], $media->getResponsiveImageUrls("non-existing-conversion"));
+    expect($media->getResponsiveImageUrls("non-existing-conversion"))->toEqual([]);
 });
 
 test('a media instance can generate the contents of scrset', function () {
@@ -38,13 +38,13 @@ test('a media instance can generate the contents of scrset', function () {
         "http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_340_280.jpg 340w, http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_284_233.jpg 284w, http://localhost/media/1/responsive-images/{$this->fileName}___media_library_original_237_195.jpg 237w",
         $media->getSrcset()
     );
-    $this->assertStringContainsString("data:image/svg+xml;base64", $media->getSrcset());
+    expect($media->getSrcset())->toContain("data:image/svg+xml;base64");
 
     $this->assertStringContainsString(
         "http://localhost/media/1/responsive-images/{$this->fileName}___thumb_50_41.jpg 50w",
         $media->getSrcset("thumb")
     );
-    $this->assertStringContainsString("data:image/svg+xml;base64,", $media->getSrcset("thumb"));
+    expect($media->getSrcset("thumb"))->toContain("data:image/svg+xml;base64,");
 });
 
 test('a responsive image can return some properties', function () {
@@ -57,11 +57,11 @@ test('a responsive image can return some properties', function () {
 
     $responsiveImage = $media->responsiveImages()->files->first();
 
-    $this->assertEquals("media_library_original", $responsiveImage->generatedFor());
+    expect($responsiveImage->generatedFor())->toEqual("media_library_original");
 
-    $this->assertEquals(340, $responsiveImage->width());
+    expect($responsiveImage->width())->toEqual(340);
 
-    $this->assertEquals(280, $responsiveImage->height());
+    expect($responsiveImage->height())->toEqual(280);
 });
 
 test('responsive image generation respects the conversion quality setting', function () {
@@ -73,7 +73,7 @@ test('responsive image generation respects the conversion quality setting', func
     $standardQualityResponsiveConversion = $this->getTempDirectory("media/1/responsive-images/{$this->fileName}___standardQuality_340_280.jpg");
     $lowerQualityResponsiveConversion = $this->getTempDirectory("media/1/responsive-images/{$this->fileName}___lowerQuality_340_280.jpg");
 
-    $this->assertLessThan(filesize($standardQualityResponsiveConversion), filesize($lowerQualityResponsiveConversion));
+    expect(filesize($lowerQualityResponsiveConversion))->toBeLessThan(filesize($standardQualityResponsiveConversion));
 });
 
 test('a media instance can get responsive image urls with conversions stored on second media disk', function () {
@@ -109,5 +109,5 @@ it('can handle file names with underscore', function () {
         "http://localhost/media/1/responsive-images/{$this->fileNameWithUnderscore}___thumb_50_41.jpg",
     ], $media->getResponsiveImageUrls("thumb"));
 
-    $this->assertSame([], $media->getResponsiveImageUrls("non-existing-conversion"));
+    expect($media->getResponsiveImageUrls("non-existing-conversion"))->toBe([]);
 });

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\MediaLibrary\Tests\TestCase;
 
 
 test('a media instance can get responsive image urls', function () {

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-beforeEach(function() {
+beforeEach(function () {
     $this->fileName = 'test';
     $this->fileNameWithUnderscore = 'test_';
 });

--- a/tests/Support/FileTest.php
+++ b/tests/Support/FileTest.php
@@ -6,15 +6,15 @@ use Spatie\MediaLibrary\Tests\TestCase;
 uses(TestCase::class);
 
 it('can determine a human readable filesize', function () {
-    $this->assertEquals('10 B', File::getHumanReadableSize(10));
-    $this->assertEquals('100 B', File::getHumanReadableSize(100));
-    $this->assertEquals('1000 B', File::getHumanReadableSize(1000));
-    $this->assertEquals('9.77 KB', File::getHumanReadableSize(10000));
+    expect(File::getHumanReadableSize(10))->toEqual('10 B');
+    expect(File::getHumanReadableSize(100))->toEqual('100 B');
+    expect(File::getHumanReadableSize(1000))->toEqual('1000 B');
+    expect(File::getHumanReadableSize(10000))->toEqual('9.77 KB');
     $this->assertEquals('976.56 KB', File::getHumanReadableSize(1_000_000));
     $this->assertEquals('9.54 MB', File::getHumanReadableSize(10_000_000));
     $this->assertEquals('9.31 GB', File::getHumanReadableSize(10_000_000_000));
 });
 
 it('can determine the mime type of a file', function () {
-    $this->assertEquals('text/x-php', File::getMimeType(__FILE__));
+    expect(File::getMimeType(__FILE__))->toEqual('text/x-php');
 });

--- a/tests/Support/FileTest.php
+++ b/tests/Support/FileTest.php
@@ -3,7 +3,6 @@
 use Spatie\MediaLibrary\Support\File;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can determine a human readable filesize', function () {
     expect(File::getHumanReadableSize(10))->toEqual('10 B');

--- a/tests/Support/FileTest.php
+++ b/tests/Support/FileTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\MediaLibrary\Support\File;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 it('can determine a human readable filesize', function () {
     expect(File::getHumanReadableSize(10))->toEqual('10 B');

--- a/tests/Support/FileTest.php
+++ b/tests/Support/FileTest.php
@@ -1,27 +1,20 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Support;
-
 use Spatie\MediaLibrary\Support\File;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-class FileTest extends TestCase
-{
-    /** @test */
-    public function it_can_determine_a_human_readable_filesize()
-    {
-        $this->assertEquals('10 B', File::getHumanReadableSize(10));
-        $this->assertEquals('100 B', File::getHumanReadableSize(100));
-        $this->assertEquals('1000 B', File::getHumanReadableSize(1000));
-        $this->assertEquals('9.77 KB', File::getHumanReadableSize(10000));
-        $this->assertEquals('976.56 KB', File::getHumanReadableSize(1_000_000));
-        $this->assertEquals('9.54 MB', File::getHumanReadableSize(10_000_000));
-        $this->assertEquals('9.31 GB', File::getHumanReadableSize(10_000_000_000));
-    }
+uses(TestCase::class);
 
-    /** @test */
-    public function it_can_determine_the_mime_type_of_a_file()
-    {
-        $this->assertEquals('text/x-php', File::getMimeType(__FILE__));
-    }
-}
+it('can determine a human readable filesize', function () {
+    $this->assertEquals('10 B', File::getHumanReadableSize(10));
+    $this->assertEquals('100 B', File::getHumanReadableSize(100));
+    $this->assertEquals('1000 B', File::getHumanReadableSize(1000));
+    $this->assertEquals('9.77 KB', File::getHumanReadableSize(10000));
+    $this->assertEquals('976.56 KB', File::getHumanReadableSize(1_000_000));
+    $this->assertEquals('9.54 MB', File::getHumanReadableSize(10_000_000));
+    $this->assertEquals('9.31 GB', File::getHumanReadableSize(10_000_000_000));
+});
+
+it('can determine the mime type of a file', function () {
+    $this->assertEquals('text/x-php', File::getMimeType(__FILE__));
+});

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -7,7 +7,6 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     foreach (range(1, 3) as $i) {

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -22,13 +22,13 @@ beforeEach(function () {
 it('can return a stream of media', function () {
     $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
 
-    $this->assertEquals(count(Media::all()), $zipStreamResponse->getMediaItems()->count());
+    expect($zipStreamResponse->getMediaItems()->count())->toEqual(count(Media::all()));
 
     Route::get('stream-test', fn () => $zipStreamResponse);
 
     $response = $this->get('stream-test');
 
-    $this->assertInstanceOf(StreamedResponse::class, $response->baseResponse);
+    expect($response->baseResponse)->toBeInstanceOf(StreamedResponse::class);
 });
 
 it('can return a stream of multiple files with the same filename', function () {
@@ -52,14 +52,14 @@ test('media can be added to it one by one', function () {
         ->addMedia(Media::find(1))
         ->addMedia(Media::find(2));
 
-    $this->assertEquals(2, $zipStreamResponse->getMediaItems()->count());
+    expect($zipStreamResponse->getMediaItems()->count())->toEqual(2);
 });
 
 test('an array of media can be added to it', function () {
     $zipStreamResponse = MediaStream::create('my-media.zip')
         ->addMedia([Media::find(1), Media::find(2)]);
 
-    $this->assertEquals(2, $zipStreamResponse->getMediaItems()->count());
+    expect($zipStreamResponse->getMediaItems()->count())->toEqual(2);
 });
 
 test('media with zip file folder prefix property saved in correct zip folder', function () {

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -3,10 +3,8 @@
 use Illuminate\Support\Facades\Route;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\MediaStream;
-use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-
 
 beforeEach(function () {
     foreach (range(1, 3) as $i) {

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\MediaLibrary\Tests\Support;
-
 use Illuminate\Support\Facades\Route;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\MediaStream;
@@ -9,75 +7,94 @@ use Spatie\MediaLibrary\Tests\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
-class MediaStreamTest extends TestCase
-{
-    public function setUp(): void
-    {
-        parent::setUp();
+uses(TestCase::class);
 
-        foreach (range(1, 3) as $i) {
-            $this
-                ->testModel
-                ->addMedia($this->getTestJpg())
-                ->preservingOriginal()
-                ->toMediaCollection();
-        }
+beforeEach(function () {
+    foreach (range(1, 3) as $i) {
+        $this
+            ->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection();
+    }
+});
+
+it('can return a stream of media', function () {
+    $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+    $this->assertEquals(count(Media::all()), $zipStreamResponse->getMediaItems()->count());
+
+    Route::get('stream-test', fn () => $zipStreamResponse);
+
+    $response = $this->get('stream-test');
+
+    $this->assertInstanceOf(StreamedResponse::class, $response->baseResponse);
+});
+
+it('can return a stream of multiple files with the same filename', function () {
+    $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+    ob_start();
+    @$zipStreamResponse->toResponse(request())->sendContent();
+    $content = ob_get_contents();
+    ob_end_clean();
+
+    $temporaryDirectory = (new TemporaryDirectory())->create();
+    file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+    $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');
+    $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test (1).jpg');
+    $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test (2).jpg');
+});
+
+test('media can be added to it one by one', function () {
+    $zipStreamResponse = MediaStream::create('my-media.zip')
+        ->addMedia(Media::find(1))
+        ->addMedia(Media::find(2));
+
+    $this->assertEquals(2, $zipStreamResponse->getMediaItems()->count());
+});
+
+test('an array of media can be added to it', function () {
+    $zipStreamResponse = MediaStream::create('my-media.zip')
+        ->addMedia([Media::find(1), Media::find(2)]);
+
+    $this->assertEquals(2, $zipStreamResponse->getMediaItems()->count());
+});
+
+test('media with zip file folder prefix property saved in correct zip folder', function () {
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties([
+            'zip_filename_prefix' => 'folder/subfolder/',
+        ])
+        ->toMediaCollection();
+
+    $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+    ob_start();
+    @$zipStreamResponse->toResponse(request())->sendContent();
+    $content = ob_get_contents();
+    ob_end_clean();
+
+    $temporaryDirectory = (new TemporaryDirectory())->create();
+    file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+    $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
+
+    $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
+});
+
+test('media with zip file folder prefix property saved in correct zip folder and correct suffix', function () {
+    foreach (range(1, 2) as $i) {
+        $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection();
     }
 
-    /** @test */
-    public function it_can_return_a_stream_of_media()
-    {
-        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
-
-        $this->assertEquals(count(Media::all()), $zipStreamResponse->getMediaItems()->count());
-
-        Route::get('stream-test', fn () => $zipStreamResponse);
-
-        $response = $this->get('stream-test');
-
-        $this->assertInstanceOf(StreamedResponse::class, $response->baseResponse);
-    }
-
-    /** @test */
-    public function it_can_return_a_stream_of_multiple_files_with_the_same_filename()
-    {
-        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
-
-        ob_start();
-        @$zipStreamResponse->toResponse(request())->sendContent();
-        $content = ob_get_contents();
-        ob_end_clean();
-
-        $temporaryDirectory = (new TemporaryDirectory())->create();
-        file_put_contents($temporaryDirectory->path('response.zip'), $content);
-
-        $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');
-        $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test (1).jpg');
-        $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test (2).jpg');
-    }
-
-    /** @test */
-    public function media_can_be_added_to_it_one_by_one()
-    {
-        $zipStreamResponse = MediaStream::create('my-media.zip')
-            ->addMedia(Media::find(1))
-            ->addMedia(Media::find(2));
-
-        $this->assertEquals(2, $zipStreamResponse->getMediaItems()->count());
-    }
-
-    /** @test */
-    public function an_array_of_media_can_be_added_to_it()
-    {
-        $zipStreamResponse = MediaStream::create('my-media.zip')
-            ->addMedia([Media::find(1), Media::find(2)]);
-
-        $this->assertEquals(2, $zipStreamResponse->getMediaItems()->count());
-    }
-
-    /** @test */
-    public function media_with_zip_file_folder_prefix_property_saved_in_correct_zip_folder()
-    {
+    foreach (range(1, 2) as $i) {
         $this->testModel
             ->addMedia($this->getTestJpg())
             ->preservingOriginal()
@@ -85,80 +102,43 @@ class MediaStreamTest extends TestCase
                 'zip_filename_prefix' => 'folder/subfolder/',
             ])
             ->toMediaCollection();
-
-        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
-
-        ob_start();
-        @$zipStreamResponse->toResponse(request())->sendContent();
-        $content = ob_get_contents();
-        ob_end_clean();
-
-        $temporaryDirectory = (new TemporaryDirectory())->create();
-        file_put_contents($temporaryDirectory->path('response.zip'), $content);
-
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
-
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
     }
 
-    /** @test */
-    public function media_with_zip_file_folder_prefix_property_saved_in_correct_zip_folder_and_correct_suffix()
-    {
-        foreach (range(1, 2) as $i) {
-            $this->testModel
-                ->addMedia($this->getTestJpg())
-                ->preservingOriginal()
-                ->toMediaCollection();
-        }
+    $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
 
-        foreach (range(1, 2) as $i) {
-            $this->testModel
-                ->addMedia($this->getTestJpg())
-                ->preservingOriginal()
-                ->withCustomProperties([
-                    'zip_filename_prefix' => 'folder/subfolder/',
-                ])
-                ->toMediaCollection();
-        }
+    ob_start();
+    @$zipStreamResponse->toResponse(request())->sendContent();
+    $content = ob_get_contents();
+    ob_end_clean();
 
-        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+    $temporaryDirectory = (new TemporaryDirectory())->create();
+    file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
-        ob_start();
-        @$zipStreamResponse->toResponse(request())->sendContent();
-        $content = ob_get_contents();
-        ob_end_clean();
+    $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test.jpg');
+    $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (1).jpg');
+    $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
 
-        $temporaryDirectory = (new TemporaryDirectory())->create();
-        file_put_contents($temporaryDirectory->path('response.zip'), $content);
+    $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
+    $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (1).jpg');
+});
 
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test.jpg');
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (1).jpg');
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
+test('media with zip file prefix property saved with correct prefix', function () {
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties([
+            'zip_filename_prefix' => 'just_a_string_prefix ',
+        ])
+        ->toMediaCollection();
 
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test.jpg');
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (1).jpg');
-    }
+    $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
 
-    /** @test */
-    public function media_with_zip_file_prefix_property_saved_with_correct_prefix()
-    {
-        $this->testModel
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->withCustomProperties([
-                'zip_filename_prefix' => 'just_a_string_prefix ',
-            ])
-            ->toMediaCollection();
+    ob_start();
+    @$zipStreamResponse->toResponse(request())->sendContent();
+    $content = ob_get_contents();
+    ob_end_clean();
+    $temporaryDirectory = (new TemporaryDirectory())->create();
+    file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
-        $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
-
-        ob_start();
-        @$zipStreamResponse->toResponse(request())->sendContent();
-        $content = ob_get_contents();
-        ob_end_clean();
-        $temporaryDirectory = (new TemporaryDirectory())->create();
-        file_put_contents($temporaryDirectory->path('response.zip'), $content);
-
-        $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'just_a_string_prefix test.jpg');
-    }
-}
+    $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'just_a_string_prefix test.jpg');
+});

--- a/tests/Support/PathGenerator/BasePathGeneratorTest.php
+++ b/tests/Support/PathGenerator/BasePathGeneratorTest.php
@@ -7,7 +7,6 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $this->config = app('config');

--- a/tests/Support/PathGenerator/BasePathGeneratorTest.php
+++ b/tests/Support/PathGenerator/BasePathGeneratorTest.php
@@ -2,6 +2,7 @@
 
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
+use Spatie\MediaLibrary\Tests\Support\PathGenerator\CustomPathGenerator;
 
 beforeEach(function () {
     $this->config = app('config');

--- a/tests/Support/PathGenerator/BasePathGeneratorTest.php
+++ b/tests/Support/PathGenerator/BasePathGeneratorTest.php
@@ -1,12 +1,7 @@
 <?php
 
-use Illuminate\Config\Repository;
-use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 beforeEach(function () {
     $this->config = app('config');

--- a/tests/Support/PathGenerator/BasePathGeneratorTest.php
+++ b/tests/Support/PathGenerator/BasePathGeneratorTest.php
@@ -26,7 +26,7 @@ it('can get the custom path for media without conversions', function () {
 
     $pathRelativeToRoot = md5($media->id).'/'.$media->file_name;
 
-    $this->assertEquals($pathRelativeToRoot, $this->urlGenerator->getPathRelativeToRoot());
+    expect($this->urlGenerator->getPathRelativeToRoot())->toEqual($pathRelativeToRoot);
 });
 
 it('can get the custom path for media with conversions', function () {
@@ -39,5 +39,5 @@ it('can get the custom path for media with conversions', function () {
 
     $pathRelativeToRoot = md5($media->id).'/c/test-'.$conversion->getName().'.'.$conversion->getResultExtension($media->extension);
 
-    $this->assertEquals($pathRelativeToRoot, $this->urlGenerator->getPathRelativeToRoot());
+    expect($this->urlGenerator->getPathRelativeToRoot())->toEqual($pathRelativeToRoot);
 });

--- a/tests/Support/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/Support/UrlGenerator/BaseUrlGeneratorTest.php
@@ -31,7 +31,7 @@ beforeEach(function () {
 it('can get the path relative to the root of media folder', function () {
     $pathRelativeToRoot = $this->media->id.'/conversions/test-'.$this->conversion->getName().'.jpg';
 
-    $this->assertEquals($pathRelativeToRoot, $this->urlGenerator->getPathRelativeToRoot());
+    expect($this->urlGenerator->getPathRelativeToRoot())->toEqual($pathRelativeToRoot);
 });
 
 it('can get the path relative to the root of media folder when keeping the original image format', function () {
@@ -42,7 +42,7 @@ it('can get the path relative to the root of media folder when keeping the origi
         'test-'.$this->conversionKeepingOriginalImageFormat->getName()
         .'.png';
 
-    $this->assertEquals($pathRelativeToRoot, $this->urlGenerator->getPathRelativeToRoot());
+    expect($this->urlGenerator->getPathRelativeToRoot())->toEqual($pathRelativeToRoot);
 });
 
 it('appends a version string when versioning is enabled', function () {
@@ -50,17 +50,17 @@ it('appends a version string when versioning is enabled', function () {
 
     $url = '/media/'.$this->media->id.'/conversions/test-'.$this->conversion->getName().'.jpg?v='.$this->media->updated_at->timestamp;
 
-    $this->assertEquals($url, $this->urlGenerator->getUrl());
+    expect($this->urlGenerator->getUrl())->toEqual($url);
 
     config()->set('media-library.version_urls', false);
 
     $url = '/media/'.$this->media->id.'/conversions/test-'.$this->conversion->getName().'.jpg';
 
-    $this->assertEquals($url, $this->urlGenerator->getUrl());
+    expect($this->urlGenerator->getUrl())->toEqual($url);
 });
 
 it('can get the responsive images directory url', function () {
     $this->config->set('filesystems.disks.public.url', 'http://localhost/media/');
 
-    $this->assertEquals('http://localhost/media/1/responsive-images/', $this->urlGenerator->getResponsiveImagesDirectoryUrl());
+    expect($this->urlGenerator->getResponsiveImagesDirectoryUrl())->toEqual('http://localhost/media/1/responsive-images/');
 });

--- a/tests/Support/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/Support/UrlGenerator/BaseUrlGeneratorTest.php
@@ -1,13 +1,8 @@
 <?php
 
-use Illuminate\Config\Repository;
-use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator;
 use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
-use Spatie\MediaLibrary\Tests\TestCase;
-
 
 beforeEach(function () {
     $this->config = app('config');

--- a/tests/Support/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/Support/UrlGenerator/BaseUrlGeneratorTest.php
@@ -8,7 +8,6 @@ use Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator;
 use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
 use Spatie\MediaLibrary\Tests\TestCase;
 
-uses(TestCase::class);
 
 beforeEach(function () {
     $this->config = app('config');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,7 +41,7 @@ abstract class TestCase extends Orchestra
 
     protected TestModelWithConversionsOnOtherDisk $testModelWithConversionsOnOtherDisk;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->loadEnvironmentVariables();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -90,7 +90,7 @@ abstract class TestCase extends Orchestra
     /**
      * @param \Illuminate\Foundation\Application $app
      */
-    protected function getEnvironmentSetUp($app)
+    public function getEnvironmentSetUp($app)
     {
         $this->initializeDirectory($this->getTempDirectory());
 


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-53809` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
