### PR TITLE
Added setConnection in FileAdder processMediaItem

### DIFF
--- a/docs/advanced-usage/customising-database-connections.md
+++ b/docs/advanced-usage/customising-database-connections.md
@@ -10,7 +10,8 @@ The built-in model (`Spatie\MediaLibrary\MediaCollections\Models\Media`) will us
 If you need to change this database, connection you can create a custom model and set the `$connection` property (https://laravel.com/docs/8.x/eloquent#database-connections). See <a href="https://docs.spatie.be/laravel-medialibrary/v9/advanced-usage/using-your-own-model">Using your own model</a> for more information.
 
 ```php
-<?
+<?php
+
 namespace App\Models;
 
 use Spatie\MediaLibrary\MediaCollections\Models\Media as BaseMedia;
@@ -27,7 +28,8 @@ class Media extends BaseMedia {
 The `Spatie\MediaLibrary\InteractsWithMedia` trait defines a `MorphMany` relationship to the media model. Eloquent automatically uses the database connection of your parent model when querying the database. In the example below, the user media results will use the `tenant` database connection rather than the application's default connection.
 
 ```php
-<?
+<?php
+
 namespace App\Models;
 
 use Spatie\MediaLibrary\HasMedia;

--- a/docs/advanced-usage/customising-database-connections.md
+++ b/docs/advanced-usage/customising-database-connections.md
@@ -1,0 +1,54 @@
+---
+title: Customising Database Connections
+weight: 13
+---
+
+### Media model connection
+
+The built-in model (`Spatie\MediaLibrary\MediaCollections\Models\Media`) will use the default database connection set for your application.
+
+If you need to change this database, connection you can create a custom model and set the `$connection` property (https://laravel.com/docs/8.x/eloquent#database-connections). See <a href="https://docs.spatie.be/laravel-medialibrary/v9/advanced-usage/using-your-own-model">Using your own model</a> for more information.
+
+```php
+<?
+namespace App\Models;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media as BaseMedia;
+
+class Media extends BaseMedia {
+
+    protected $connection = 'tenant';
+
+}
+```
+
+### Parent model connection
+
+The `Spatie\MediaLibrary\InteractsWithMedia` trait defines a `MorphMany` relationship to the media model. Eloquent automatically uses the database connection of your parent model when querying the database. In the example below, the user media results will use the `tenant` database connection rather than the application's default connection.
+
+```php
+<?
+namespace App\Models;
+
+use Spatie\MediaLibrary\HasMedia;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\MediaLibrary\InteractsWithMedia;
+
+class User extends Model implements HasMedia {
+
+    use InteractsWithMedia;
+
+    protected $connection = 'tenant';
+
+}
+```
+
+When you save files using the code below, the `Spatie\MediaLibrary\MediaCollections\FileAdder` will also automatically use the parent model's database connection if that is set.
+
+```php
+$model
+    ->addMedia($path)
+    ->toMediaCollection();
+```
+
+If you need to customise the database connection further before fetching or adding media, use you can do `$model->setConnection('landlord')`.

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -419,6 +419,10 @@ class FileAdder
 
         $this->checkGenerateResponsiveImages($media);
 
+        if (! $media->getConnectionName()) {
+            $media->setConnection($model->getConnectionName());
+        }
+
         $model->media()->save($media);
 
         if ($fileAdder->file instanceof RemoteFile) {


### PR DESCRIPTION
Thanks for the package.

I'm using it within a SaaS app where there is a single Media model that uses the landlord or tenant connection depending on the context it is used in.

A model's queried media contains the correct results since Eloquent's `hasMany` sets the media model to use the same database connection name as the parent model (https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php#L753-L760)

However when using `$model->addMedia($path)->toMediaCollecton($collection)` I was running into:

```
Illuminate\Database\QueryException

  SQLSTATE[3D000]: Invalid catalog name: 1046 No database selected (SQL: select max(`order_column`) as aggregate from `media`)
  ```
  
I believe this is because the `FileAdder` "news up" a media model without specifying the database connection of the parent. 

This PR updates the `processMediaItem` method to automatically set the media model connection to the same as the parent model if that is set.

