### PR TITLE
Fix tests

### DIFF
--- a/tests/Feature/S3Integration/S3TestPathGenerator.php
+++ b/tests/Feature/S3Integration/S3TestPathGenerator.php
@@ -33,6 +33,6 @@ class S3TestPathGenerator implements PathGenerator
      */
     protected function getBasePath(Media $media): string
     {
-        return (S3IntegrationTest::getS3BaseTestDirectory()).'/'.$media->getKey();
+        return (getS3BaseTestDirectory()).'/'.$media->getKey();
     }
 }


### PR DESCRIPTION
This PR will fix the "beforeEach already exist" error in pest test suite

Can't test the code, though (have not an S3 for testing)

my only fear is that you couldn't call Pest's `getS3BaseTestDirectory()` directly from `S3TestPathGenerator.php`, but the main issue is that `S3IntegrationTest` class was autoloaded by composer in `S3TestPathGenerator.php` and it looked into `S3IntegrationTest.php` triggering beforeEach() a second time