### PR TITLE
Fix `media-library:clean` command when using custom path generators

### DIFF
--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -111,6 +111,7 @@ class CleanCommand extends Command
 
         collect($currentFilePaths)
             ->reject(fn (string $currentFilePath) => $conversionFilePaths->contains(basename($currentFilePath)))
+            ->reject(fn (string $currentFilePath) => $media->file_name === basename($currentFilePath))
             ->each(function (string $currentFilePath) use ($media) {
                 if (! $this->isDryRun) {
                     $this->fileSystem->disk($media->disk)->delete($currentFilePath);

--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -14,7 +14,7 @@ use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
-use Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator;
+use Spatie\MediaLibrary\Support\PathGenerator\PathGeneratorFactory;
 
 class CleanCommand extends Command
 {
@@ -34,8 +34,6 @@ class CleanCommand extends Command
 
     protected Factory $fileSystem;
 
-    protected DefaultPathGenerator $basePathGenerator;
-
     protected bool $isDryRun = false;
 
     protected int $rateLimit = 0;
@@ -44,12 +42,10 @@ class CleanCommand extends Command
         MediaRepository $mediaRepository,
         FileManipulator $fileManipulator,
         Factory $fileSystem,
-        DefaultPathGenerator $basePathGenerator
     ) {
         $this->mediaRepository = $mediaRepository;
         $this->fileManipulator = $fileManipulator;
         $this->fileSystem = $fileSystem;
-        $this->basePathGenerator = $basePathGenerator;
 
         if (! $this->confirmToProceed()) {
             return;
@@ -110,7 +106,7 @@ class CleanCommand extends Command
     {
         $conversionFilePaths = ConversionCollection::createForMedia($media)->getConversionsFiles($media->collection_name);
 
-        $conversionPath = $this->basePathGenerator->getPathForConversions($media);
+        $conversionPath = PathGeneratorFactory::create($media)->getPathForConversions($media);
         $currentFilePaths = $this->fileSystem->disk($media->disk)->files($conversionPath);
 
         collect($currentFilePaths)

--- a/tests/TestSupport/TestPathGenerators/TestPathGeneratorConversionsInOriginalImageDirectory.php
+++ b/tests/TestSupport/TestPathGenerators/TestPathGeneratorConversionsInOriginalImageDirectory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestPathGenerators;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator;
+use Spatie\MediaLibrary\Support\PathGenerator\PathGenerator;
+
+class TestPathGeneratorConversionsInOriginalImageDirectory extends DefaultPathGenerator implements PathGenerator
+{
+    public function getPathForConversions(Media $media): string
+    {
+        return $this->getPath($media);
+    }
+}


### PR DESCRIPTION
This PR fixes #2922 that I opened myself (this is a personal account, the account used to open the PR is my professional account).

Two modifications were done in this PR:

#### 1.

The path generator used by the `media-library:clean` command is now dynamically created in the `deleteConversionFilesForDeprecatedConversions` method for each processed media using the [PathGeneratorFactory](https://github.com/spatie/laravel-medialibrary/blob/main/src/Support/PathGenerator/PathGeneratorFactory.php).

This modification allows custom path generators configured via the `media-library.custom_path_generators` to actually be used by the command and not only the [DefaultPathGenerator](https://github.com/spatie/laravel-medialibrary/blob/main/src/Support/PathGenerator/DefaultPathGenerator.php) included in this package, and consequently for conversions saved in custom path to be properly deleted.

#### 2.

Following this change, another issue came to light where the original image would be deleted if the path for conversions is configured to be the same as the original image path.

A new check was added to the `deleteConversionFilesForDeprecatedConversions` method to ensure that the original image is not mistakenly considered as a deprecated conversion and deleted.

---

Side note: This is my first PR to open source project and I'm not really familiar with tests, so I hope the changes included in this PR are satisfying enough.