### PR TITLE
fix: explicitly load media

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -530,7 +530,7 @@ trait InteractsWithMedia
     public function loadMedia(string $collectionName): Collection
     {
         $collection = $this->exists
-            ? $this->media
+            ? $this->loadMissing('media')->media
             : collect($this->unAttachedMediaLibraryItems)->pluck('media');
 
         $collection = new MediaCollections\Models\Collections\MediaCollection($collection);


### PR DESCRIPTION
Currently, if lazy loading is disabled there is a dump because `media` is eager loaded. This PR fixes it and loads `media` explicitly if it wasn't loaded yet.

It would be great if you could also apply the same for the 9.* release. Thanks!