### PR TITLE
Update preparing-your-model.md

### DIFF
--- a/docs/basic-usage/preparing-your-model.md
+++ b/docs/basic-usage/preparing-your-model.md
@@ -23,6 +23,9 @@ The `Collection` component will show a preview thumbnail for items in the collec
 To generate that thumbnail, you must add a conversion like this one to your model.
 
 ```php
+use Spatie\Image\Manipulations;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
 public function registerMediaConversions(Media $media = null): void
 {
     $this


### PR DESCRIPTION
When implementing the `registerMediaConversions()` method, it is not clear that additional models need to be imported. Hopefully this PR makes it a little more clear for users with an IDE that does not automatically import the required models.