### PR TITLE
Added down functionality for migration

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -29,4 +29,9 @@ return new class extends Migration
             $table->nullableTimestamps();
         });
     }
+    
+    public function down(): void
+    {
+        Schema::dropIfExists('media');
+    }
 };


### PR DESCRIPTION
Since the down function is not added, it does not drop the table in case of migrate:rollback. 

I encountered an issue as I was installing the media library and then also created a model too. Initially migrating it works without an issue. I wanted to make some changes on my model DB structure and tried to rollback and re migrate the tables. When I do so, It throws an error saying media table already exists.
 
By adding the `down` method we can provide a solution for this. (This is a rare scenario but it is worth adding to avoid this kind of issues.)