### PR TITLE
fix #3090 syncMediaPath incorrectly comparing paths

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -241,7 +241,7 @@ class Filesystem
 
         $oldMedia = (clone $media)->fill($media->getOriginal());
 
-        if ($oldMedia->getPath() === $media->getPath()) {
+        if ($factory->getPath($oldMedia) === $factory->getPath($media)) {
             return;
         }
 


### PR DESCRIPTION
fixes `syncMediaPath()` in Filesystem which was using `getPath()` on the media object which returns the filename as well as the file path, rather than using `getPath()` from the `PathGeneratorFactory` which only returns the path. 

We can blame SPL for the poorly named `getPath` :)