### PR TITLE
[10.x] Added string support for id in deleteMedia()

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -476,7 +476,7 @@ trait InteractsWithMedia
      *
      * @throws \Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeDeleted
      */
-    public function deleteMedia(int|Media $mediaId): void
+    public function deleteMedia(int|string|Media $mediaId): void
     {
         if ($mediaId instanceof Media) {
             $mediaId = $mediaId->getKey();


### PR DESCRIPTION
Currently, method `deleteMedia()` in `InteractsWithMedia` trait has a typed param `$mediaId` as an `int` or `Media` object.
That's a problem if you extend a default `Media` model and have a `string` type primary key (e.g.: UUID).
This PR resolves that by adding a string type support for `$mediaId` param.