### PR TITLE
Update README.md to reference pest

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you've found a bug regarding security please mail [security@spatie.be](mailto
 You can run the tests with:
 
 ```bash
-vendor/bin/phpunit
+./vendor/bin/pest
 ```
 
 ## Upgrading


### PR DESCRIPTION
Minor, but useful.
```
Fatal error: Uncaught Pest\Exceptions\InvalidPestCommand: Please run `./vendor/bin/pest` instead of `/vendor/bin/phpunit`. in /Users/michaellindahl/Projects/laravel-medialibrary/vendor/pestphp/pest/src/TestSuite.php:114
```