### PR TITLE
Fix phpstan errors in ci

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -176,11 +176,6 @@ parameters:
 			path: src/Conversions/ConversionCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:each\\(\\) expects callable\\(mixed\\)\\: mixed, Closure\\(mixed, mixed\\)\\: void given\\.$#"
-			count: 1
-			path: src/Conversions/ConversionCollection.php
-
-		-
 			message: "#^Unable to resolve the template type TKey in call to function collect$#"
 			count: 1
 			path: src/Conversions/ConversionCollection.php
@@ -486,42 +481,7 @@ parameters:
 			path: src/MediaCollections/Commands/CleanCommand.php
 
 		-
-			message: "#^Method Spatie\\\\MediaLibrary\\\\MediaCollections\\\\Commands\\\\CleanCommand\\:\\:getMediaItems\\(\\) return type with generic class Illuminate\\\\Database\\\\Eloquent\\\\Collection does not specify its types\\: TKey, TModel$#"
-			count: 1
-			path: src/MediaCollections/Commands/CleanCommand.php
-
-		-
 			message: "#^Method Spatie\\\\MediaLibrary\\\\MediaCollections\\\\Commands\\\\CleanCommand\\:\\:handle\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/MediaCollections/Commands/CleanCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:each\\(\\) expects callable\\(Illuminate\\\\Database\\\\Eloquent\\\\Model\\)\\: mixed, Closure\\(Spatie\\\\MediaLibrary\\\\MediaCollections\\\\Models\\\\Media\\)\\: void given\\.$#"
-			count: 1
-			path: src/MediaCollections/Commands/CleanCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),float\\|int\\|string\\>\\:\\:each\\(\\) expects callable\\(float\\|int\\|numeric\\-string\\)\\: mixed, Closure\\(string\\)\\: void given\\.$#"
-			count: 1
-			path: src/MediaCollections/Commands/CleanCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),float\\|int\\|string\\>\\:\\:reject\\(\\) expects bool\\|\\(callable\\(float\\|int\\|numeric\\-string\\)\\: bool\\), Closure\\(string\\)\\: bool given\\.$#"
-			count: 1
-			path: src/MediaCollections/Commands/CleanCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:each\\(\\) expects callable\\(mixed\\)\\: mixed, Closure\\(bool, string\\)\\: Spatie\\\\MediaLibrary\\\\MediaCollections\\\\Models\\\\Media given\\.$#"
-			count: 1
-			path: src/MediaCollections/Commands/CleanCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:filter\\(\\) expects \\(callable\\(mixed\\)\\: bool\\)\\|null, Closure\\(bool, string\\)\\: bool given\\.$#"
-			count: 1
-			path: src/MediaCollections/Commands/CleanCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<int,int\\|string\\>\\:\\:map\\(\\) expects callable\\(int\\|string, int\\)\\: Spatie\\\\MediaLibrary\\\\ResponsiveImages\\\\RegisteredResponsiveImages, Closure\\(string\\)\\: Spatie\\\\MediaLibrary\\\\ResponsiveImages\\\\RegisteredResponsiveImages given\\.$#"
 			count: 1
 			path: src/MediaCollections/Commands/CleanCommand.php
 
@@ -561,17 +521,7 @@ parameters:
 			path: src/MediaCollections/Commands/CleanCommand.php
 
 		-
-			message: "#^Method Spatie\\\\MediaLibrary\\\\MediaCollections\\\\Commands\\\\ClearCommand\\:\\:getMediaItems\\(\\) return type with generic class Illuminate\\\\Database\\\\Eloquent\\\\Collection does not specify its types\\: TKey, TModel$#"
-			count: 1
-			path: src/MediaCollections/Commands/ClearCommand.php
-
-		-
 			message: "#^Method Spatie\\\\MediaLibrary\\\\MediaCollections\\\\Commands\\\\ClearCommand\\:\\:handle\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/MediaCollections/Commands/ClearCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:each\\(\\) expects callable\\(Illuminate\\\\Database\\\\Eloquent\\\\Model\\)\\: mixed, Closure\\(Spatie\\\\MediaLibrary\\\\MediaCollections\\\\Models\\\\Media\\)\\: void given\\.$#"
 			count: 1
 			path: src/MediaCollections/Commands/ClearCommand.php
 
@@ -1511,11 +1461,6 @@ parameters:
 			path: src/MediaCollections/Models/Media.php
 
 		-
-			message: "#^Return type of call to function collect contains unresolvable type\\.$#"
-			count: 1
-			path: src/MediaCollections/Models/Media.php
-
-		-
 			message: "#^Unable to resolve the template type TKey in call to function collect$#"
 			count: 1
 			path: src/MediaCollections/Models/Media.php
@@ -1546,16 +1491,6 @@ parameters:
 			path: src/MediaCollections/Models/Observers/MediaObserver.php
 
 		-
-			message: "#^Class Laravel\\\\Lumen\\\\Application not found\\.$#"
-			count: 1
-			path: src/MediaCollections/Models/Observers/MediaObserver.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/MediaCollections/Models/Observers/MediaObserver.php
-
-		-
 			message: "#^Method Spatie\\\\MediaLibrary\\\\MediaCollections\\\\Models\\\\Observers\\\\MediaObserver\\:\\:creating\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/MediaCollections/Models/Observers/MediaObserver.php
@@ -1572,16 +1507,6 @@ parameters:
 
 		-
 			message: "#^Method Spatie\\\\MediaLibrary\\\\MediaCollections\\\\Models\\\\Observers\\\\MediaObserver\\:\\:updating\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/MediaCollections/Models/Observers/MediaObserver.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between '9\\.x\\-dev' and '7\\.x\\-dev' will always evaluate to false\\.$#"
-			count: 1
-			path: src/MediaCollections/Models/Observers/MediaObserver.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: src/MediaCollections/Models/Observers/MediaObserver.php
 

--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -67,6 +67,7 @@ class CleanCommand extends Command
         $this->info('All done!');
     }
 
+    /** @return Collection<int, Media> */
     public function getMediaItems(): Collection
     {
         $modelType = $this->argument('modelType');
@@ -131,6 +132,7 @@ class CleanCommand extends Command
             ->map(fn (Conversion $conversion) => $conversion->getName())
             ->push('media_library_original');
 
+        /** @var array<int, string> $responsiveImagesGeneratedFor */
         $responsiveImagesGeneratedFor = array_keys($media->responsive_images);
 
         collect($responsiveImagesGeneratedFor)
@@ -156,9 +158,13 @@ class CleanCommand extends Command
 
         $mediaIds = collect($this->mediaRepository->all()->pluck($keyName)->toArray());
 
-        collect($this->fileSystem->disk($diskName)->directories())
+        /** @var array<int, string> */
+        $directories = $this->fileSystem->disk($diskName)->directories();
+
+        collect($directories)
             ->filter(fn (string $directory) => is_numeric($directory))
-            ->reject(fn (string $directory) => $mediaIds->contains((int) $directory))->each(function (string $directory) use ($diskName) {
+            ->reject(fn (string $directory) => $mediaIds->contains((int) $directory))
+            ->each(function (string $directory) use ($diskName) {
                 if (! $this->isDryRun) {
                     $this->fileSystem->disk($diskName)->deleteDirectory($directory);
                 }

--- a/src/MediaCollections/Commands/ClearCommand.php
+++ b/src/MediaCollections/Commands/ClearCommand.php
@@ -41,6 +41,7 @@ class ClearCommand extends Command
         $this->info('All done!');
     }
 
+    /** @return Collection<int, Media> */
     public function getMediaItems(): Collection
     {
         $modelType = $this->argument('modelType');

--- a/src/MediaCollections/Models/Observers/MediaObserver.php
+++ b/src/MediaCollections/Models/Observers/MediaObserver.php
@@ -4,7 +4,6 @@ namespace Spatie\MediaLibrary\MediaCollections\Models\Observers;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Application;
-use Laravel\Lumen\Application as Lumen;
 use Spatie\MediaLibrary\Conversions\FileManipulator;
 use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -42,10 +41,6 @@ class MediaObserver
 
         $original = $media->getOriginal('manipulations');
 
-        if (! $this->isLumen() && ! $this->isLaravel7orHigher()) {
-            $original = json_decode($original, true, 512, JSON_THROW_ON_ERROR);
-        }
-
         if ($media->manipulations !== $original) {
             $eventDispatcher = Media::getEventDispatcher();
             Media::unsetEventDispatcher();
@@ -71,23 +66,5 @@ class MediaObserver
         $filesystem = app(Filesystem::class);
 
         $filesystem->removeAllFiles($media);
-    }
-
-    private function isLaravel7orHigher(): bool
-    {
-        if (Application::VERSION === '7.x-dev') {
-            return true;
-        }
-
-        if (version_compare(Application::VERSION, '7.0', '>=')) {
-            return true;
-        }
-
-        return false;
-    }
-
-    protected function isLumen(): bool
-    {
-        return app() instanceof Lumen;
     }
 }


### PR DESCRIPTION
Since CI is failing I thought I rather just fix it if you don't mind :)

I have:

- Removed no longer failing errors
- Added a few `@return` and `@var` type hints to make PHPStan happy again
- Removed code for the `MediaObserver` `isLumen()` and `isLaravel7orHigher()` since L7 is no longer supported

Types and generics are still not my strong side so if anything is not as expected please let me know!

At least now CI is no longer complaining without just suppressing the errors :)