### PR TITLE
Add compatibility for `migrate:rollback`

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -29,4 +29,9 @@ return new class extends Migration
             $table->nullableTimestamps();
         });
     }
+    
+    public function down(): void
+    {
+        Schema::dropIfExists('media');
+    }
 };


### PR DESCRIPTION
When publishing the migrations. In the event someone wants to rollback, this change will prevent an error from occurring if someone rollsback and then re-migrates