### PR TITLE
Add methods to get first-available conversion url

### DIFF
--- a/docs/converting-images/retrieving-converted-images.md
+++ b/docs/converting-images/retrieving-converted-images.md
@@ -25,3 +25,12 @@ If a conversion is queued, a file may not exist yet on the generated url. You ca
 ```php
 $yourModel->getMedia('images')[0]->hasGeneratedConversion('thumb'); // returns true or false
 ```
+
+If a conversion does not exist, you might want to fallback to an other conversion or even the original file. This can be achieved using the `getAvailableUrl`, `getAvailableFullUrl` or `getAvailablePath` method. Each of these methods accepts an array of conversion names. It will return the url or path of the first conversion that has been generated and is available. If none of the provided conversions have been generated yet, then it will use the url or path of the original file.
+
+```php
+$mediaItems = $yourModel->getMedia('images');
+$mediaItems[0]->getAvailableUrl(['small', 'medium', 'large']);
+$mediaItems[0]->getAvailableFullUrl(['small', 'medium', 'large']);
+$mediaItems[0]->getAvailablePath(['small', 'medium', 'large']);
+```

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -93,6 +93,45 @@ class Media extends Model implements Responsable, Htmlable
         return $urlGenerator->getPath();
     }
 
+    public function getAvailableUrl(array $conversionNames): string
+    {
+        foreach ($conversionNames as $conversionName) {
+            if (! $this->hasGeneratedConversion($conversionName)) {
+                continue;
+            }
+
+            return $this->getUrl($conversionName);
+        }
+
+        return $this->getUrl();
+    }
+
+    public function getAvailableFullUrl(array $conversionNames): string
+    {
+        foreach ($conversionNames as $conversionName) {
+            if (! $this->hasGeneratedConversion($conversionName)) {
+                continue;
+            }
+
+            return $this->getFullUrl($conversionName);
+        }
+
+        return $this->getFullUrl();
+    }
+
+    public function getAvailablePath(array $conversionNames): string
+    {
+        foreach ($conversionNames as $conversionName) {
+            if (! $this->hasGeneratedConversion($conversionName)) {
+                continue;
+            }
+
+            return $this->getPath($conversionName);
+        }
+
+        return $this->getPath();
+    }
+
     protected function type(): Attribute
     {
         return Attribute::get(

--- a/tests/Feature/Media/GetAvailableUrlTest.php
+++ b/tests/Feature/Media/GetAvailableUrlTest.php
@@ -1,0 +1,36 @@
+<?php
+
+it('can get a url of first available conversion', function () {
+    $media = $this->testModelWithMultipleConversions->addMedia($this->getTestJpg())->toMediaCollection();
+
+    $media->markAsConversionNotGenerated('small');
+    $media->markAsConversionNotGenerated('medium');
+    $media->markAsConversionGenerated('large');
+
+    expect($media->getAvailableUrl(['small', 'medium', 'large']))->toEqual("/media/{$media->id}/conversions/test-large.jpg");
+    expect($media->getAvailableFullUrl(['small', 'medium', 'large']))->toEqual("http://localhost/media/{$media->id}/conversions/test-large.jpg");
+    expect($media->getAvailablePath(['small', 'medium', 'large']))->toEqual($this->makePathOsSafe($this->getMediaDirectory() . "/{$media->id}/conversions/test-large.jpg"));
+
+    $media->markAsConversionGenerated('medium');
+
+    expect($media->getAvailableUrl(['small', 'medium', 'large']))->toEqual("/media/{$media->id}/conversions/test-medium.jpg");
+    expect($media->getAvailableFullUrl(['small', 'medium', 'large']))->toEqual("http://localhost/media/{$media->id}/conversions/test-medium.jpg");
+    expect($media->getAvailablePath(['small', 'medium', 'large']))->toEqual($this->makePathOsSafe($this->getMediaDirectory() . "/{$media->id}/conversions/test-medium.jpg"));
+
+    $media->markAsConversionGenerated('small');
+
+    expect($media->getAvailableUrl(['small', 'medium', 'large']))->toEqual("/media/{$media->id}/conversions/test-small.jpg");
+    expect($media->getAvailableFullUrl(['small', 'medium', 'large']))->toEqual("http://localhost/media/{$media->id}/conversions/test-small.jpg");
+    expect($media->getAvailablePath(['small', 'medium', 'large']))->toEqual($this->makePathOsSafe($this->getMediaDirectory() . "/{$media->id}/conversions/test-small.jpg"));
+});
+
+it('uses original url if no conversion has been generated yet', function () {
+    $media = $this->testModelWithMultipleConversions->addMedia($this->getTestJpg())->toMediaCollection();
+    $media->markAsConversionNotGenerated('small');
+    $media->markAsConversionNotGenerated('medium');
+    $media->markAsConversionNotGenerated('large');
+
+    expect($media->getAvailableUrl(['small', 'medium', 'large']))->toEqual("/media/{$media->id}/test.jpg");
+    expect($media->getAvailableFullUrl(['small', 'medium', 'large']))->toEqual("http://localhost/media/{$media->id}/test.jpg");
+    expect($media->getAvailablePath(['small', 'medium', 'large']))->toEqual($this->makePathOsSafe($this->getMediaDirectory() . "/{$media->id}/test.jpg"));
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,7 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionQueued;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionsOnOtherDisk;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMorphMap;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMultipleConversions;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithPreviewConversion;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithResponsiveImages;
@@ -28,6 +29,8 @@ abstract class TestCase extends Orchestra
     protected TestModel $testUnsavedModel;
 
     protected TestModelWithConversion $testModelWithConversion;
+
+    protected TestModelWithMultipleConversion $testModelWithMultipleConversion;
 
     protected TestModelWithPreviewConversion $testModelWithPreviewConversion;
 
@@ -54,6 +57,7 @@ abstract class TestCase extends Orchestra
         $this->testModel = TestModel::first();
         $this->testUnsavedModel = new TestModel();
         $this->testModelWithConversion = TestModelWithConversion::first();
+        $this->testModelWithMultipleConversions = TestModelWithMultipleConversions::first();
         $this->testModelWithPreviewConversion = TestModelWithPreviewConversion::first();
         $this->testModelWithConversionQueued = TestModelWithConversionQueued::first();
         $this->testModelWithoutMediaConversions = TestModelWithoutMediaConversions::first();

--- a/tests/TestSupport/TestModels/TestModelWithMultipleConversions.php
+++ b/tests/TestSupport/TestModels/TestModelWithMultipleConversions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class TestModelWithMultipleConversions extends TestModel
+{
+    public function registerMediaConversions(Media $media = null): void
+    {
+        $this->addMediaConversion('small')
+            ->width(50)
+            ->nonQueued();
+
+        $this->addMediaConversion('medium')
+            ->width(100)
+            ->nonQueued();
+
+        $this->addMediaConversion('large')
+            ->width(200)
+            ->nonQueued();
+    }
+}


### PR DESCRIPTION
When a new media model has been saved, the conversions are not instantly available as they need to be generated by a job on the queue. That means you have to fall back to the original URL in the meantime to ensure the user does see something instead of an error because the conversion image can not be found. Currently you have to that manually with the following code:
```php
$media->getFullUrl($media->hasGeneratedConversion('small') ? 'thumbnail' : '');
```
That is a bit cumbersome. To fix that, this PR adds a method that returns the URL (or path) of the first available conversion. If no conversion exists, then it returns the URL (or path) of the original file.
```php
$media->getUrl(['small', 'medium', 'large']);
$media->getFullUrl(['small', 'medium', 'large']);
$media->getPath(['small', 'medium', 'large']);
```