### PR TITLE
Add explanation for processing responses

### DIFF
--- a/docs/handling-uploads-with-media-library-pro/processing-uploads-on-the-server.md
+++ b/docs/handling-uploads-with-media-library-pro/processing-uploads-on-the-server.md
@@ -259,7 +259,7 @@ class StoreLivewireCollectionCustomPropertyRequest extends FormRequest
 
 ## Processing responses
 
-After you've validated the response, you should persist the changes to the media library. The media library provides two methods for that: `syncFromMediaLibraryRequest` and `addFromMediaLibraryRequest`. Both these methods are available on all [models that handle media](/docs/laravel-medialibrary/v10/basic-usage/preparing-your-model).
+After you've validated the response, you should persist the changes to the media library. The media library provides two methods for that: `syncFromMediaLibraryRequest` and `addFromMediaLibraryRequest`. Both these methods are available on all [models that handle media](/docs/laravel-medialibrary/v10/basic-usage/preparing-your-model). Either way call the method `toMediaCollection` to update your media-model in the database. This will also ensure that temporary uploads are converted to the appropriate model.
 
 ### `addFromMediaLibraryRequest`
 


### PR DESCRIPTION
Not sure if I missed it somewhere else, but I guess the behaviour is by design like this, but basically we have to call the `toMediaCollection` method to ensure that the database is up to date and that the `model_type` is updated. I was using it with the temporary uploads functionality (which is enabled by default I think) and didn't call the method `toMediaCollection`  because I only have a default one, but noticed that I couldn't retrieve any media-files.

After a bit of reading source code and debugging I noticed that we have to call this, so that the `PendingMediaItem` is converted to the associated model.

Hope my explanation makes sense.

so my code was basically:
```php
$model
    ->addFromMediaLibraryRequest($request->attachments)
    ->usingName(fn(MediaLibraryRequestItem $item) => strtolower($item->name));
```

and had to change it to
```php
$model
    ->addFromMediaLibraryRequest($request->attachments)
    ->usingName(fn(MediaLibraryRequestItem $item) => strtolower($item->name))
    ->toMediaCollection();
```

I am using medialibrary v10 and pro v2 with the blade directives.

Hope this helps