### PR TITLE
Update percentage value in the config file

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -183,7 +183,7 @@ return [
     'responsive_images' => [
         /*
          * This class is responsible for calculating the target widths of the responsive
-         * images. By default we optimize for filesize and create variations that each are 20%
+         * images. By default we optimize for filesize and create variations that each are 30%
          * smaller than the previous one. More info in the documentation.
          *
          * https://docs.spatie.be/laravel-medialibrary/v9/advanced-usage/generating-responsive-images


### PR DESCRIPTION
The `FileSizeOptimizedWidthCalculator` uses the following line when generating widths for responsive images:

`$predictedFileSize *= 0.7;`

I updated the comment in the config file to match this logic.