### PR TITLE
Prevent error when extracting an image from a video

### DIFF
--- a/src/Conversions/ImageGenerators/Video.php
+++ b/src/Conversions/ImageGenerators/Video.php
@@ -22,7 +22,7 @@ class Video extends ImageGenerator
         $duration = $ffmpeg->getFFProbe()->format($file)->get('duration');
 
         $seconds = $conversion ? $conversion->getExtractVideoFrameAtSecond() : 0;
-        $seconds = $duration < $seconds ? 0 : $seconds;
+        $seconds = $duration <= $seconds ? 0 : $seconds;
 
         $frame = $video->frame(TimeCode::fromSeconds($seconds));
         $frame->save($imageFile);


### PR DESCRIPTION
Prevent error when the video is exactly as long (in seconds) as the timestamp set in extractVideoFrameAtSecond()