### PR TITLE
Added option to set custom queue connection

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -15,6 +15,12 @@ return [
     'max_file_size' => 1024 * 1024 * 10, // 10MB
 
     /*
+     * This queue connection will be used to generate derived and responsive images.
+     * Leave empty to use the default queue connection.
+     */
+    'queue_connection_name' => env('QUEUE_CONNECTION', 'sync'),
+
+    /*
      * This queue will be used to generate derived and responsive images.
      * Leave empty to use the default queue.
      */

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -122,7 +122,7 @@ $media->getUrl('thumb') // returns ''
 
 ## Queuing conversions
 
-By default, a conversion will be added to the queue that you've [specified in the configuration](/laravel-medialibrary/v10/installation-setup). If you want your image to be created directly (and not on a queue) use `nonQueued` on a conversion.
+By default, a conversion will be added to the connection and queue that you've [specified in the configuration](/laravel-medialibrary/v10/installation-setup). If you want your image to be created directly (and not on a queue) use `nonQueued` on a conversion.
 
 ```php
 // in your model

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -51,6 +51,12 @@ return [
      * Adding a larger file will result in an exception.
      */
     'max_file_size' => 1024 * 1024 * 10,
+    
+    /*
+     * This queue connection will be used to generate derived and responsive images.
+     * Leave empty to use the default queue connection.
+     */
+    'queue_connection_name' => '',
 
     /*
      * This queue will be used to generate derived and responsive images.

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -92,6 +92,7 @@ class FileManipulator
 
         /** @var PerformConversionsJob $job */
         $job = (new $performConversionsJobClass($conversions, $media, $onlyMissing))
+            ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue(config('media-library.queue_name'));
 
         dispatch($job);
@@ -116,6 +117,7 @@ class FileManipulator
 
         /** @var GenerateResponsiveImagesJob $job */
         $job = (new $generateResponsiveImagesJobClass($media))
+            ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue(config('media-library.queue_name'));
 
         dispatch($job);

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -456,6 +456,10 @@ class FileAdder
 
             $job = new $generateResponsiveImagesJobClass($media);
 
+            if ($customConnection = config('media-library.queue_connection_name')) {
+                $job->onConnection($customConnection);
+            }
+
             if ($customQueue = config('media-library.queue_name')) {
                 $job->onQueue($customQueue);
             }


### PR DESCRIPTION
Hello Spatie,

For convenience, I usually setup a custom queue connection that uses separate jobs table for heavy and high volume tasks like image processing. For this purpose, I've added a option to set up custom queue connection in the config and updated the documentation where necessary. I thought of adding some tests. However, Laravel itself validates empty string passed to its job's `onConnection` and `onQueue` methods. So, I didn't bother doing the same. All the other test cases passed except `create a derived version for an image without an extension` which was not related to this. I will have a look when possible. Let me know what you think of it and will update if any changes needed.