### PR TITLE
Added support for passing attributes to toHtml(), added attribution sanitization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "illuminate/database": "^9.0",
         "illuminate/pipeline": "^9.0",
         "illuminate/support": "^9.0",
+        "illuminate/view": "^9.0",
         "intervention/image": "^2.7",
         "maennchen/zipstream-php": "^2.0",
         "spatie/image": "^2.2.2",

--- a/src/MediaCollections/HtmlableMedia.php
+++ b/src/MediaCollections/HtmlableMedia.php
@@ -51,7 +51,8 @@ class HtmlableMedia implements Htmlable, \Stringable
         }
 
         $attributeString = collect($this->extraAttributes)
-            ->map(fn ($value, $name) => $name.'="'.$value.'"')->implode(' ');
+            ->map(fn ($value, $name) => $name.'="'. \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute($value) .'"')
+            ->implode(' ');
 
         if (strlen($attributeString)) {
             $attributeString = ' '.$attributeString;

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -391,9 +391,9 @@ class Media extends Model implements Responsable, Htmlable
         return $filesystem->getStream($this);
     }
 
-    public function toHtml()
+    public function toHtml($attributes = [])
     {
-        return $this->img()->toHtml();
+        return $this->img('', $attributes)->toHtml();
     }
 
     public function img(string $conversionName = '', $extraAttributes = []): HtmlableMedia


### PR DESCRIPTION
- Added support to pass attributes array to `Media.php` `toHtml()` method.
- Added sanitization of attributes to the same method

**Reference**: https://github.com/spatie/laravel-medialibrary-pro/discussions/423