### PR TITLE
Throw error if disk cannot be accessed

### DIFF
--- a/src/MediaCollections/Exceptions/DiskCannotBeAccessed.php
+++ b/src/MediaCollections/Exceptions/DiskCannotBeAccessed.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\MediaLibrary\MediaCollections\Exceptions;
+
+class DiskCannotBeAccessed extends FileCannotBeAdded
+{
+    public static function create(string $diskName): self
+    {
+        return new static("filesystem disk named `{$diskName}` cannot be accessed");
+    }
+}

--- a/src/MediaCollections/Exceptions/DiskCannotBeAccessed.php
+++ b/src/MediaCollections/Exceptions/DiskCannotBeAccessed.php
@@ -6,6 +6,6 @@ class DiskCannotBeAccessed extends FileCannotBeAdded
 {
     public static function create(string $diskName): self
     {
-        return new static("filesystem disk named `{$diskName}` cannot be accessed");
+        return new static("Disk named `{$diskName}` cannot be accessed");
     }
 }

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\MediaCollections;
 
 use Closure;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Traits\Macroable;
@@ -431,6 +432,8 @@ class FileAdder
 
         $this->checkGenerateResponsiveImages($media);
 
+        DB::beginTransaction();
+
         if (! $media->getConnectionName()) {
             $media->setConnection($model->getConnectionName());
         }
@@ -470,6 +473,8 @@ class FileAdder
                 $model->clearMediaCollectionExcept($media->collection_name, $collectionMedia->reverse()->take($collectionSizeLimit));
             }
         }
+
+        DB::commit();
     }
 
     protected function getMediaCollection(string $collectionName): ?MediaCollection

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -598,10 +598,7 @@ it('can add an upload to the media library using dot notation', function () {
 });
 
 it('will throw and exception and not create a record in database if file cannot be added', function () {
-
-    $this->expectException(DiskCannotBeAccessed::class);
-
-    config()->set('filesystems.disks.minio_disk', [
+    config()->set('filesystems.disks.invalid_disk', [
         'driver' => 's3',
         'secret' => 'test',
         'key' => 'test',
@@ -611,7 +608,7 @@ it('will throw and exception and not create a record in database if file cannot 
 
     $this->testModel
         ->addMedia($this->getTestJpg())
-        ->toMediaCollection('default', 'minio_disk');
+        ->toMediaCollection('default', 'invalid_disk');
 
     expect(Media::count())->toBe(0);
-});
+})->throws(DiskCannotBeAccessed::class);

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -603,6 +603,8 @@ it('will throw and exception and not create a record in database if file cannot 
 
     config()->set('filesystems.disks.minio_disk', [
         'driver' => 's3',
+        'secret' => 'test',
+        'key' => 'test',
         'region' => 'test',
         'bucket' => 'test',
     ]);


### PR DESCRIPTION
This PR changes the behaviour when a filesytem cannot be accessed as seen in #3010, it will throw and exception and not create a new media record.