### PR TITLE
Change to forceDelete in move method of Media

### DIFF
--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -286,7 +286,7 @@ class Media extends Model implements Responsable, Htmlable
     {
         $newMedia = $this->copy($model, $collectionName, $diskName, $fileName);
 
-        $this->delete();
+        $this->forceDelete();
 
         return $newMedia;
     }


### PR DESCRIPTION
Some of us subclass the Media model class to add the SoftDelete trait.

This lead to the delete() in the move method doing a soft delete instead. Which can cause some issues. like if we copy the uuid of the earlier record to the new record. Since uuid is defined as unique in the migrations.