### PR TITLE
Make fallback url/path have different defaults (in tests)

### DIFF
--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -204,11 +204,11 @@ it('can get the path to first media in a collection', function () {
 });
 
 it('can get the default path to the first media in a collection', function () {
-    expect($this->testModel->getFirstMediaPath('avatar'))->toEqual('/default.jpg');
+    expect($this->testModel->getFirstMediaPath('avatar'))->toEqual('/default-path.jpg');
 });
 
 it('can get the default url to the first media in a collection', function () {
-    expect($this->testModel->getFirstMediaUrl('avatar'))->toEqual('/default.jpg');
+    expect($this->testModel->getFirstMediaUrl('avatar'))->toEqual('/default-url.jpg');
 });
 
 it('can get the default path to the first media in a collection if conversion not marked as generated yet', function () {

--- a/tests/TestSupport/TestModels/TestModel.php
+++ b/tests/TestSupport/TestModels/TestModel.php
@@ -20,7 +20,7 @@ class TestModel extends Model implements HasMedia
     {
         $this
             ->addMediaCollection('avatar')
-            ->useFallbackUrl('/default.jpg')
-            ->useFallbackPath('/default.jpg');
+            ->useFallbackUrl('/default-url.jpg')
+            ->useFallbackPath('/default-path.jpg');
     }
 }


### PR DESCRIPTION
I was looking at the tests surrounding fallbackUrl as part of https://github.com/spatie/laravel-medialibrary/discussions/2734 and just noticed that I could slightly improve them by using a different default image name.

This prevents the tests from passing if we accidentally return the fallbackPath on the fallbackUrl method
