### PR TITLE
fix #3090 - branch v9 PHP 7.4 version of the fix

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -245,7 +245,7 @@ class Filesystem
 
         $oldMedia = (clone $media)->fill($media->getOriginal());
 
-        if ($oldMedia->getPath() === $media->getPath()) {
+        if ($factory->getPath($oldMedia) === $factory->getPath($media)) {
             return;
         }
 


### PR DESCRIPTION
Fixes syncMediaPath not checking paths have changed correctly.

Push to v9 branch to fix this for the version of medialibrary that supports PHP7.4