### PR TITLE
Added allowed image format types to config

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -226,4 +226,9 @@ return [
      * If you set this to `/my-subdir`, all your media will be stored in a `/my-subdir` directory.
      */
     'prefix' => env('MEDIA_PREFIX', ''),
+
+    /**
+     * Allow user to specify the default image conversion mime types.
+     */
+    'default_image_conversion_types' => ['jpg', 'jpeg', 'pjpg', 'png', 'gif', 'webp'],
 ];

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -230,5 +230,6 @@ return [
     /**
      * Allow user to specify the default image conversion mime types.
      */
-    'default_image_conversion_types' => ['jpg', 'jpeg', 'pjpg', 'png', 'gif', 'webp'],
+
+    'keep_image_formats' => ['jpg', 'jpeg', 'pjpg', 'png', 'gif', 'webp'],
 ];

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -201,7 +201,7 @@ class Conversion
     public function getResultExtension(string $originalFileExtension = ''): string
     {
         if ($this->shouldKeepOriginalImageFormat()) {
-            if (in_array(strtolower($originalFileExtension), config('default_image_conversion_types'))) {
+            if (in_array(strtolower($originalFileExtension), config('keep_image_formats'))) {
                 return $originalFileExtension;
             }
         }

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -201,7 +201,7 @@ class Conversion
     public function getResultExtension(string $originalFileExtension = ''): string
     {
         if ($this->shouldKeepOriginalImageFormat()) {
-            if (in_array(strtolower($originalFileExtension), ['jpg', 'jpeg', 'pjpg', 'png', 'gif', 'webp'])) {
+            if (in_array(strtolower($originalFileExtension), config('default_image_conversion_types'))) {
                 return $originalFileExtension;
             }
         }


### PR DESCRIPTION
Allows the user to specify the allowed image extensions in config if shouldKeepOriginalImageFormat is enabled