### PR TITLE
feat: add ability to replace original in conversion

### DIFF
--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -165,3 +165,24 @@ public function registerMediaConversions(Media $media = null): void
 ```
 
 Be aware that this can lead to a hit in performance. When processing media the media library has to perform queries to fetch each separate model.
+
+
+## Converting the original image
+
+If one of your collection will always have the same size or format, it is a good idea to run some conversions directly on the original image to preserve space on your server
+
+Luckily it is possible using `replaceOriginal()` on the conversion, just keep in mind you will lose the original image and only the optimized image will be stored
+
+```php
+// in your model
+public function registerMediaConversions(Media $media = null): void
+{
+    $this->addMediaConversion('original')
+          ->width(500)
+          ->height(500)
+          ->format('jpg')
+          ->quality(80)
+          ->replaceOriginal()
+          ->performOnCollections('images');
+}
+```

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -28,6 +28,8 @@ class Conversion
 
     protected int $pdfPageNumber = 1;
 
+    protected bool $replaceOriginal = false;
+
     public function __construct(
         protected string $name
     ) {
@@ -215,7 +217,8 @@ class Conversion
 
     public function getConversionFile(Media $media): string
     {
-        $fileName = $this->fileNamer->conversionFileName($media->file_name, $this);
+        $fileName = $this->shouldReplaceOriginal() ? pathinfo($media->file_name, PATHINFO_FILENAME) :
+            $this->fileNamer->conversionFileName($media->file_name, $this);
 
         $fileExtension = $this->fileNamer->extensionFromBaseImage($media->file_name);
         $extension = $this->getResultExtension($fileExtension) ?: $fileExtension;
@@ -245,5 +248,17 @@ class Conversion
     public function getPdfPageNumber(): int
     {
         return $this->pdfPageNumber;
+    }
+
+    public function replaceOriginal(bool $replace = true): self
+    {
+        $this->replaceOriginal = $replace;
+
+        return $this;
+    }
+
+    public function shouldReplaceOriginal(): bool
+    {
+        return $this->replaceOriginal;
     }
 }

--- a/tests/Conversions/ConversionReplaceOriginalTest.php
+++ b/tests/Conversions/ConversionReplaceOriginalTest.php
@@ -1,0 +1,29 @@
+<?php
+
+it('will generate the conversion and remove the old file if the file type differs', function () {
+    /** @var \Spatie\MediaLibrary\Tests\TestCase $this */
+    $this->testModelWithConversionReplacingOriginal->addMedia($this->getTestPng())->toMediaCollection('images');
+
+    expect($this->testModelWithConversionReplacingOriginal->getFirstMediaUrl("images"))->toEqual("/media/1/test.jpg");
+    expect($this->testModelWithConversionReplacingOriginal->getFirstMedia("images")->file_name)->toEqual("test.jpg");
+
+    $path = $this->testModelWithConversionReplacingOriginal->getFirstMediaPath("images");
+    $png = substr($path, 0, -3) . 'png';
+    expect($png)->toEndWith('.png');
+    expect(file_exists(substr($path, 0, -3) . 'png'))->toBeFalse();
+    expect(file_exists($path))->toBeTrue();
+});
+
+it('will replace the original file', function () {
+    /** @var \Spatie\MediaLibrary\Tests\TestCase $this */
+    $this->testModelWithConversionReplacingOriginal->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $media = $this->testModelWithConversionReplacingOriginal->getFirstMedia("images");
+
+    expect($media->getUrl())->toEqual("/media/1/test.jpg");
+    expect($media->file_name)->toEqual("test.jpg");
+    expect($media->hasGeneratedConversion("replace_original"))->toBeFalse();
+
+    [$width, $height] = getimagesize($media->getPath());
+    expect($width)->toEqual(200);
+    expect($height)->toEqual(165); // Because ratio is preserved
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,7 @@ use Spatie\MediaLibrary\Support\MediaLibraryPro;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionQueued;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionReplacingOriginal;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionsOnOtherDisk;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMorphMap;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMultipleConversions;
@@ -29,7 +30,7 @@ abstract class TestCase extends Orchestra
 
     protected TestModelWithConversion $testModelWithConversion;
 
-    protected TestModelWithMultipleConversion $testModelWithMultipleConversion;
+    protected TestModelWithMultipleConversions $testModelWithMultipleConversions;
 
     protected TestModelWithPreviewConversion $testModelWithPreviewConversion;
 
@@ -42,6 +43,8 @@ abstract class TestCase extends Orchestra
     protected TestModelWithResponsiveImages $testModelWithResponsiveImages;
 
     protected TestModelWithConversionsOnOtherDisk $testModelWithConversionsOnOtherDisk;
+
+    protected TestModelWithConversionReplacingOriginal $testModelWithConversionReplacingOriginal;
 
     protected function setUp(): void
     {
@@ -63,6 +66,7 @@ abstract class TestCase extends Orchestra
         $this->testModelWithMorphMap = TestModelWithMorphMap::first();
         $this->testModelWithResponsiveImages = TestModelWithResponsiveImages::first();
         $this->testModelWithConversionsOnOtherDisk = TestModelWithConversionsOnOtherDisk::first();
+        $this->testModelWithConversionReplacingOriginal = TestModelWithConversionReplacingOriginal::first();
     }
 
     protected function loadEnvironmentVariables()

--- a/tests/TestSupport/TestModels/TestModelWithConversionReplacingOriginal.php
+++ b/tests/TestSupport/TestModels/TestModelWithConversionReplacingOriginal.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class TestModelWithConversionReplacingOriginal extends TestModel
+{
+    public function registerMediaConversions(Media $media = null): void
+    {
+        $this->addMediaConversion('replace_original')
+            ->format('jpg')
+            ->width(200)
+            ->height(200)
+            ->replaceOriginal();
+    }
+}


### PR DESCRIPTION
This is a simple feature to allow conversions to be performed on the original image

Fixes #1526 