### PR TITLE
Update FileAdder.php

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -396,6 +396,7 @@ class FileAdder
 
     public function defaultSanitizer(string $fileName): string
     {
+        $fileName = preg_replace('#\p{C}+#u', '', $fileName);
         return str_replace(['#', '/', '\\', ' '], '-', $fileName);
     }
 


### PR DESCRIPTION
Update the default filename sanitizer to handle funky whitespace characters in files - I had a case where a file was being uploaded, and it kepts throwing Flysystems `CorruptedPathDetected` exception. Not sure if copy-pasting the filename to github keeps the characters there: `Scan-‎9‎.‎14‎.‎2022-‎7‎.‎23‎.‎28.pdf`

![Screenshot 2022-09-14 at 08 57 37](https://user-images.githubusercontent.com/1391027/190083324-7387392d-b7de-4397-a1fe-735aaf86630c.png)
