### PR TITLE
Allow the Github actions to run locally via act

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,10 +22,10 @@ jobs:
               run: sudo apt-get update --fix-missing
 
             - name: Install ffmpeg
-              run: sudo apt-get install ffmpeg
+              run: sudo apt-get -y install ffmpeg
 
             - name: Install ghostscript
-              run: sudo apt-get install ghostscript
+              run: sudo apt-get -y install ghostscript
 
             - name: Checkout code
               uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ You can run the tests with:
 ./vendor/bin/pest
 ```
 
+You can run the Github actions locally with [act](https://github.com/nektos/act). You have to use a [custom image](https://github.com/shivammathur/setup-php#local-testing-setup) for the ubuntu-latest platform to get PHP up and running properly. To run the tests locally, run:
+
+```bash
+act -P ubuntu-latest=shivammathur/node:latest
+```
+
+To run a specific workflow, for example `run-tests.yml` run:
+
+```bash
+act -P ubuntu-latest=shivammathur/node:latest -j run-tests
+```
+
 ## Upgrading
 
 Please see [UPGRADING](UPGRADING.md) for details.


### PR DESCRIPTION
1. Invoke `apt-get` with `-y` because `apt-get` would wait for input when running the actions locally.
2. Add some docs about act.