### PR TITLE
Upgrade example using JSON_EXTRACT

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,7 +41,7 @@ class AddGeneratedConversionsToMediaTable extends Migration {
             })
             ->whereRaw("JSON_LENGTH(custom_properties) > 0")
             ->update([
-                'generated_conversions' => DB::raw('custom_properties->"$.generated_conversions"'),
+                'generated_conversions' => DB::raw("JSON_EXTRACT(custom_properties, '$.generated_conversions')"),
                 // OPTIONAL: Remove the generated conversions from the custom_properties field as well:
                 // 'custom_properties'     => DB::raw("JSON_REMOVE(custom_properties, '$.generated_conversions')")
             ]);


### PR DESCRIPTION
Closes #2969
>Change
>'generated_conversions' => DB::raw('custom_properties->"$.generated_conversions")
To
'generated_conversions' => DB::raw('JSON_EXTRACT(custom_properties, "$.generated_conversions")')
>
>Think this could possibly be added to the docs as anyone using a MariaDb database will run into this issue.

[JSON_EXTRACT Tested on Mysql, MariaDB](https://paiza.io/projects/x6dxlM9iaITCzP6720halw)