### PR TITLE
Fix typo in property name in Media model

### DIFF
--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -441,7 +441,7 @@ class Media extends Model implements Responsable, Htmlable, Attachable
         $attachment = Attachment::fromStorageDisk($this->disk, $this->getPathRelativeToRoot($conversion))->as($this->file_name);
 
         if ($this->mime_type) {
-            $attachment->withMime($this->mime);
+            $attachment->withMime($this->mime_type);
         }
 
         return $attachment;


### PR DESCRIPTION
Hi!

I just found a little typo in one property of Media model, while sending mails with `Model::shouldBeStrict(true)`.

Have a nice day! 👋 