### PR TITLE
Add fallback path/url support for conversions

### DIFF
--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -58,6 +58,49 @@ public function registerMediaCollections(): void
 }
 ```
 
+When you use a fallback URL/path, [conversions](https://spatie.be/docs/laravel-medialibrary/v10/converting-images/defining-conversions) will use the default fallback URL/path if the media do not exist. You can pass a conversion name to the second parameter to use fallbacks per conversion.
+
+```php
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+// ...
+
+public function registerMediaCollections(): void
+{
+    $this
+        ->addMediaCollection('avatar')
+        ->useFallbackUrl('/default_avatar.jpg')
+        ->useFallbackUrl('/default_avatar_thumb.jpg', 'thumb')
+        ->useFallbackPath(public_path('/default_avatar.jpg'))
+        ->useFallbackPath(public_path('/default_avatar_thumb.jpg'), 'thumb')
+        ->registerMediaConversions(function (Media $media) {
+            $this
+                ->addMediaConversion('thumb')
+                ->width(50)
+                ->height(50);
+                
+            $this
+                ->addMediaConversion('thumb_2')
+                ->width(100)
+                ->height(100);
+        });
+}
+```
+
+This way, the image sizes are always as expected:
+
+```php
+$model->getFirstMediaUrl('avatar'); // default_avatar.jpg
+$model->getFirstMediaUrl('avatar', 'thumb'); // default_avatar_thumb.jpg
+$model->getFirstMediaUrl('avatar', 'thumb_2'); // default_avatar.jpg
+
+// ...
+
+$model->getFirstMediaPath('avatar'); // .../default_avatar.jpg
+$model->getFirstMediaPath('avatar', 'thumb'); // .../default_avatar_thumb.jpg
+$model->getFirstMediaPath('avatar', 'thumb_2'); // .../default_avatar.jpg
+```
+
 ## Only allow certain files in a collection
 
 You can pass a callback to `acceptsFile` that will check if a file is allowed into the collection. In this example we only accept `jpeg` files.

--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -87,7 +87,7 @@ public function registerMediaCollections(): void
 }
 ```
 
-This way, the image sizes are always as expected:
+In this way, the image sizes are always as expected:
 
 ```php
 $model->getFirstMediaUrl('avatar'); // default_avatar.jpg

--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -90,15 +90,15 @@ public function registerMediaCollections(): void
 In this way, the image sizes are always as expected:
 
 ```php
-$model->getFirstMediaUrl('avatar'); // default_avatar.jpg
-$model->getFirstMediaUrl('avatar', 'thumb'); // default_avatar_thumb.jpg
-$model->getFirstMediaUrl('avatar', 'thumb_2'); // default_avatar.jpg
+$yourModel->getFirstMediaUrl('avatar'); // default_avatar.jpg
+$yourModel->getFirstMediaUrl('avatar', 'thumb'); // default_avatar_thumb.jpg
+$yourModel->getFirstMediaUrl('avatar', 'thumb_2'); // default_avatar.jpg
 
 // ...
 
-$model->getFirstMediaPath('avatar'); // .../default_avatar.jpg
-$model->getFirstMediaPath('avatar', 'thumb'); // .../default_avatar_thumb.jpg
-$model->getFirstMediaPath('avatar', 'thumb_2'); // .../default_avatar.jpg
+$yourModel->getFirstMediaPath('avatar'); // .../default_avatar.jpg
+$yourModel->getFirstMediaPath('avatar', 'thumb'); // .../default_avatar_thumb.jpg
+$yourModel->getFirstMediaPath('avatar', 'thumb_2'); // .../default_avatar.jpg
 ```
 
 ## Only allow certain files in a collection

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -293,7 +293,7 @@ trait InteractsWithMedia
         $media = $this->getFirstMedia($collectionName);
 
         if (! $media) {
-            return $this->getFallbackMediaUrl($collectionName) ?: '';
+            return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
         }
 
         if ($conversionName !== '' && ! $media->hasGeneratedConversion($conversionName)) {
@@ -317,7 +317,7 @@ trait InteractsWithMedia
         $media = $this->getFirstMedia($collectionName);
 
         if (! $media) {
-            return $this->getFallbackMediaUrl($collectionName) ?: '';
+            return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
         }
 
         if ($conversionName !== '' && ! $media->hasGeneratedConversion($conversionName)) {
@@ -342,14 +342,26 @@ trait InteractsWithMedia
             ->first(fn (MediaCollection $collection) => $collection->name === $collectionName);
     }
 
-    public function getFallbackMediaUrl(string $collectionName = 'default'): string
+    public function getFallbackMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return optional($this->getMediaCollection($collectionName))->fallbackUrl ?? '';
+        $collection = optional($this->getMediaCollection($collectionName));
+
+        if (in_array($conversionName, ['', 'default'], true)) {
+            return $collection->fallbackUrl['default'] ?? '';
+        }
+
+        return $collection->fallbackUrl[$conversionName] ?? $collection->fallbackUrl['default'] ?? '';
     }
 
-    public function getFallbackMediaPath(string $collectionName = 'default'): string
+    public function getFallbackMediaPath(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return optional($this->getMediaCollection($collectionName))->fallbackPath ?? '';
+        $collection = optional($this->getMediaCollection($collectionName));
+
+        if (in_array($conversionName, ['', 'default'], true)) {
+            return $collection->fallbackPath['default'] ?? '';
+        }
+
+        return $collection->fallbackPath[$conversionName] ?? $collection->fallbackPath['default'] ?? '';
     }
 
     /*
@@ -362,7 +374,7 @@ trait InteractsWithMedia
         $media = $this->getFirstMedia($collectionName);
 
         if (! $media) {
-            return $this->getFallbackMediaPath($collectionName) ?: '';
+            return $this->getFallbackMediaPath($collectionName, $conversionName) ?: '';
         }
 
         if ($conversionName !== '' && ! $media->hasGeneratedConversion($conversionName)) {

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -344,24 +344,24 @@ trait InteractsWithMedia
 
     public function getFallbackMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
     {
-        $collection = optional($this->getMediaCollection($collectionName));
+        $fallbackUrl = optional($this->getMediaCollection($collectionName))->fallbackUrl;
 
         if (in_array($conversionName, ['', 'default'], true)) {
-            return $collection->fallbackUrl['default'] ?? '';
+            return $fallbackUrl['default'] ?? '';
         }
 
-        return $collection->fallbackUrl[$conversionName] ?? $collection->fallbackUrl['default'] ?? '';
+        return $fallbackUrl[$conversionName] ?? $fallbackUrl['default'] ?? '';
     }
 
     public function getFallbackMediaPath(string $collectionName = 'default', string $conversionName = ''): string
     {
-        $collection = optional($this->getMediaCollection($collectionName));
+        $fallbackPath = optional($this->getMediaCollection($collectionName))->fallbackPath;
 
         if (in_array($conversionName, ['', 'default'], true)) {
-            return $collection->fallbackPath['default'] ?? '';
+            return $fallbackPath['default'] ?? '';
         }
 
-        return $collection->fallbackPath[$conversionName] ?? $collection->fallbackPath['default'] ?? '';
+        return $fallbackPath[$conversionName] ?? $fallbackPath['default'] ?? '';
     }
 
     /*

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -344,24 +344,24 @@ trait InteractsWithMedia
 
     public function getFallbackMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
     {
-        $fallbackUrl = optional($this->getMediaCollection($collectionName))->fallbackUrl;
+        $fallbackUrls = optional($this->getMediaCollection($collectionName))->fallbackUrls;
 
         if (in_array($conversionName, ['', 'default'], true)) {
-            return $fallbackUrl['default'] ?? '';
+            return $fallbackUrls['default'] ?? '';
         }
 
-        return $fallbackUrl[$conversionName] ?? $fallbackUrl['default'] ?? '';
+        return $fallbackUrls[$conversionName] ?? $fallbackUrls['default'] ?? '';
     }
 
     public function getFallbackMediaPath(string $collectionName = 'default', string $conversionName = ''): string
     {
-        $fallbackPath = optional($this->getMediaCollection($collectionName))->fallbackPath;
+        $fallbackPaths = optional($this->getMediaCollection($collectionName))->fallbackPaths;
 
         if (in_array($conversionName, ['', 'default'], true)) {
-            return $fallbackPath['default'] ?? '';
+            return $fallbackPaths['default'] ?? '';
         }
 
-        return $fallbackPath[$conversionName] ?? $fallbackPath['default'] ?? '';
+        return $fallbackPaths[$conversionName] ?? $fallbackPaths['default'] ?? '';
     }
 
     /*

--- a/src/MediaCollections/MediaCollection.php
+++ b/src/MediaCollections/MediaCollection.php
@@ -29,10 +29,10 @@ class MediaCollection
     public bool $singleFile = false;
 
     /** @var array<string, string> */
-    public array $fallbackUrl = [];
+    public array $fallbackUrls = [];
 
     /** @var array<string, string> */
-    public array $fallbackPath = [];
+    public array $fallbackPaths = [];
 
     public function __construct(
         public string $name
@@ -105,7 +105,7 @@ class MediaCollection
             $conversionName = 'default';
         }
 
-        $this->fallbackUrl[$conversionName] = $url;
+        $this->fallbackUrls[$conversionName] = $url;
 
         return $this;
     }
@@ -116,7 +116,7 @@ class MediaCollection
             $conversionName = 'default';
         }
 
-        $this->fallbackPath[$conversionName] = $path;
+        $this->fallbackPaths[$conversionName] = $path;
 
         return $this;
     }

--- a/src/MediaCollections/MediaCollection.php
+++ b/src/MediaCollections/MediaCollection.php
@@ -28,9 +28,11 @@ class MediaCollection
 
     public bool $singleFile = false;
 
-    public string $fallbackUrl = '';
+    /** @var array<string, string> */
+    public array $fallbackUrl = [];
 
-    public string $fallbackPath = '';
+    /** @var array<string, string> */
+    public array $fallbackPath = [];
 
     public function __construct(
         public string $name
@@ -97,16 +99,24 @@ class MediaCollection
         $this->mediaConversionRegistrations = $mediaConversionRegistrations;
     }
 
-    public function useFallbackUrl(string $url): self
+    public function useFallbackUrl(string $url, string $conversionName = ''): self
     {
-        $this->fallbackUrl = $url;
+        if ($conversionName === '') {
+            $conversionName = 'default';
+        }
+
+        $this->fallbackUrl[$conversionName] = $url;
 
         return $this;
     }
 
-    public function useFallbackPath(string $path): self
+    public function useFallbackPath(string $path, string $conversionName = ''): self
     {
-        $this->fallbackPath = $path;
+        if ($conversionName === '') {
+            $conversionName = 'default';
+        }
+
+        $this->fallbackPath[$conversionName] = $path;
 
         return $this;
     }

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -203,13 +203,23 @@ it('can get the path to first media in a collection', function () {
     expect($this->testModel->getFirstMediaPath('images'))->toEqual($firstMedia->getPath());
 });
 
-it('can get the default path to the first media in a collection', function () {
-    expect($this->testModel->getFirstMediaPath('avatar'))->toEqual('/default-path.jpg');
-});
+it('can get the default path to the first media in a collection', function ($conversionName, $expectedPath) {
+    expect($this->testModel->getFirstMediaPath('avatar', $conversionName))->toEqual($expectedPath);
+})->with([
+    ['', '/default-path.jpg'],
+    ['default', '/default-path.jpg'],
+    ['foo', '/default-path.jpg'],
+    ['avatar_thumb', '/default-avatar-thumb-path.jpg'],
+]);
 
-it('can get the default url to the first media in a collection', function () {
-    expect($this->testModel->getFirstMediaUrl('avatar'))->toEqual('/default-url.jpg');
-});
+it('can get the default url to the first media in a collection', function ($conversionName, $expectedUrl) {
+    expect($this->testModel->getFirstMediaUrl('avatar', $conversionName))->toEqual($expectedUrl);
+})->with([
+    ['', '/default-url.jpg'],
+    ['default', '/default-url.jpg'],
+    ['foo', '/default-url.jpg'],
+    ['avatar_thumb', '/default-avatar-thumb-url.jpg'],
+]);
 
 it('can get the default path to the first media in a collection if conversion not marked as generated yet', function () {
     $media = $this

--- a/tests/TestSupport/TestModels/TestModel.php
+++ b/tests/TestSupport/TestModels/TestModel.php
@@ -21,6 +21,8 @@ class TestModel extends Model implements HasMedia
         $this
             ->addMediaCollection('avatar')
             ->useFallbackUrl('/default-url.jpg')
-            ->useFallbackPath('/default-path.jpg');
+            ->useFallbackUrl('/default-avatar-thumb-url.jpg', 'avatar_thumb')
+            ->useFallbackPath('/default-path.jpg')
+            ->useFallbackPath('/default-avatar-thumb-path.jpg', 'avatar_thumb');
     }
 }


### PR DESCRIPTION
```php
$this->addMediaCollection('avatar')
     ->useFallbackUrl('/default-avatar.jpg')
     ->useFallbackUrl('/default-avatar-50x50.jpg', 'avatar_thumb');

```

```php
$this->addMediaConversion('avatar_thumb')
     ->width(50)
     ->height(50);
```

```php
$model->getFirstMediaUrl('avatar'); // default-avatar.jpg

$model->getFirstMediaUrl('avatar', 'avatar_thumb'); // default-avatar-50x50.jpg

$model->getFirstMediaUrl('avatar', 'foo'); // default-avatar.jpg
```

---

```php
$this->addMediaCollection('seo_images')
     ->useFallbackUrl('/default-1920x1080.jpg')
     ->useFallbackUrl('/default-twitter-1200x600.jpg', 'twitter')
     ->useFallbackUrl('/default-open-graph-1200x630.jpg', 'open_graph');

```

```php
$this->addMediaConversion('twitter')
     ->width(1200)
     ->height(600);

$this->addMediaConversion('open_graph')
     ->width(1200)
     ->height(630);
```

```php
$model->getFirstMediaUrl('seo_images'); // default-1920x1080.jpg

$model->getFirstMediaUrl('seo_images', 'twitter'); // default-twitter-1200x600.jpg

$model->getFirstMediaUrl('seo_images', 'open_graph'); // default-open-graph-1200x630.jpg

```