### PR TITLE
Add media-library:transform-path command to migrate to a new path generator

### DIFF
--- a/docs/advanced-usage/migrating-between-directory-structures.md
+++ b/docs/advanced-usage/migrating-between-directory-structures.md
@@ -1,0 +1,46 @@
+---
+title: Migrating between custom directory structures
+weight: 5
+---
+
+If you wish to adopt or change your custom directory structure but already have `Media` objects created, 
+it is necessary not only to update the `path_generator` config setting, but also to move the 
+existing media files (and potentially any associated conversions) to match the new folder structure.
+
+Begin by [creating a custom path generator to meet your requirements](using-a-custom-directory-structure.md), but
+do not activate it in your configuration until you are ready to migrate the existing data. 
+Once your path generator has been written, the Artisan `media-library:transform-path` command can be used to help 
+automate the process of moving existing media to match the new naming scheme.
+
+```
+Usage:
+  media-library:transform-path [options] [--] <sourceGeneratorClass> <targetGeneratorClass> [<modelType> [<collectionName>]]
+
+Arguments:
+  sourceGeneratorClass                Name of the PathGenerator class used to for existing media
+  targetGeneratorClass                Name of the PathGenerator class to generate new paths for media
+  modelType                           Name of the model to include in processing
+  collectionName                      Name of the collection to include in processing
+
+Options:
+      --dry-run                       List files that will be moved (without moving them)
+      --force                         Force the operation to run when in production
+      --rate-limit[=RATE-LIMIT]       Limit the number of items processed per second
+      --ignore-missing-source-files   Do not consider missing source files to be an error
+      --ignore-existing-target-files  Allow moving/overwriting existing target files
+  -v|vv|vvv, --verbose                Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+```
+
+
+If migrating from the library default, use `"Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator"`  
+for the `sourceGeneratorClass` parameter.
+
+If `-v` (verbose mode) is turned on, a line will be printed to the console showing the source and target path name for
+each file that is moved. If `-vv` (very verbose mode) is turned on, a more detailed report of the planned changes will 
+also be presented. This can be useful in combination with `--dry-run` to ensure that the results are as you expect them 
+to be.
+
+**NOTE**: This will not necessarily clean up your source disk, which may be left with empty 
+directories. Consider running a command such as `find $BASE_DIR -type d -empty -delete` (where `BASE_DIR` 
+represents the root of your media storage, e.g. `/var/www/html/storage/app/media`).  (Consider 
+using `find $BASE_DIR -type d -empty -print` to verify the impacted directories first!)

--- a/src/MediaCollections/Commands/TransformPathCommand.php
+++ b/src/MediaCollections/Commands/TransformPathCommand.php
@@ -1,0 +1,392 @@
+<?php
+
+namespace Spatie\MediaLibrary\MediaCollections\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Contracts\Filesystem\Factory;
+use Illuminate\Database\Eloquent\Collection as DbCollection;
+use Illuminate\Support\Collection;
+use Spatie\MediaLibrary\Conversions\ConversionCollection;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\MediaCollections\MediaRepository;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Support\PathGenerator\PathGenerator;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TransformPathCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /*
+     * Artisan configuration
+     */
+    protected $signature = 'media-library:transform-path
+    {sourceGeneratorClass : Name of the PathGenerator class used to for existing media},
+    {targetGeneratorClass : Name of the PathGenerator class to generate new paths for media},
+    {modelType? : Name of the model to include in processing},
+    {collectionName? : Name of the collection to include in processing},
+    {--dry-run : List files that will be moved (without moving them)},
+    {--force : Force the operation to run when in production},
+    {--rate-limit= : Limit the number of items processed per second},
+    {--ignore-missing-source-files : Do not consider missing source files to be an error},
+    {--ignore-existing-target-files : Allow moving/overwriting existing target files}';
+
+    protected $description = 'Moves media stored based on the "sourceGeneratorClass" path generator to comply with the path scheme provided by "targetGeneratorClass" .';
+
+    /*
+     * Options
+     */
+    protected ?PathGenerator $sourceGenerator = null;
+    protected ?PathGenerator $targetGenerator = null;
+    protected ?string $modelType = null;
+    protected ?string $collectionName = null;
+    protected bool $isDryRun = false;
+    protected bool $ignoreMissingSourceFiles = false;
+    protected bool $ignoreExistingTargetFiles = false;
+    protected int $rateLimit = 0;
+
+    /*
+     * Dependencies
+     */
+    protected MediaRepository $mediaRepository;
+    protected Factory $fileSystem;
+
+    /**
+     * @return int 0 on success, 1 on error
+     */
+    public function handle(
+        MediaRepository $mediaRepository,
+        Factory $fileSystem,
+    ): int
+    {
+        $this->mediaRepository = $mediaRepository;
+        $this->fileSystem = $fileSystem;
+
+        if (! $this->handleArguments() || ! $this->confirmToProceed()) {
+            return 1;
+        }
+
+        $mediaItems = $this->getMediaItems();
+        $itemsToProcess = $this->scan($mediaItems);
+        if (! $this->validate($itemsToProcess)) {
+            return 1;
+        }
+
+        $hadErrors = false;
+        foreach($itemsToProcess as $file) {
+            if (!$this->processMediaFile($file))
+                $hadErrors = true;
+        }
+
+        if ($hadErrors) {
+            $this->info('Path transformation complete');
+        } else {
+            $this->warn('Path transformation completed with errors; see above');
+        }
+
+        return (int)$hadErrors;
+    }
+
+    /**
+     * Generates an identifier string that provides information on the Media object,
+     * its associated model, and the disks storing the media/conversion. This information
+     * appears in error/warning messages for troubleshooting purposes.
+     *
+     * @param Media $media
+     * @return string
+     */
+    protected function generateMediaIdentifier(Media $media): string
+    {
+        return "#$media->id ({$media->model->name} #{$media->getKey()} $media->disk/$media->conversions_disk)";
+    }
+
+    /**
+     * Validate command line options/arguments
+     *
+     * @return bool FALSE if an error/invalid command line argument was detected, TRUE otherwise
+     */
+    protected function handleArguments(): bool
+    {
+        if (! $this->guardAgainstInvalidGeneratorClasses(
+            $this->argument('sourceGeneratorClass'),
+            $this->argument('targetGeneratorClass')
+        )) {
+            return false;
+        }
+        $this->sourceGenerator = app($this->argument('sourceGeneratorClass'));
+        $this->targetGenerator = app($this->argument('targetGeneratorClass'));
+
+        $this->isDryRun = $this->option('dry-run');
+        $this->ignoreMissingSourceFiles = $this->option('ignore-missing-source-files');
+        $this->ignoreExistingTargetFiles = $this->option('ignore-existing-target-files');
+        $this->rateLimit = (int) $this->option('rate-limit');
+
+        $this->modelType = $this->argument('modelType');
+        if (! $this->guardAgainstInvalidModelType()) {
+            return false;
+        }
+
+        $this->collectionName = $this->argument('collectionName');
+
+        return true;
+    }
+
+    protected function guardAgainstInvalidGeneratorClasses(
+        string $sourceGeneratorClass,
+        string $targetGeneratorClass):
+    bool
+    {
+        foreach([
+            'Source' => $sourceGeneratorClass,
+            'Target' => $targetGeneratorClass,
+        ] as $type => $className) {
+            if (! class_exists($className)) {
+                $this->error("$type generator class '$className' not found");
+                return false;
+            }
+
+            if (! is_subclass_of($className, PathGenerator::class)) {
+                $this->error("$type generator class '$className' does not implement the PathGenerator interface");
+                return false;
+            }
+        }
+
+        if ($sourceGeneratorClass === $targetGeneratorClass) {
+            $this->error("Source and target generator classes cannot be of the same type");
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function guardAgainstInvalidModelType(): bool
+    {
+        if (! $this->modelType) {
+            return true;
+        }
+
+        if (! class_exists($this->modelType)) {
+            $this->error("Model '$this->modelType' does not exist");
+            return false;
+        }
+
+        if (! is_subclass_of($this->modelType, HasMedia::class)) {
+            $this->error("Model '$this->modelType' does not implement the HasMedia interface");
+            return false;
+        }
+
+        return true;
+    }
+
+    /** @return DbCollection<int, Media> */
+    protected function getMediaItems(): DbCollection
+    {
+        if (is_string($this->modelType) && is_string($this->collectionName)) {
+            return $this->mediaRepository->getByModelTypeAndCollectionName(
+                $this->modelType,
+                $this->collectionName
+            );
+        }
+
+        if (is_string($this->modelType)) {
+            return $this->mediaRepository->getByModelType($this->modelType);
+        }
+
+        if (is_string($this->collectionName)) {
+            return $this->mediaRepository->getByCollectionName($this->collectionName);
+        }
+
+        return $this->mediaRepository->all();
+    }
+
+    /**
+     *
+     * @return Collection
+     * @var DbCollection<int, Media> $items
+     */
+    protected function scan(DbCollection $items): Collection
+    {
+        return $items->map(function(Media $media) {
+            return [
+                'id' => $this->generateMediaIdentifier($media),
+                'media' => $media,
+                'status' => $this->checkFileStatus($media)
+            ];
+        });
+    }
+
+    protected function checkFileStatus(Media $media): array
+    {
+        $conversionCollection = ConversionCollection::createForMedia($media);
+        $conversions = array_merge([NULL], $media->getMediaConversionNames());
+
+        $mediaDisk = $this->fileSystem->disk($media->disk);
+        $sourcePath = $this->sourceGenerator->getPath($media);
+        $targetPath = $this->targetGenerator->getPath($media);
+
+        $conversionsDisk = $this->fileSystem->disk($media->conversions_disk);
+        $sourceConversionsPath = $this->sourceGenerator->getPathForConversions($media);
+        $targetConversionsPath = $this->targetGenerator->getPathForConversions($media);
+
+        $results = [];
+
+        foreach($conversions as $conversionName) {
+            if (!$conversionName) {
+                $sourcePathAndFilename = $sourcePath . basename($media->getPath());
+                $targetPathAndFilename = $targetPath . basename($media->getPath());
+                $disk = $mediaDisk;
+            } else {
+                $conversionFile = $conversionCollection
+                    ->getByName($conversionName)
+                    ->getConversionFile($media);
+                $sourcePathAndFilename = $sourceConversionsPath . $conversionFile;
+                $targetPathAndFilename = $targetConversionsPath . $conversionFile;
+                $disk = $conversionsDisk;
+            }
+
+            $results[] = [
+                'name' => $conversionName,
+                'source' => $sourcePathAndFilename,
+                'source_exists' => $disk->exists($sourcePathAndFilename),
+                'target' => $targetPathAndFilename,
+                'target_exists' => $disk->exists($targetPathAndFilename)
+            ];
+        }
+
+        return $results;
+    }
+
+    /**
+     * Unless these checks are disabled, ensure that there are no files that match the
+     * source path generator that are missing, and that there are no pre-existing files that
+     * match the target generator that are already present. Files which have already been moved
+     * (i.e. that exist under the target generator but not under the source) are not considered
+     * to be a problem.
+     *
+     * @param Collection<int,array> $items
+     * @return bool
+     */
+    protected function validate(Collection $items): bool
+    {
+        $foundProblems = false;
+
+        foreach ($items as $item) {
+            $identifier = $item['id'];
+
+            if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERY_VERBOSE) {
+                $this->showStatusReport($item);
+            }
+
+            foreach($item['status'] as $status) {
+                // Check if the source file is missing, and the matching destination file does not
+                // already exist (in case we are resuming an interrupted move operation).  For
+                // conversions, a missing source file is not considered an error but it will
+                // be flagged as a warning.
+                if (! $this->ignoreMissingSourceFiles && (! $status['source_exists'] && ! $status['target_exists'])) {
+                    if (!$status['name']) {
+                        $this->error("$identifier: Source media is missing (${status['source']})");
+                        $foundProblems = true;
+                    } else {
+                        $this->warn("$identifier: Source media for conversion '${status['name']}' is missing (${status['source']})");
+                    }
+                }
+
+                // Warn if the destination file already exists, unless the source file is missing
+                // (in case we are resuming an interrupted move operation).
+                if (! $this->ignoreExistingTargetFiles && ($status['target_exists'] && $status['source_exists'])) {
+                    if (!$status['name']) {
+                        $this->error("$identifier: Target media already exists (${status['target']})");
+                    } else {
+                        $this->error("$identifier: Target conversion '${status['name']}' already exists (${status['target']})");
+                    }
+
+                    $foundProblems = true;
+                }
+            }
+        }
+
+        return ! $foundProblems;
+    }
+
+    protected function showStatusReport(array $item): void
+    {
+        $this->newLine(1);
+        $this->info($item['id']);
+
+        foreach($item['status'] as $status) {
+            $this->info("  " . ($status['name'] ?? 'Primary Media') . ":");
+            $this->info("    Source: ${status['source']} (exists: " . ($status['source_exists'] ? "yes" : "no") . ")");
+            $this->info("    Target: ${status['target']} (exists: " . ($status['target_exists'] ? "yes" : "no") . ")");
+            if (!$status['source_exists'] && $status['target_exists']) {
+                $this->info("    Status: Already moved");
+            } else if ($status['source_exists'] && !$status['target_exists']) {
+                $this->info("    Status: To be moved");
+            } else if (!$status['source_exists'] && !$status['target_exists']) {
+                $this->info("    Status: Source missing");
+            } else if ($status['source_exists'] && $status['target_exists']) {
+                $this->info("    Status: Target to be replaced");
+            }
+        }
+
+        $this->newLine(1);
+    }
+
+
+
+    protected function processMediaFile(array $itemData): bool
+    {
+        $identifier = $itemData['id'];
+        $media = $itemData['media'];
+
+        foreach($itemData['status'] as $item) {
+            $this->rateLimiter();
+
+            $isConversion = !!$item['name'];
+            $diskName = $isConversion ? $media->conversions_disk : $media->disk;
+            $disk = $this->fileSystem->disk($diskName);
+
+            $sourcePath = $item['source'];
+            $targetPath = $item['target'];
+
+            if (! $disk->exists($sourcePath)) {
+                if ($this->ignoreMissingSourceFiles) {
+                    // If source file does not exist, we cannot move it; consider this a success
+                    return true;
+                } else {
+                    $this->error($identifier . ": Source file missing ($sourcePath) on disk $diskName");
+                    return false;
+                }
+            }
+
+            if ($disk->exists($targetPath)) {
+                if (! $this->ignoreExistingTargetFiles) {
+                    $this->error($identifier . ": Target file already exists ($targetPath) on disk $diskName");
+                    return false;
+                }
+
+                $disk->delete($targetPath);
+            }
+
+            if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+                $this->info($identifier . ": $sourcePath -> $targetPath ($diskName)");
+            }
+
+            if (! $this->isDryRun) {
+                if (! $disk->move($sourcePath, $targetPath)) {
+                    $this->error($identifier . ": Failed to move '$sourcePath' to '$targetPath' on disk $diskName");
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    protected function rateLimiter()
+    {
+        if ($this->rateLimit) {
+            usleep((1 / $this->rateLimit) * 1_000_000 * 2);
+        }
+    }
+}

--- a/src/MediaCollections/Commands/TransformPathCommand.php
+++ b/src/MediaCollections/Commands/TransformPathCommand.php
@@ -245,6 +245,11 @@ class TransformPathCommand extends Command
                 $disk = $conversionsDisk;
             }
 
+            // If source and target path are the same, we do not need to move
+            // and we can skip this
+            if ($sourcePathAndFilename === $targetPathAndFilename)
+                continue;
+
             $results[] = [
                 'name' => $conversionName,
                 'source' => $sourcePathAndFilename,

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary;
 use Illuminate\Support\ServiceProvider;
 use Spatie\MediaLibrary\Conversions\Commands\RegenerateCommand;
 use Spatie\MediaLibrary\MediaCollections\Commands\CleanCommand;
+use Spatie\MediaLibrary\MediaCollections\Commands\TransformPathCommand;
 use Spatie\MediaLibrary\MediaCollections\Commands\ClearCommand;
 use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
@@ -64,11 +65,13 @@ class MediaLibraryServiceProvider extends ServiceProvider
         $this->app->bind('command.media-library:regenerate', RegenerateCommand::class);
         $this->app->bind('command.media-library:clear', ClearCommand::class);
         $this->app->bind('command.media-library:clean', CleanCommand::class);
+        $this->app->bind('command.media-library:transform-path', TransformPathCommand::class);
 
         $this->commands([
             'command.media-library:regenerate',
             'command.media-library:clear',
             'command.media-library:clean',
+            'command.media-library:transform-path',
         ]);
     }
 }

--- a/tests/MediaCollections/TransformPathCommandTest.php
+++ b/tests/MediaCollections/TransformPathCommandTest.php
@@ -1,0 +1,333 @@
+<?php
+
+use Illuminate\Support\Arr;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Tests\TestSupport\TestPathGenerator;
+use Spatie\MediaLibrary\Tests\TestSupport\TestUuidPathGenerator;
+
+function getSourceExpectedPath(Media $media, ?string $conversionName = NULL): string
+{
+    return $media->model->id
+        . '/' . md5($media->id)
+        . ($conversionName
+            ? '/custom_conversions/test-' . $conversionName . '.jpg'
+            : '/test.jpg');
+}
+
+function getTargetExpectedPath(Media $media, ?string $conversionName = NULL): string
+{
+    return $media->uuid
+        . ($conversionName
+            ? '/custom_conversions/test-' . $conversionName . '.jpg'
+            : '/test.jpg');
+}
+
+beforeEach(function () {
+    config([
+        'media-library.path_generator' => TestPathGenerator::class,
+    ]);
+
+    $this->media['model1']['collection1'] = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection1');
+
+    $this->media['model1']['collection2'] = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection2');
+
+    $this->media['model2']['collection1'] = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection1');
+
+    $this->media['model2']['collection2'] = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection2');
+
+    /**
+     * @var Media $mediaItem
+     */
+    foreach (Arr::flatten($this->media) as $mediaItem) {
+        config([
+            'media-library.path_generator' => TestPathGenerator::class,
+        ]);
+
+        expect($this->getMediaDirectory(getSourceExpectedPath($mediaItem)))->toBeFile();
+
+        foreach($mediaItem->getGeneratedConversions() as $conversionName => $conversionPresent) {
+            $oldExpectedConversionPath = $mediaItem->model->id . '/' . md5($mediaItem->id) . '/custom_conversions/test-' . $conversionName . '.jpg';
+            expect($this->getMediaDirectory($oldExpectedConversionPath))->toBeFile();
+        }
+    }
+});
+
+
+it('can transform file paths', function () {
+    $media = $this->media['model1']['collection1'];
+    Media::where('id', '<>', $media->id)->delete();
+
+    $this->artisan('media-library:transform-path', [
+        'sourceGeneratorClass' => TestPathGenerator::class,
+        'targetGeneratorClass' => TestUuidPathGenerator::class,
+    ]);
+
+    // Ensure files are gone from 'old' location
+    expect($this->getMediaDirectory(getSourceExpectedPath($media)))
+        ->not()
+        ->toBeFile();
+
+    // Ensure files have arrived at the 'new' location
+    expect($this->getMediaDirectory(getTargetExpectedPath($media)))
+        ->toBeFile();
+});
+
+it('can transform file paths including conversions', function () {
+    $media = $this->media['model2']['collection1'];
+    Media::where('id', '<>', $media->id)->delete();
+
+    $this->artisan('media-library:transform-path', [
+        'sourceGeneratorClass' => TestPathGenerator::class,
+        'targetGeneratorClass' => TestUuidPathGenerator::class,
+    ]);
+
+    // Ensure files are gone from 'old' location
+    expect($this->getMediaDirectory(getSourceExpectedPath($media)))
+        ->not()
+        ->toBeFile();
+
+    foreach($media->getMediaConversionNames() as $conversionName) {
+        expect($this->getMediaDirectory(getSourceExpectedPath($media, $conversionName)))
+            ->not()
+            ->toBeFile();
+    }
+
+    // Ensure files have arrived at the 'new' location
+    expect($this->getMediaDirectory(getTargetExpectedPath($media)))
+        ->toBeFile();
+
+    foreach($media->getMediaConversionNames() as $conversionName) {
+        expect($this->getMediaDirectory(getTargetExpectedPath($media, $conversionName)))
+            ->toBeFile();
+    }
+});
+
+it('can transform file paths from a specific model type', function () {
+    $this->artisan('media-library:transform-path', [
+        'sourceGeneratorClass' => TestPathGenerator::class,
+        'targetGeneratorClass' => TestUuidPathGenerator::class,
+        'modelType' => 'Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel',
+    ]);
+
+    // Ensure files are gone from 'old' location for model1
+    foreach(Arr::flatten($this->media['model1']) as $media) {
+        expect($this->getMediaDirectory(getSourceExpectedPath($media)))
+            ->not()
+            ->toBeFile();
+    }
+
+    // Ensure files are still in place from 'old' location for model2, including
+    // the conversions
+    foreach(Arr::flatten($this->media['model2']) as $media) {
+        expect($this->getMediaDirectory(getSourceExpectedPath($media)))
+            ->toBeFile();
+
+        foreach($media->getMediaConversionNames() as $conversionName) {
+            expect($this->getMediaDirectory(getSourceExpectedPath($media, $conversionName)))
+                ->toBeFile();
+        }
+    }
+
+    // Ensure files have arrived in new location for model1
+    foreach(Arr::flatten($this->media['model1']) as $media) {
+        expect($this->getMediaDirectory(getTargetExpectedPath($media)))
+            ->toBeFile();
+    }
+});
+
+it('can transform file paths from a specific collection', function () {
+    $this->artisan('media-library:transform-path', [
+        'sourceGeneratorClass' => TestPathGenerator::class,
+        'targetGeneratorClass' => TestUuidPathGenerator::class,
+        'collectionName' => 'collection2',
+    ]);
+
+    // Ensure files are gone from 'old' location for collection2, including
+    // any conversions
+    foreach(Arr::pluck($this->media, 'collection2') as $media) {
+        expect($this->getMediaDirectory(getSourceExpectedPath($media)))
+            ->not()
+            ->toBeFile();
+
+        foreach($media->getMediaConversionNames() as $conversionName) {
+            expect($this->getMediaDirectory(getSourceExpectedPath($media, $conversionName)))
+                ->not()
+                ->toBeFile();
+        }
+    }
+
+    // Ensure files are still in place from 'old' location for collection1, including
+    // the conversions
+    foreach(Arr::pluck($this->media, 'collection1') as $media) {
+        expect($this->getMediaDirectory(getSourceExpectedPath($media)))
+            ->toBeFile();
+
+        foreach($media->getMediaConversionNames() as $conversionName) {
+            expect($this->getMediaDirectory(getSourceExpectedPath($media, $conversionName)))
+                ->toBeFile();
+        }
+    }
+
+    // Ensure files have arrived in new location for collection2, including any
+    // conversions
+    foreach(Arr::pluck($this->media, 'collection2') as $media) {
+        expect($this->getMediaDirectory(getTargetExpectedPath($media)))
+            ->toBeFile();
+
+        foreach($media->getMediaConversionNames() as $conversionName) {
+            expect($this->getMediaDirectory(getTargetExpectedPath($media, $conversionName)))
+                ->toBeFile();
+        }
+    }
+});
+
+it('can transform file paths from a specific model type and collection', function () {
+    $moved = $this->media['model2']['collection2'];
+    $notMoving = Arr::except(Arr::dot($this->media), 'model2.collection2');
+
+    $this->artisan('media-library:transform-path', [
+        'sourceGeneratorClass' => TestPathGenerator::class,
+        'targetGeneratorClass' => TestUuidPathGenerator::class,
+        'modelType' => 'Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion',
+        'collectionName' => 'collection2',
+    ]);
+
+    // Ensure files are still in place for all the models that ought not to have
+    // moved, including any conversions.  (Everything except model2/collection2)
+    foreach($notMoving as $media) {
+        expect($this->getMediaDirectory(getSourceExpectedPath($media)))
+            ->toBeFile();
+
+        foreach($media->getMediaConversionNames() as $conversionName) {
+            expect($this->getMediaDirectory(getSourceExpectedPath($media, $conversionName)))
+                ->toBeFile();
+        }
+    }
+
+    // Ensure model2/collection1 moved
+    expect($this->getMediaDirectory(getTargetExpectedPath($moved)))
+        ->toBeFile();
+
+    foreach($moved->getMediaConversionNames() as $conversionName) {
+        expect($this->getMediaDirectory(getTargetExpectedPath($moved, $conversionName)))
+            ->toBeFile();
+    }
+});
+
+it('can transform paths where conversions are on another disk', function() {
+    $media = $this->testModelWithConversionsOnOtherDisk
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('thumb');
+
+    // Ensure files are in place from new model addition above
+    expect($this->getMediaDirectory(getSourceExpectedPath($media)))
+        ->toBeFile();
+
+    foreach($media->getMediaConversionNames() as $conversionName) {
+        expect($this->getTempDirectory() . '/media2/' . getSourceExpectedPath($media, $conversionName))
+            ->toBeFile();
+    }
+
+    $this->artisan('media-library:transform-path', [
+        'sourceGeneratorClass' => TestPathGenerator::class,
+        'targetGeneratorClass' => TestUuidPathGenerator::class,
+        'modelType' => 'Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionsOnOtherDisk',
+    ]);
+
+    // Ensure files have disappeared from old location
+    expect($this->getMediaDirectory(getSourceExpectedPath($media)))
+        ->not()
+        ->toBeFile();
+
+    foreach($media->getMediaConversionNames() as $conversionName) {
+        expect($this->getTempDirectory() . '/media2/' . getSourceExpectedPath($media, $conversionName))
+            ->not()
+            ->toBeFile();
+    }
+
+    // Ensure files are in new location
+    expect($this->getMediaDirectory(getTargetExpectedPath($media)))
+        ->toBeFile();
+
+    foreach($media->getMediaConversionNames() as $conversionName) {
+        expect($this->getTempDirectory() . '/media2/' . getTargetExpectedPath($media, $conversionName))
+            ->toBeFile();
+    }
+});
+
+it('will error if source files are missing', function() {
+    $media = $this->media['model1']['collection1'];
+    Media::where('id', '<>', $media->id)->delete();
+
+    unlink($this->getMediaDirectory(getSourceExpectedPath($media)));
+
+    $this->artisan('media-library:transform-path', [
+            'sourceGeneratorClass' => TestPathGenerator::class,
+            'targetGeneratorClass' => TestUuidPathGenerator::class,
+        ])
+        ->assertExitCode(1)
+        ->expectsOutput('#1 (test #1 public/public): Source media is missing (1/c4ca4238a0b923820dcc509a6f75849b/test.jpg)');
+
+});
+
+it('will not error if source files are missing but check is disabled', function() {
+    $media = $this->media['model1']['collection1'];
+    Media::where('id', '<>', $media->id)->delete();
+
+    unlink($this->getMediaDirectory(getSourceExpectedPath($media)));
+
+    $this->artisan('media-library:transform-path', [
+        'sourceGeneratorClass' => TestPathGenerator::class,
+        'targetGeneratorClass' => TestUuidPathGenerator::class,
+        '--ignore-missing-source-files' => true
+    ])->assertExitCode(0);
+});
+
+it('will error if target files already exist', function() {
+    $media = $this->media['model1']['collection1'];
+    Media::where('id', '<>', $media->id)->delete();
+
+    mkdir($this->getMediaDirectory() . '/' . $media->uuid);
+    touch($this->getMediaDirectory(getTargetExpectedPath($media)));
+
+    $this->artisan('media-library:transform-path', [
+        'sourceGeneratorClass' => TestPathGenerator::class,
+        'targetGeneratorClass' => TestUuidPathGenerator::class,
+    ])
+        ->assertExitCode(1)
+        ->expectsOutput('#1 (test #1 public/public): Target media already exists (' . $media->uuid . '/test.jpg)');
+});
+
+it('will not error if target files already exist but check has been disabled', function() {
+    $media = $this->media['model1']['collection1'];
+    Media::where('id', '<>', $media->id)->delete();
+
+    mkdir($this->getMediaDirectory() . '/' . $media->uuid);
+    touch($this->getMediaDirectory(getTargetExpectedPath($media)));
+
+    $this->artisan('media-library:transform-path', [
+        'sourceGeneratorClass' => TestPathGenerator::class,
+        'targetGeneratorClass' => TestUuidPathGenerator::class,
+        '--ignore-existing-target-files' => true,
+    ])->assertExitCode(0);
+
+    // Touched (0 length) file should now be replaced with real image
+    $testJpgFileSize = filesize($this->getTestFilesDirectory('test.jpg'));
+    expect($this->getMediaDirectory(getTargetExpectedPath($media)))
+        ->toBeFile();
+    expect(filesize($this->getMediaDirectory(getTargetExpectedPath($media))))
+        ->toEqual($testJpgFileSize);
+});

--- a/tests/MediaCollections/TransformPathCommandTest.php
+++ b/tests/MediaCollections/TransformPathCommandTest.php
@@ -5,7 +5,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestSupport\TestPathGenerator;
 use Spatie\MediaLibrary\Tests\TestSupport\TestUuidPathGenerator;
 
-function getSourceExpectedPath(Media $media, ?string $conversionName = NULL): string
+function getSourceExpectedPath(Media $media, ?string $conversionName = null): string
 {
     return $media->model->id
         . '/' . md5($media->id)
@@ -14,7 +14,7 @@ function getSourceExpectedPath(Media $media, ?string $conversionName = NULL): st
             : '/test.jpg');
 }
 
-function getTargetExpectedPath(Media $media, ?string $conversionName = NULL): string
+function getTargetExpectedPath(Media $media, ?string $conversionName = null): string
 {
     return $media->uuid
         . ($conversionName
@@ -57,8 +57,11 @@ beforeEach(function () {
 
         expect($this->getMediaDirectory(getSourceExpectedPath($mediaItem)))->toBeFile();
 
-        foreach($mediaItem->getGeneratedConversions() as $conversionName => $conversionPresent) {
-            $oldExpectedConversionPath = $mediaItem->model->id . '/' . md5($mediaItem->id) . '/custom_conversions/test-' . $conversionName . '.jpg';
+        foreach ($mediaItem->getGeneratedConversions() as $conversionName => $conversionPresent) {
+            $oldExpectedConversionPath =
+                $mediaItem->model->id
+                . '/' . md5($mediaItem->id)
+                . '/custom_conversions/test-' . $conversionName . '.jpg';
             expect($this->getMediaDirectory($oldExpectedConversionPath))->toBeFile();
         }
     }
@@ -98,7 +101,7 @@ it('can transform file paths including conversions', function () {
         ->not()
         ->toBeFile();
 
-    foreach($media->getMediaConversionNames() as $conversionName) {
+    foreach ($media->getMediaConversionNames() as $conversionName) {
         expect($this->getMediaDirectory(getSourceExpectedPath($media, $conversionName)))
             ->not()
             ->toBeFile();
@@ -108,7 +111,7 @@ it('can transform file paths including conversions', function () {
     expect($this->getMediaDirectory(getTargetExpectedPath($media)))
         ->toBeFile();
 
-    foreach($media->getMediaConversionNames() as $conversionName) {
+    foreach ($media->getMediaConversionNames() as $conversionName) {
         expect($this->getMediaDirectory(getTargetExpectedPath($media, $conversionName)))
             ->toBeFile();
     }
@@ -122,7 +125,7 @@ it('can transform file paths from a specific model type', function () {
     ]);
 
     // Ensure files are gone from 'old' location for model1
-    foreach(Arr::flatten($this->media['model1']) as $media) {
+    foreach (Arr::flatten($this->media['model1']) as $media) {
         expect($this->getMediaDirectory(getSourceExpectedPath($media)))
             ->not()
             ->toBeFile();
@@ -130,18 +133,18 @@ it('can transform file paths from a specific model type', function () {
 
     // Ensure files are still in place from 'old' location for model2, including
     // the conversions
-    foreach(Arr::flatten($this->media['model2']) as $media) {
+    foreach (Arr::flatten($this->media['model2']) as $media) {
         expect($this->getMediaDirectory(getSourceExpectedPath($media)))
             ->toBeFile();
 
-        foreach($media->getMediaConversionNames() as $conversionName) {
+        foreach ($media->getMediaConversionNames() as $conversionName) {
             expect($this->getMediaDirectory(getSourceExpectedPath($media, $conversionName)))
                 ->toBeFile();
         }
     }
 
     // Ensure files have arrived in new location for model1
-    foreach(Arr::flatten($this->media['model1']) as $media) {
+    foreach (Arr::flatten($this->media['model1']) as $media) {
         expect($this->getMediaDirectory(getTargetExpectedPath($media)))
             ->toBeFile();
     }
@@ -156,12 +159,12 @@ it('can transform file paths from a specific collection', function () {
 
     // Ensure files are gone from 'old' location for collection2, including
     // any conversions
-    foreach(Arr::pluck($this->media, 'collection2') as $media) {
+    foreach (Arr::pluck($this->media, 'collection2') as $media) {
         expect($this->getMediaDirectory(getSourceExpectedPath($media)))
             ->not()
             ->toBeFile();
 
-        foreach($media->getMediaConversionNames() as $conversionName) {
+        foreach ($media->getMediaConversionNames() as $conversionName) {
             expect($this->getMediaDirectory(getSourceExpectedPath($media, $conversionName)))
                 ->not()
                 ->toBeFile();
@@ -170,11 +173,11 @@ it('can transform file paths from a specific collection', function () {
 
     // Ensure files are still in place from 'old' location for collection1, including
     // the conversions
-    foreach(Arr::pluck($this->media, 'collection1') as $media) {
+    foreach (Arr::pluck($this->media, 'collection1') as $media) {
         expect($this->getMediaDirectory(getSourceExpectedPath($media)))
             ->toBeFile();
 
-        foreach($media->getMediaConversionNames() as $conversionName) {
+        foreach ($media->getMediaConversionNames() as $conversionName) {
             expect($this->getMediaDirectory(getSourceExpectedPath($media, $conversionName)))
                 ->toBeFile();
         }
@@ -182,11 +185,11 @@ it('can transform file paths from a specific collection', function () {
 
     // Ensure files have arrived in new location for collection2, including any
     // conversions
-    foreach(Arr::pluck($this->media, 'collection2') as $media) {
+    foreach (Arr::pluck($this->media, 'collection2') as $media) {
         expect($this->getMediaDirectory(getTargetExpectedPath($media)))
             ->toBeFile();
 
-        foreach($media->getMediaConversionNames() as $conversionName) {
+        foreach ($media->getMediaConversionNames() as $conversionName) {
             expect($this->getMediaDirectory(getTargetExpectedPath($media, $conversionName)))
                 ->toBeFile();
         }
@@ -206,11 +209,11 @@ it('can transform file paths from a specific model type and collection', functio
 
     // Ensure files are still in place for all the models that ought not to have
     // moved, including any conversions.  (Everything except model2/collection2)
-    foreach($notMoving as $media) {
+    foreach ($notMoving as $media) {
         expect($this->getMediaDirectory(getSourceExpectedPath($media)))
             ->toBeFile();
 
-        foreach($media->getMediaConversionNames() as $conversionName) {
+        foreach ($media->getMediaConversionNames() as $conversionName) {
             expect($this->getMediaDirectory(getSourceExpectedPath($media, $conversionName)))
                 ->toBeFile();
         }
@@ -220,13 +223,13 @@ it('can transform file paths from a specific model type and collection', functio
     expect($this->getMediaDirectory(getTargetExpectedPath($moved)))
         ->toBeFile();
 
-    foreach($moved->getMediaConversionNames() as $conversionName) {
+    foreach ($moved->getMediaConversionNames() as $conversionName) {
         expect($this->getMediaDirectory(getTargetExpectedPath($moved, $conversionName)))
             ->toBeFile();
     }
 });
 
-it('can transform paths where conversions are on another disk', function() {
+it('can transform paths where conversions are on another disk', function () {
     $media = $this->testModelWithConversionsOnOtherDisk
         ->addMedia($this->getTestJpg())
         ->preservingOriginal()
@@ -236,7 +239,7 @@ it('can transform paths where conversions are on another disk', function() {
     expect($this->getMediaDirectory(getSourceExpectedPath($media)))
         ->toBeFile();
 
-    foreach($media->getMediaConversionNames() as $conversionName) {
+    foreach ($media->getMediaConversionNames() as $conversionName) {
         expect($this->getTempDirectory() . '/media2/' . getSourceExpectedPath($media, $conversionName))
             ->toBeFile();
     }
@@ -252,7 +255,7 @@ it('can transform paths where conversions are on another disk', function() {
         ->not()
         ->toBeFile();
 
-    foreach($media->getMediaConversionNames() as $conversionName) {
+    foreach ($media->getMediaConversionNames() as $conversionName) {
         expect($this->getTempDirectory() . '/media2/' . getSourceExpectedPath($media, $conversionName))
             ->not()
             ->toBeFile();
@@ -262,13 +265,13 @@ it('can transform paths where conversions are on another disk', function() {
     expect($this->getMediaDirectory(getTargetExpectedPath($media)))
         ->toBeFile();
 
-    foreach($media->getMediaConversionNames() as $conversionName) {
+    foreach ($media->getMediaConversionNames() as $conversionName) {
         expect($this->getTempDirectory() . '/media2/' . getTargetExpectedPath($media, $conversionName))
             ->toBeFile();
     }
 });
 
-it('will error if source files are missing', function() {
+it('will error if source files are missing', function () {
     $media = $this->media['model1']['collection1'];
     Media::where('id', '<>', $media->id)->delete();
 
@@ -279,11 +282,12 @@ it('will error if source files are missing', function() {
             'targetGeneratorClass' => TestUuidPathGenerator::class,
         ])
         ->assertExitCode(1)
-        ->expectsOutput('#1 (test #1 public/public): Source media is missing (1/c4ca4238a0b923820dcc509a6f75849b/test.jpg)');
-
+        ->expectsOutput(
+            '#1 (test #1 public/public): Source media is missing (1/c4ca4238a0b923820dcc509a6f75849b/test.jpg)'
+        );
 });
 
-it('will not error if source files are missing but check is disabled', function() {
+it('will not error if source files are missing but check is disabled', function () {
     $media = $this->media['model1']['collection1'];
     Media::where('id', '<>', $media->id)->delete();
 
@@ -296,7 +300,7 @@ it('will not error if source files are missing but check is disabled', function(
     ])->assertExitCode(0);
 });
 
-it('will error if target files already exist', function() {
+it('will error if target files already exist', function () {
     $media = $this->media['model1']['collection1'];
     Media::where('id', '<>', $media->id)->delete();
 
@@ -311,7 +315,7 @@ it('will error if target files already exist', function() {
         ->expectsOutput('#1 (test #1 public/public): Target media already exists (' . $media->uuid . '/test.jpg)');
 });
 
-it('will not error if target files already exist but check has been disabled', function() {
+it('will not error if target files already exist but check has been disabled', function () {
     $media = $this->media['model1']['collection1'];
     Media::where('id', '<>', $media->id)->delete();
 

--- a/tests/TestSupport/TestPathGenerator.php
+++ b/tests/TestSupport/TestPathGenerator.php
@@ -19,11 +19,11 @@ class TestPathGenerator implements PathGenerator
 
     public function getPathForConversions(Media $media): string
     {
-        return $this->getPath($media).'/custom_conversions/';
+        return $this->getPath($media).'custom_conversions/';
     }
 
     public function getPathForResponsiveImages(Media $media): string
     {
-        return $this->getPath($media).'/custom_responsive_images/';
+        return $this->getPath($media).'custom_responsive_images/';
     }
 }


### PR DESCRIPTION
This PR adds a new command to facilitate migrating existing media objects into a new path generation scheme by moving all existing objects from the "old" path generator into the schema provided by a "new" path generator.

Use case: I recently encountered a project which used the default `media/id` folder structure, which is ordinarily fine, except that there were many hundreds of thousands of images being added.  While not technically hitting a file system limitation, anyone who inadvertently tried to list all the files in that directory was in for an unpleasant wait.  However, changing to a sharded directory structure meant not only changing to a new path generator, but migrating all of the existing data into the new format. 

[A Laracasts discussion](https://laracasts.com/discuss/channels/general-discussion/spatie-media-library-can-i-add-a-custom-path-generator-then-update-all-old-media-to-reflect-the-new-structure-easily) put me on the right track, but I realized that solution would not handle conversions, particularly if on a separate disk, nor warn about potential conflicts, etc.

This moves both primary media and conversions, and will work even if conversions are on a different disk. 

NOTE: There is an unrelated but necessary and included change to `TestPathGenerator`, which was adding an extra forward slash to conversion/responsive image paths leading to errors in my testing.  The fix does not appear to have broken any of the other existing tests.
