### PR TITLE
Added support to conditionally enable or disable queue on media conversion

### DIFF
--- a/docs/api/defining-conversions.md
+++ b/docs/api/defining-conversions.md
@@ -28,20 +28,20 @@ public function addMediaConversion(string $name): \Spatie\MediaLibrary\Conversio
  * @param string $collectionNames,...
  */
 public function performOnCollections($collectionNames): self
-``` 
+```
 
 ### queued
 
-```php 
+```php
 /*
  * Mark this conversion as one that should be queued.
  */
- public function queued(): self
+ public function queued(bool $performOnQueue = true): self
 ```
 
 ### nonQueued
 
-```php 
+```php
 /*
  * Mark this conversion as one that should not be queued.
  */
@@ -57,4 +57,3 @@ You can learn more on native lazy loading [in this post on css-tricks](https://c
 ## Image manipulations
 
 You may add any call to one of [the manipulation functions](https://docs.spatie.be/image) available on [the spatie/image package](https://github.com/spatie/image).
-

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -76,8 +76,8 @@ use Spatie\Image\Manipulations;
 
         $this->addMediaConversion('old-picture')
               ->sepia()
-              ->border(10, 'black', Manipulations::BORDER_OVERLAY);
-              
+              ->border(10, 'black', Manipulations::BORDER_OVERLAY;
+
         $this->addMediaConversion('thumb-cropped')
             ->crop('crop-center', 400, 400); // Trim or crop the image to the center for specified width and height.
     }
@@ -143,6 +143,19 @@ public function registerMediaConversions(Media $media = null): void
             ->width(368)
             ->height(232)
             ->queued();
+}
+```
+
+The `queued` method also accepts a value (true by default) to determine whether or not the conversion should be queued; You can override this behavior to optionally disable the queue for some scenarios. In this example, the conversion queue will only be applied if the app is running in the console:
+
+```php
+// in your model
+public function registerMediaConversions(Media $media = null): void
+{
+    $this->addMediaConversion('thumb')
+            ->width(368)
+            ->height(232)
+            ->queued(app()->runingInConsole());
 }
 ```
 

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -160,18 +160,9 @@ class Conversion
         return in_array($collectionName, $this->performOnCollections);
     }
 
-    public function queued(): self
+    public function queued(bool $performOnQueue = true): self
     {
-        $this->performOnQueue = true;
-
-        return $this;
-    }
-
-    public function queuedIf(bool $condition): self
-    {
-        if ($condition) {
-            $this->performOnQueue = true;
-        }
+        $this->performOnQueue = $performOnQueue;
 
         return $this;
     }
@@ -179,15 +170,6 @@ class Conversion
     public function nonQueued(): self
     {
         $this->performOnQueue = false;
-
-        return $this;
-    }
-
-    public function nonQueuedIf(bool $condition): self
-    {
-        if ($condition) {
-            $this->performOnQueue = false;
-        }
 
         return $this;
     }

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -64,19 +64,14 @@ it('can be set to queued', function () {
     expect($this->conversion->queued()->shouldBeQueued())->toBeTrue();
 });
 
-it('can be conditionally set to queued', function () {
-    config()->set('media-library.queue_conversions_by_default', false);
-    expect($this->conversion->queuedIf(true)->shouldBeQueued())->toBeTrue();
+it('can disable conversion queue', function () {
+    config()->set('media-library.queue_conversions_by_default', true);
+    expect($this->conversion->queued(false)->shouldBeQueued())->toBeFalse();
 });
 
 it('can be set to non queued', function () {
     config()->set('media-library.queue_conversions_by_default', true);
     expect($this->conversion->nonQueued()->shouldBeQueued())->toBeFalse();
-});
-
-it('can be conditionally set to non queued', function () {
-    config()->set('media-library.queue_conversions_by_default', true);
-    expect($this->conversion->nonQueuedIf(true)->shouldBeQueued())->toBeFalse();
 });
 
 it('can determine the extension of the result', function () {


### PR DESCRIPTION
This PR adds two new methods to the Conversion class to allow to enable or disable queued conversion execution based on a condition.

For example, in my case I have a model that can be used with from the web and from the artisan console. I want to be able to process the conversions from the web without queuing the conversion, to do so I must do something like this:

```
    public function registerMediaConversions(Media $media = null): void
    {
        if (app()->runningInConsole()) {
            $this->addMediaConversion('thumb')
                ->height(350);
        } else {
            $this->addMediaConversion('thumb')
                ->height(350)
                ->nonQueued();
        }
    }
```

It would be much cleaner if you could define if you want to queue or not with the same method.

```
    public function registerMediaConversions(Media $media = null): void
    {
        $this->addMediaConversion('thumb')
            ->height(350)
            ->nonQueuedIf(!app()->runningInConsole());
    }
```

In case the application is not running in the console, the condition will be true and the conversion will be done without using the queue.