### PR TITLE
Fix High CPU Usage

### DIFF
--- a/src/MediaCollections/Models/Concerns/IsSorted.php
+++ b/src/MediaCollections/Models/Concerns/IsSorted.php
@@ -15,7 +15,9 @@ trait IsSorted
 
     public function getHighestOrderNumber(): int
     {
-        return (int) static::max($this->determineOrderColumnName());
+        return (int) static::where('model_type', $this->model_type)
+						->where('model_id', $this->model_id)
+						->max($this->determineOrderColumnName());
     }
 
     public function scopeOrdered(Builder $query): Builder


### PR DESCRIPTION
Have 4 million rows in our media table and this query takes over than 5 seconds on 10 Core CPU server.
And CPU is using %300 on during crowded hours.

I think not needed execute this query for all rows, can execute for only model related rows.