### PR TITLE
Fix `jsonSerialize` return type

### DIFF
--- a/src/MediaCollections/Models/Collections/MediaCollection.php
+++ b/src/MediaCollections/Models/Collections/MediaCollection.php
@@ -66,6 +66,6 @@ class MediaCollection extends Collection implements Htmlable
                 'extension' => $media->extension,
                 'size' => $media->size,
             ];
-        })->keyBy('uuid');
+        })->keyBy('uuid')->toArray();
     }
 }


### PR DESCRIPTION
Currently `jsonSerialize` returns collection from but method expects array.