### PR TITLE
Change `MediaRepository` to scoped instance (Octane support)

### DIFF
--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -29,7 +29,7 @@ class MediaLibraryServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/media-library.php', 'media-library');
 
-        $this->app->singleton(MediaRepository::class, function () {
+        $this->app->scoped(MediaRepository::class, function () {
             $mediaClass = config('media-library.media_model');
 
             return new MediaRepository(new $mediaClass());


### PR DESCRIPTION
This makes sure that the `MediaRepository` instance (and thus the `Media` instance contained within) is cleared on every request & job.

In a multi-tenancy environment or when using Octane, it's always good to assume that the application's config might get changed (for different tenants) or gets contaminated (accidentally in the request flow). Making sure a new `MediaRepository` with a new `Media` model and a new DB connection is available is best practice