### PR TITLE
Update preparing-your-model.md

### DIFF
--- a/docs/basic-usage/preparing-your-model.md
+++ b/docs/basic-usage/preparing-your-model.md
@@ -11,6 +11,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class YourModel extends Model implements HasMedia
 {


### PR DESCRIPTION
When copy/pasting the example `registerMediaConversions()` method, an `App\Models\Media is not available` error is thrown. Adding `use Spatie\MediaLibrary\MediaCollections\Models\Media;` fixes this.