### PR TITLE
Change the create method to use 'static'

### DIFF
--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -17,7 +17,7 @@ class MediaStream implements Responsable
 
     public static function create(string $zipName): self
     {
-        return new self($zipName);
+        return new static($zipName);
     }
 
     public function __construct(protected string $zipName)


### PR DESCRIPTION
It is better to use the `static` keyword instead of `self` in order to let the methods of this class beeing override when the class is extended 
see discussion here #3020