### PR TITLE
Order media relationship

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -57,7 +57,7 @@ trait InteractsWithMedia
 
     public function media(): MorphMany
     {
-        return $this->morphMany(config('media-library.media_model'), 'model');
+        return $this->morphMany(config('media-library.media_model'), 'model')->orderBy('order_column');
     }
 
     /**

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -11,6 +11,20 @@ it('can handle an empty collection', function () {
     expect($emptyCollection)->toHaveCount(0);
 });
 
+it('will return ordered media when accessing the relation', function () {
+    $media1 = $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->setOrder(2)->toMediaCollection();
+    $media2 = $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->setOrder(1)->toMediaCollection();
+    $media3 = $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->setOrder(4)->toMediaCollection();
+    $media4 = $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->setOrder(3)->toMediaCollection();
+
+    expect($this->testModel->media->modelKeys())->toBe([
+        $media2->getKey(),
+        $media1->getKey(),
+        $media4->getKey(),
+        $media3->getKey(),
+    ]);
+});
+
 it('will only get media from the specified collection', function () {
     expect($this->testModel->getMedia('images'))->toHaveCount(0);
     expect($this->testModel->getMedia('downloads'))->toHaveCount(0);

--- a/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/UpdateMediaTest.php
@@ -61,8 +61,8 @@ it('reorders media items', function () {
     $this->testModel->updateMedia($differentOrder);
     $this->testModel->load('media');
 
-    $orderedMedia = $this->testModel->media->sortBy('order_column');
+    $orderedMedia = $this->testModel->media;
 
-    expect($orderedMedia[1]->order_column)->toEqual($mediaArray[0]['order_column']);
-    expect($orderedMedia[0]->order_column)->toEqual($mediaArray[1]['order_column']);
+    expect($orderedMedia[1]['id'])->toEqual($mediaArray[0]['id']);
+    expect($orderedMedia[0]['id'])->toEqual($mediaArray[1]['id']);
 });


### PR DESCRIPTION
Any reason for not ordering the `media()` relationship by default?
Especially because the order does get applied in `loadMedia()`:

https://github.com/spatie/laravel-medialibrary/blob/19576a5fab5f173b7edcd8444e851b36203b6695/src/InteractsWithMedia.php#L529-L541