### PR TITLE
Add Additional FIlename Sanitization Rules

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.1, 8.0]
+                php: [8.2, 8.1, 8.0]
                 laravel: [9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
@@ -47,7 +47,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" --no-interaction --no-update
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             - name: Execute tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 10.6.0 - 2022-10-21
+
+### What's Changed
+
+- Hint to additional installation instructions by @driesvints in https://github.com/spatie/laravel-medialibrary/pull/3047
+- PHP 8.2 Build by @erikn69 in https://github.com/spatie/laravel-medialibrary/pull/3061
+- Add fallback path/url support for conversions by @mertasan in https://github.com/spatie/laravel-medialibrary/pull/3062
+
+### New Contributors
+
+- @mertasan made their first contribution in https://github.com/spatie/laravel-medialibrary/pull/3062
+
+**Full Changelog**: https://github.com/spatie/laravel-medialibrary/compare/10.5.2...10.6.0
+
 ## 10.5.2 - 2022-09-30
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 10.7.1 - 2022-11-09
+
+### What's Changed
+
+- fix #3090 syncMediaPath incorrectly comparing paths by @SlyDave in https://github.com/spatie/laravel-medialibrary/pull/3092
+
+**Full Changelog**: https://github.com/spatie/laravel-medialibrary/compare/10.7.0...10.7.1
+
 ## 9.12.4 - 2022-11-09
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 10.7.0 - 2022-11-09
+
+### What's Changed
+
+- Added option to set custom queue connection by @rahulhaque in https://github.com/spatie/laravel-medialibrary/pull/3085
+
+### New Contributors
+
+- @rahulhaque made their first contribution in https://github.com/spatie/laravel-medialibrary/pull/3085
+
+**Full Changelog**: https://github.com/spatie/laravel-medialibrary/compare/10.6.1...10.7.0
+
 ## 10.6.1 - 2022-11-04
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 10.5.1 - 2022-09-21
+
+### What's Changed
+
+- Allow the Github actions to run locally via act by @emielmolenaar in https://github.com/spatie/laravel-medialibrary/pull/3028
+- Never explicitly create directories on GCS, just as with S3 by @boboldehampsink in https://github.com/spatie/laravel-medialibrary/pull/3037
+
+### New Contributors
+
+- @boboldehampsink made their first contribution in https://github.com/spatie/laravel-medialibrary/pull/3037
+
+**Full Changelog**: https://github.com/spatie/laravel-medialibrary/compare/10.5.0...10.5.1
+
 ## 10.5.0 - 2022-09-12
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 10.5.2 - 2022-09-30
+
+### What's Changed
+
+- Fix for audio only "video" files by @rcerljenko in https://github.com/spatie/laravel-medialibrary/pull/3046
+
+**Full Changelog**: https://github.com/spatie/laravel-medialibrary/compare/10.5.1...10.5.2
+
 ## 10.5.1 - 2022-09-21
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 9.12.4 - 2022-11-09
+
+### What's Changed
+
+- fix #3090 - branch v9 PHP 7.4 version of the fix by @SlyDave in https://github.com/spatie/laravel-medialibrary/pull/3091
+
+**Full Changelog**: https://github.com/spatie/laravel-medialibrary/compare/9.12.3...9.12.4
+
 ## 10.7.0 - 2022-11-09
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 10.6.1 - 2022-11-04
+
+### What's Changed
+
+- docs: fix some typos by @ArnaudLier in https://github.com/spatie/laravel-medialibrary/pull/3075
+- Fix typo in property name in Media model by @pdziewa in https://github.com/spatie/laravel-medialibrary/pull/3082
+
+### New Contributors
+
+- @ArnaudLier made their first contribution in https://github.com/spatie/laravel-medialibrary/pull/3075
+- @pdziewa made their first contribution in https://github.com/spatie/laravel-medialibrary/pull/3082
+
+**Full Changelog**: https://github.com/spatie/laravel-medialibrary/compare/10.6.0...10.6.1
+
 ## 10.6.0 - 2022-10-21
 
 ### What's Changed

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -15,6 +15,12 @@ return [
     'max_file_size' => 1024 * 1024 * 10, // 10MB
 
     /*
+     * This queue connection will be used to generate derived and responsive images.
+     * Leave empty to use the default queue connection.
+     */
+    'queue_connection_name' => env('QUEUE_CONNECTION', 'sync'),
+
+    /*
      * This queue will be used to generate derived and responsive images.
      * Leave empty to use the default queue.
      */

--- a/docs/advanced-usage/customising-database-connections.md
+++ b/docs/advanced-usage/customising-database-connections.md
@@ -7,7 +7,7 @@ weight: 13
 
 The built-in model (`Spatie\MediaLibrary\MediaCollections\Models\Media`) will use the default database connection set for your application.
 
-If you need to change this database, connection you can create a custom model and set the `$connection` property (https://laravel.com/docs/9.x/eloquent#database-connections). See <a href="https://docs.spatie.be/laravel-medialibrary/v10/advanced-usage/using-your-own-model">Using your own model</a> for more information.
+If you need to change this database connection, you can create a custom model and set the `$connection` property (https://laravel.com/docs/9.x/eloquent#database-connections). See <a href="https://docs.spatie.be/laravel-medialibrary/v10/advanced-usage/using-your-own-model">Using your own model</a> for more information.
 
 ```php
 <?php

--- a/docs/advanced-usage/disable-cdn.md
+++ b/docs/advanced-usage/disable-cdn.md
@@ -5,7 +5,7 @@ weight: 12
 
 Media Library Pro uses a CDN to load the [Dragula](https://github.com/bevacqua/dragula) library. Dragula provides the drag-and-drop-ability inside a Media Library Pro component.
 
-If you like to disable the loading via CDN and want to take care by yourself of including Dragula you will need to add the following option to your `media-library.php` config file.
+If you would like to disable the loading via CDN and want to take care by yourself of including Dragula you will need to add the following option to your `media-library.php` config file.
 
 ```php
     ...

--- a/docs/advanced-usage/generating-custom-urls.md
+++ b/docs/advanced-usage/generating-custom-urls.md
@@ -1,10 +1,10 @@
 ---
-title: Generating custom urls
+title: Generating custom URLs
 weight: 9
 ---
 
-When `getUrl` is called, the task of generating that url is passed to an implementation of `Spatie\MediaLibrary\Support\UrlGenerator\UrlGenerator`.
+When `getUrl` is called, the task of generating that URL is passed to an implementation of `Spatie\MediaLibrary\Support\UrlGenerator\UrlGenerator`.
 
-The package contains a `DefaultUrlGenerator` that can generate urls for a media library that is stored inside the public path. It can also generate URLs for S3.
+The package contains a `DefaultUrlGenerator` that can generate URLs for a media library that is stored inside the public path. It can also generate URLs for S3.
 
 If you are storing your media files in a private directory or are using a different filesystem, you can write your own `UrlGenerator`. Your generator must implement the `Spatie\MediaLibrary\Support\UrlGenerator\UrlGenerator` interface. 

--- a/docs/advanced-usage/using-a-custom-directory-structure.md
+++ b/docs/advanced-usage/using-a-custom-directory-structure.md
@@ -57,7 +57,7 @@ There aren't any restrictions on how the directories can be named. When a `Media
 
 ## Are you a visual learner?
 
-Here's a video that shows customize paths
+Here's a video that shows custom paths:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/hCXtDyGcPSo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/api/defining-conversions.md
+++ b/docs/api/defining-conversions.md
@@ -50,7 +50,7 @@ public function nonQueued(): self
 
 ### useLoadingAttributeValue
 
-This is the value that, when this conversation is converted to html, will be used in the `loading` attribute. The loading attribute is a standardised attribute that controls lazy loading behaviour of the browser. Possible values are `lazy`, `eager`, `auto` or null if you don't want to set any loading instruction.
+This is the value that, when this conversation is converted to HTML, will be used in the `loading` attribute. The loading attribute is a standardised attribute that controls lazy loading behaviour of the browser. Possible values are `lazy`, `eager`, `auto` or null if you don't want to set any loading instruction.
 
 You can learn more on native lazy loading [in this post on css-tricks](https://css-tricks.com/native-lazy-loading/).
 

--- a/docs/basic-usage/retrieving-media.md
+++ b/docs/basic-usage/retrieving-media.md
@@ -11,18 +11,18 @@ $mediaItems = $yourModel->getMedia();
 
 The method returns a collection of `Media`-objects.
 
-You can retrieve the url and path to the file associated with the `Media`-object using  `getUrl`, `getTemporaryUrl` (for S3 only) and `getPath`:
+You can retrieve the URL and path to the file associated with the `Media`-object using  `getUrl`, `getTemporaryUrl` (for S3 only) and `getPath`:
 
 ```php
 $publicUrl = $mediaItems[0]->getUrl();
-$publicFullUrl = $mediaItems[0]->getFullUrl(); //url including domain
+$publicFullUrl = $mediaItems[0]->getFullUrl(); // URL including domain
 $fullPathOnDisk = $mediaItems[0]->getPath();
 $temporaryS3Url = $mediaItems[0]->getTemporaryUrl(Carbon::now()->addMinutes(5));
 ```
 
-If you want to retrieve versioned media urls, for example when needing cache busting, you can enable versioning by setting the `version_urls` config value to `true` in your `media-library.php` config file. The `getUrl()` and `getFullUrl()` functions will return the url with a version string based on the `updated_at` column of the media model.
+If you want to retrieve versioned media URLs, for example when needing cache busting, you can enable versioning by setting the `version_urls` config value to `true` in your `media-library.php` config file. The `getUrl()` and `getFullUrl()` functions will return the URL with a version string based on the `updated_at` column of the media model.
 
-Since retrieving the first media and the url for the first media for an object is such a common scenario, the `getFirstMedia` and `getFirstMediaUrl` convenience-methods are also provided:
+Since retrieving the first media and the URL for the first media for an object is such a common scenario, the `getFirstMedia` and `getFirstMediaUrl` convenience-methods are also provided:
 
 ```php
 $media = $yourModel->getFirstMedia();

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -122,7 +122,7 @@ $media->getUrl('thumb') // returns ''
 
 ## Queuing conversions
 
-By default, a conversion will be added to the queue that you've [specified in the configuration](/laravel-medialibrary/v10/installation-setup). If you want your image to be created directly (and not on a queue) use `nonQueued` on a conversion.
+By default, a conversion will be added to the connection and queue that you've [specified in the configuration](/laravel-medialibrary/v10/installation-setup). If you want your image to be created directly (and not on a queue) use `nonQueued` on a conversion.
 
 ```php
 // in your model

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -9,6 +9,8 @@ Media conversions will be executed whenever  a `jpg`, `png`, `svg`, `webp`, `pdf
 
 Internally, [spatie/image](https://docs.spatie.be/image/v1/) is used to manipulate the images. You can use [any manipulation function](https://docs.spatie.be/image) from that package.
 
+Please check [the image generator docs](/laravel-medialibrary/v10/converting-other-file-types/using-image-generators) for additional installation requirements when working with PDF, SVG or video formats.
+
 ## Are you a visual learner?
 
 Here's a video that shows how to working with conversion.
@@ -120,7 +122,7 @@ $media->getUrl('thumb') // returns ''
 
 ## Queuing conversions
 
-By default, a conversion will be added to the queue that you've [specified in the configuration](https://docs.spatie.be/laravel-medialibrary/v10/installation-setup). If you want your image to be created directly (and not on a queue) use `nonQueued` on a conversion.
+By default, a conversion will be added to the queue that you've [specified in the configuration](/laravel-medialibrary/v10/installation-setup). If you want your image to be created directly (and not on a queue) use `nonQueued` on a conversion.
 
 ```php
 // in your model

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -94,7 +94,7 @@ $media->getUrl('old-picture') // the url to the sepia, bordered version
 
 ## Performing conversions on specific collections
 
-By default a conversion will be performed on all files regardless of which [collection](/laravel-medialibrary/v10/working-with-media-collections/simple-media-collections) is used.  Conversions can also be performed on all specific collections by adding a call to  `performOnCollections`.
+By default a conversion will be performed on all files regardless of which [collection](/laravel-medialibrary/v10/working-with-media-collections/simple-media-collections) is used. Conversions can also be performed on specific collections by adding a call to `performOnCollections`.
 
 This is how that looks like in the model:
 
@@ -103,9 +103,9 @@ This is how that looks like in the model:
 public function registerMediaConversions(Media $media = null): void
 {
     $this->addMediaConversion('thumb')
+          ->performOnCollections('images', 'downloads')
           ->width(368)
-          ->height(232)
-          ->performOnCollections('images', 'downloads');
+          ->height(232);
 }
 ```
 
@@ -160,9 +160,9 @@ public $registerMediaConversionsUsingModelInstance = true;
 public function registerMediaConversions(Media $media = null): void
 {
     $this->addMediaConversion('thumb')
+          ->performOnCollections('images', 'downloads')
           ->width($this->width)
-          ->height($this->height)
-          ->performOnCollections('images', 'downloads');
+          ->height($this->height);
 }
 ```
 

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -51,6 +51,12 @@ return [
      * Adding a larger file will result in an exception.
      */
     'max_file_size' => 1024 * 1024 * 10,
+    
+    /*
+     * This queue connection will be used to generate derived and responsive images.
+     * Leave empty to use the default queue connection.
+     */
+    'queue_connection_name' => '',
 
     /*
      * This queue will be used to generate derived and responsive images.

--- a/docs/responsive-images/customizing-the-rendered-html.md
+++ b/docs/responsive-images/customizing-the-rendered-html.md
@@ -1,5 +1,5 @@
 ---
-title: Customizing the rendered html
+title: Customizing the rendered HTML
 weight: 3
 ---
 

--- a/docs/responsive-images/generating-your-own-tiny-placeholder.md
+++ b/docs/responsive-images/generating-your-own-tiny-placeholder.md
@@ -3,9 +3,9 @@ title: Generating your own tiny placeholder
 weight: 4
 ---
 
-When generating responsive images, the media library will generate a tiny version of your image which will be used for [progressive image loading](/laravel-medialibrary/v10/responsive-images/getting-started-with-responsive-images#progressive-image-loading). By default this tiny version will be blurred version of the original.
+When generating responsive images, the media library will generate a tiny version of your image which will be used for [progressive image loading](/laravel-medialibrary/v10/responsive-images/getting-started-with-responsive-images#progressive-image-loading). By default, this tiny version will be a blurred version of the original.
 
-You can customize how the tiny version of the image should be generated. Maybe you want a to just use the dominant color instead of blur. In the  `responsive_images.tiny_placeholder_generator` of the `media-library` config file you can specify a class that implements `Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator`. This interface only requires you to implement one function:
+You can customize how the tiny version of the image should be generated. Maybe you want to just use the dominant color instead of blur. In the  `responsive_images.tiny_placeholder_generator` of the `media-library` config file you can specify a class that implements `Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator`. This interface only requires you to implement one function:
 
 ```php
 public function generateTinyPlaceholder(string $sourceImagePath, string $tinyImageDestinationPath);
@@ -13,7 +13,7 @@ public function generateTinyPlaceholder(string $sourceImagePath, string $tinyIma
 
 `$sourceImagePath` contains the path of the image where you should generate a tiny representation for. The generated tiny image should be saved at `$tinyImageDestinationPath`. This tiny image should be a `jpg`.
 
-Here's a an example implementation that generates a blurred version.
+Here's an example implementation that generates a blurred version:
 
 ```php
 namespace App;

--- a/docs/responsive-images/getting-started-with-responsive-images.md
+++ b/docs/responsive-images/getting-started-with-responsive-images.md
@@ -5,9 +5,9 @@ weight: 1
 
 Websites are viewed on various devices with widely differing screen sizes and connection speeds. When serving images it's best not to use the same image for all devices. A large image might be fine on a desktop computer with a fast internet connection, but on a small mobile device with limited bandwidth, the download might take a long time.
 
-The media library has support for generating the necessary files and html markup for responsive images. In addition the medialibrary also has support for progressive image loading.
+The media library has support for generating the necessary files and HTML markup for responsive images. In addition the medialibrary also has support for progressive image loading.
 
-Try a [demo of the concept](/laravel-medialibrary/v10/responsive-images/demo) here.
+[Try a demo of the concept here.](/laravel-medialibrary/v10/responsive-images/demo)
 
 ## Are you a visual learner?
 
@@ -59,13 +59,13 @@ At the same time we can use this technique to use this smallest picture as the p
 
 ### Progressive image loading
 
-When visiting a [Medium](https://medium.com/) blog you might have noticed (on a slower connection) that before a full image is displayed a blurred version of the image is shown. The blurred image is replace by a high res one as soon as that big version has been downloaded. The blurred image is actually a very tiny image that's being sized up.
+When visiting a [Medium](https://medium.com/) blog you might have noticed (on a slower connection) that before a full image is displayed, a blurred version of the image is shown. The blurred image is replaced by a high res one as soon as that big version has been downloaded. The blurred image is actually a very tiny image that's being sized up.
 
 The advantage of displaying a blurred version is that a visitor has a hint of what is going to be displayed very early on and that your page layout is ready right away.
 
 The media library comes with support for progressive image loading out of the box. The tiny blurred image will automatically be generated whenever you leverage responsive images. By replacing the `sizes` attribute on load with JavaScript, the tiny placeholder will be swapped with a bigger version as soon as it is downloaded.
 
-This placeholder is base64-encoded as SVG inside the `srcset` attribute, so it is available in the initial response right away without extra network request.
+This placeholder is base64-encoded as SVG inside the `srcset` attribute, so it is available in the initial response right away without an extra network request.
 The SVG has the exact same ratio as the original image, so the layout should not flicker during the swap.
 
 If you want to leverage responsive images but don't want the progressive image loading, you can set the `responsive_images.use_tiny_placeholders` key in the `media-library` config file to `false`.
@@ -98,7 +98,7 @@ To display a responsive image simply output a `Media` object in a blade view.
 {{ $yourModel->getFirstMedia() }}
 ```
 
-Per image attached to your model the resulting html will look more or less like this:
+Per image attached to your model the resulting HTML will look more or less like this:
 ```html
 <img srcset="/media/1/responsive-images/testimage___media_library_original_188_105.png 188w, /media/1/responsive-images/testimage___media_library_original_158_88.png 158w, /media/1/responsive-images/testimage___media_library_original_132_74.png 132w, /media/1/responsive-images/testimage___media_library_original_110_61.png 110w, data:image/svg+xml;base64,PCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbDpzcGFjZT0icHJlc2VydmUiIHg9IjAiCiB5PSIwIiB2aWV3Qm94PSIwIDAgMTkyMCAxMDgwIj4KCTxpbWFnZSB3aWR0aD0iMTkyMCIgaGVpZ2h0PSIxMDgwIiB4bGluazpocmVmPSJkYXRhOmltYWdlL2pwZWc7YmFzZTY0LC85ai80QUFRU2taSlJnQUJBUUFBQVFBQkFBRC8vZ0E3UTFKRlFWUlBVam9nWjJRdGFuQmxaeUIyTVM0d0lDaDFjMmx1WnlCSlNrY2dTbEJGUnlCMk9UQXBMQ0J4ZFdGc2FYUjVJRDBnT1RBSy85c0FRd0FEQWdJREFnSURBd01EQkFNREJBVUlCUVVFQkFVS0J3Y0dDQXdLREF3TENnc0xEUTRTRUEwT0VRNExDeEFXRUJFVEZCVVZGUXdQRnhnV0ZCZ1NGQlVVLzlzQVF3RURCQVFGQkFVSkJRVUpGQTBMRFJRVUZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVVGQlFVRkJRVUZCUVUvOEFBRVFnQUVnQWdBd0VpQUFJUkFRTVJBZi9FQUI4QUFBRUZBUUVCQVFFQkFBQUFBQUFBQUFBQkFnTUVCUVlIQ0FrS0MvL0VBTFVRQUFJQkF3TUNCQU1GQlFRRUFBQUJmUUVDQXdBRUVRVVNJVEZCQmhOUllRY2ljUlF5Z1pHaENDTkNzY0VWVXRId0pETmljb0lKQ2hZWEdCa2FKU1luS0NrcU5EVTJOemc1T2tORVJVWkhTRWxLVTFSVlZsZFlXVnBqWkdWbVoyaHBhbk4wZFhaM2VIbDZnNFNGaG9lSWlZcVNrNVNWbHBlWW1acWlvNlNscHFlb3FhcXlzN1MxdHJlNHVickN3OFRGeHNmSXljclMwOVRWMXRmWTJkcmg0dVBrNWVibjZPbnE4Zkx6OVBYMjkvajUrdi9FQUI4QkFBTUJBUUVCQVFFQkFRRUFBQUFBQUFBQkFnTUVCUVlIQ0FrS0MvL0VBTFVSQUFJQkFnUUVBd1FIQlFRRUFBRUNkd0FCQWdNUkJBVWhNUVlTUVZFSFlYRVRJaktCQ0JSQ2thR3h3UWtqTTFMd0ZXSnkwUW9XSkRUaEpmRVhHQmthSmljb0tTbzFOamM0T1RwRFJFVkdSMGhKU2xOVVZWWlhXRmxhWTJSbFptZG9hV3B6ZEhWMmQzaDVlb0tEaElXR2g0aUppcEtUbEpXV2w1aVptcUtqcEtXbXA2aXBxckt6dExXMnQ3aTV1c0xEeE1YR3g4akp5dExUMU5YVzE5aloydUxqNU9YbTUranA2dkx6OVBYMjkvajUrdi9hQUF3REFRQUNFUU1SQUQ4QStRZkVPaE1sd05veUs2andibzhjZHUyOEFaSGVvdkxlOWZMOUtTNFM1Z1haREp0cnFxWXlsVGJsSGNpblNyVmw3S1pTOFhhSWthbVJlUlhFU1FCVHhYcC8yS1M0MHIvU01zUUs1TzQ4T003c1VIQjZDdDNWcFZLZnRObVJTOXRTcmV4ZXlPcnRmOVZTUy82NUtLSytHcS94WkgwK0czUnRPUDhBaVduNlZsd0FiUnhSUlhxUi9nSTRLdjhBdkQ5VC85az0iPgoJPC9pbWFnZT4KPC9zdmc+ 32w" onload="if(this.dataset.sized===undefined){this.sizes=Math.ceil(this.getBoundingClientRect().width/window.innerWidth*100)+'vw';this.dataset.sized=''}" sizes="1px" src="/media/1/testimage.png" data-sized="">
 ```

--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -44,7 +44,7 @@ This returns a collection of `MediaCollection` objects.
 
 ## Defining a fallback URL or path
 
-If your media collection does not contain any items, calling `getFirstMediaUrl` or `getFirstMediaPath` will return `null`. You can change this by setting a fallback url and/or path using `useFallbackUrl` and `useFallbackPath`.
+If your media collection does not contain any items, calling `getFirstMediaUrl` or `getFirstMediaPath` will return `null`. You can change this by setting a fallback URL and/or path using `useFallbackUrl` and `useFallbackPath`.
 
 ```php
 use Spatie\MediaLibrary\MediaCollections\File;
@@ -58,7 +58,7 @@ public function registerMediaCollections(): void
 }
 ```
 
-When you use a fallback URL/path, [conversions](https://spatie.be/docs/laravel-medialibrary/v10/converting-images/defining-conversions) will use the default fallback URL/path if the media do not exist. You can pass a conversion name to the second parameter to use fallbacks per conversion.
+When you use a fallback URL/path, [conversions](https://spatie.be/docs/laravel-medialibrary/v10/converting-images/defining-conversions) will use the default fallback URL/path if the media does not exist. You can pass a conversion name to the second parameter to use fallbacks per conversion.
 
 ```php
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -206,7 +206,7 @@ The first time you add a file to the collection it will be stored as usual.
 ```php
 $yourModel->addMedia($pathToImage)->toMediaCollection('avatar');
 $yourModel->getMedia('avatar')->count(); // returns 1
-$yourModel->getFirstMediaUrl('avatar'); // will return an url to the `$pathToImage` file
+$yourModel->getFirstMediaUrl('avatar'); // will return an URL to the `$pathToImage` file
 ```
 
 When adding another file to a single file collection the first one will be deleted.
@@ -215,7 +215,7 @@ When adding another file to a single file collection the first one will be delet
 // this will remove other files in the collection
 $yourModel->addMedia($anotherPathToImage)->toMediaCollection('avatar');
 $yourModel->getMedia('avatar')->count(); // returns 1
-$yourModel->getFirstMediaUrl('avatar'); // will return an url to the `$anotherPathToImage` file
+$yourModel->getFirstMediaUrl('avatar'); // will return an URL to the `$anotherPathToImage` file
 ```
 
 This video shows you a demo of a single file collection.

--- a/docs/working-with-media-collections/defining-media-collections.md
+++ b/docs/working-with-media-collections/defining-media-collections.md
@@ -58,6 +58,49 @@ public function registerMediaCollections(): void
 }
 ```
 
+When you use a fallback URL/path, [conversions](https://spatie.be/docs/laravel-medialibrary/v10/converting-images/defining-conversions) will use the default fallback URL/path if the media do not exist. You can pass a conversion name to the second parameter to use fallbacks per conversion.
+
+```php
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+// ...
+
+public function registerMediaCollections(): void
+{
+    $this
+        ->addMediaCollection('avatar')
+        ->useFallbackUrl('/default_avatar.jpg')
+        ->useFallbackUrl('/default_avatar_thumb.jpg', 'thumb')
+        ->useFallbackPath(public_path('/default_avatar.jpg'))
+        ->useFallbackPath(public_path('/default_avatar_thumb.jpg'), 'thumb')
+        ->registerMediaConversions(function (Media $media) {
+            $this
+                ->addMediaConversion('thumb')
+                ->width(50)
+                ->height(50);
+                
+            $this
+                ->addMediaConversion('thumb_2')
+                ->width(100)
+                ->height(100);
+        });
+}
+```
+
+In this way, the image sizes are always as expected:
+
+```php
+$yourModel->getFirstMediaUrl('avatar'); // default_avatar.jpg
+$yourModel->getFirstMediaUrl('avatar', 'thumb'); // default_avatar_thumb.jpg
+$yourModel->getFirstMediaUrl('avatar', 'thumb_2'); // default_avatar.jpg
+
+// ...
+
+$yourModel->getFirstMediaPath('avatar'); // .../default_avatar.jpg
+$yourModel->getFirstMediaPath('avatar', 'thumb'); // .../default_avatar_thumb.jpg
+$yourModel->getFirstMediaPath('avatar', 'thumb_2'); // .../default_avatar.jpg
+```
+
 ## Only allow certain files in a collection
 
 You can pass a callback to `acceptsFile` that will check if a file is allowed into the collection. In this example we only accept `jpeg` files.

--- a/src/Conversions/Actions/PerformConversionAction.php
+++ b/src/Conversions/Actions/PerformConversionAction.php
@@ -21,7 +21,7 @@ class PerformConversionAction
 
         $copiedOriginalFile = $imageGenerator->convert($copiedOriginalFile, $conversion);
 
-        if (!$copiedOriginalFile) {
+        if (! $copiedOriginalFile) {
             return;
         }
 

--- a/src/Conversions/Actions/PerformConversionAction.php
+++ b/src/Conversions/Actions/PerformConversionAction.php
@@ -17,11 +17,15 @@ class PerformConversionAction
         Media $media,
         string $copiedOriginalFile
     ) {
-        event(new ConversionWillStart($media, $conversion, $copiedOriginalFile));
-
         $imageGenerator = ImageGeneratorFactory::forMedia($media);
 
         $copiedOriginalFile = $imageGenerator->convert($copiedOriginalFile, $conversion);
+
+        if (!$copiedOriginalFile) {
+            return;
+        }
+
+        event(new ConversionWillStart($media, $conversion, $copiedOriginalFile));
 
         $manipulationResult = (new PerformManipulationsAction())->execute($media, $conversion, $copiedOriginalFile);
 

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -92,6 +92,7 @@ class FileManipulator
 
         /** @var PerformConversionsJob $job */
         $job = (new $performConversionsJobClass($conversions, $media, $onlyMissing))
+            ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue(config('media-library.queue_name'));
 
         dispatch($job);
@@ -116,6 +117,7 @@ class FileManipulator
 
         /** @var GenerateResponsiveImagesJob $job */
         $job = (new $generateResponsiveImagesJobClass($media))
+            ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue(config('media-library.queue_name'));
 
         dispatch($job);

--- a/src/Conversions/ImageGenerators/ImageGenerator.php
+++ b/src/Conversions/ImageGenerators/ImageGenerator.php
@@ -11,7 +11,7 @@ abstract class ImageGenerator
     /*
      * This function should return a path to an image representation of the given file.
      */
-    abstract public function convert(string $file, Conversion $conversion = null): string;
+    abstract public function convert(string $file, Conversion $conversion = null): ?string;
 
     public function canConvert(Media $media): bool
     {

--- a/src/Conversions/ImageGenerators/Video.php
+++ b/src/Conversions/ImageGenerators/Video.php
@@ -19,7 +19,7 @@ class Video extends ImageGenerator
 
         $video = $ffmpeg->open($file);
 
-        if (!($video instanceof FFMpegVideo)) {
+        if (! ($video instanceof FFMpegVideo)) {
             return null;
         }
 

--- a/src/Conversions/ImageGenerators/Video.php
+++ b/src/Conversions/ImageGenerators/Video.php
@@ -4,25 +4,31 @@ namespace Spatie\MediaLibrary\Conversions\ImageGenerators;
 
 use FFMpeg\Coordinate\TimeCode;
 use FFMpeg\FFMpeg;
+use FFMpeg\Media\Video as FFMpegVideo;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Conversions\Conversion;
 
 class Video extends ImageGenerator
 {
-    public function convert(string $file, Conversion $conversion = null): string
+    public function convert(string $file, Conversion $conversion = null): ?string
     {
-        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
-
         $ffmpeg = FFMpeg::create([
             'ffmpeg.binaries' => config('media-library.ffmpeg_path'),
             'ffprobe.binaries' => config('media-library.ffprobe_path'),
         ]);
 
         $video = $ffmpeg->open($file);
+
+        if (!($video instanceof FFMpegVideo)) {
+            return null;
+        }
+
         $duration = $ffmpeg->getFFProbe()->format($file)->get('duration');
 
         $seconds = $conversion ? $conversion->getExtractVideoFrameAtSecond() : 0;
         $seconds = $duration <= $seconds ? 0 : $seconds;
+
+        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
 
         $frame = $video->frame(TimeCode::fromSeconds($seconds));
         $frame->save($imageFile);

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -293,7 +293,7 @@ trait InteractsWithMedia
         $media = $this->getFirstMedia($collectionName);
 
         if (! $media) {
-            return $this->getFallbackMediaUrl($collectionName) ?: '';
+            return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
         }
 
         if ($conversionName !== '' && ! $media->hasGeneratedConversion($conversionName)) {
@@ -317,7 +317,7 @@ trait InteractsWithMedia
         $media = $this->getFirstMedia($collectionName);
 
         if (! $media) {
-            return $this->getFallbackMediaUrl($collectionName) ?: '';
+            return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
         }
 
         if ($conversionName !== '' && ! $media->hasGeneratedConversion($conversionName)) {
@@ -342,14 +342,26 @@ trait InteractsWithMedia
             ->first(fn (MediaCollection $collection) => $collection->name === $collectionName);
     }
 
-    public function getFallbackMediaUrl(string $collectionName = 'default'): string
+    public function getFallbackMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return optional($this->getMediaCollection($collectionName))->fallbackUrl ?? '';
+        $fallbackUrls = optional($this->getMediaCollection($collectionName))->fallbackUrls;
+
+        if (in_array($conversionName, ['', 'default'], true)) {
+            return $fallbackUrls['default'] ?? '';
+        }
+
+        return $fallbackUrls[$conversionName] ?? $fallbackUrls['default'] ?? '';
     }
 
-    public function getFallbackMediaPath(string $collectionName = 'default'): string
+    public function getFallbackMediaPath(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return optional($this->getMediaCollection($collectionName))->fallbackPath ?? '';
+        $fallbackPaths = optional($this->getMediaCollection($collectionName))->fallbackPaths;
+
+        if (in_array($conversionName, ['', 'default'], true)) {
+            return $fallbackPaths['default'] ?? '';
+        }
+
+        return $fallbackPaths[$conversionName] ?? $fallbackPaths['default'] ?? '';
     }
 
     /*
@@ -362,7 +374,7 @@ trait InteractsWithMedia
         $media = $this->getFirstMedia($collectionName);
 
         if (! $media) {
-            return $this->getFallbackMediaPath($collectionName) ?: '';
+            return $this->getFallbackMediaPath($collectionName, $conversionName) ?: '';
         }
 
         if ($conversionName !== '' && ! $media->hasGeneratedConversion($conversionName)) {

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -472,7 +472,7 @@ class FileAdder
             $collectionMedia = $this->subject->fresh()->getMedia($media->collection_name);
 
             if ($collectionMedia->count() > $collectionSizeLimit) {
-                $model->clearMediaCollectionExcept($media->collection_name, $collectionMedia->reverse()->take($collectionSizeLimit));
+                $model->clearMediaCollectionExcept($media->collection_name, $collectionMedia->slice(-$collectionSizeLimit, $collectionSizeLimit));
             }
         }
     }

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -457,6 +457,10 @@ class FileAdder
 
             $job = new $generateResponsiveImagesJobClass($media);
 
+            if ($customConnection = config('media-library.queue_connection_name')) {
+                $job->onConnection($customConnection);
+            }
+
             if ($customQueue = config('media-library.queue_name')) {
                 $job->onQueue($customQueue);
             }

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -396,6 +396,7 @@ class FileAdder
 
     public function defaultSanitizer(string $fileName): string
     {
+        $fileName = preg_replace('#\p{C}+#u', '', $fileName);
         return str_replace(['#', '/', '\\', ' '], '-', $fileName);
     }
 

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -397,6 +397,7 @@ class FileAdder
     public function defaultSanitizer(string $fileName): string
     {
         $fileName = preg_replace('#\p{C}+#u', '', $fileName);
+
         return str_replace(['#', '/', '\\', ' '], '-', $fileName);
     }
 

--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -241,7 +241,7 @@ class Filesystem
 
         $oldMedia = (clone $media)->fill($media->getOriginal());
 
-        if ($oldMedia->getPath() === $media->getPath()) {
+        if ($factory->getPath($oldMedia) === $factory->getPath($media)) {
             return;
         }
 

--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -313,7 +313,7 @@ class Filesystem
             ? $media->conversions_disk
             : $media->disk;
 
-        if (! in_array($diskDriverName, ['s3'], true)) {
+        if (! in_array($diskDriverName, ['s3', 'gcs'], true)) {
             $this->filesystem->disk($diskName)->makeDirectory($directory);
         }
 

--- a/src/MediaCollections/MediaCollection.php
+++ b/src/MediaCollections/MediaCollection.php
@@ -28,9 +28,11 @@ class MediaCollection
 
     public bool $singleFile = false;
 
-    public string $fallbackUrl = '';
+    /** @var array<string, string> */
+    public array $fallbackUrls = [];
 
-    public string $fallbackPath = '';
+    /** @var array<string, string> */
+    public array $fallbackPaths = [];
 
     public function __construct(
         public string $name
@@ -97,16 +99,24 @@ class MediaCollection
         $this->mediaConversionRegistrations = $mediaConversionRegistrations;
     }
 
-    public function useFallbackUrl(string $url): self
+    public function useFallbackUrl(string $url, string $conversionName = ''): self
     {
-        $this->fallbackUrl = $url;
+        if ($conversionName === '') {
+            $conversionName = 'default';
+        }
+
+        $this->fallbackUrls[$conversionName] = $url;
 
         return $this;
     }
 
-    public function useFallbackPath(string $path): self
+    public function useFallbackPath(string $path, string $conversionName = ''): self
     {
-        $this->fallbackPath = $path;
+        if ($conversionName === '') {
+            $conversionName = 'default';
+        }
+
+        $this->fallbackPaths[$conversionName] = $path;
 
         return $this;
     }

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -441,7 +441,7 @@ class Media extends Model implements Responsable, Htmlable, Attachable
         $attachment = Attachment::fromStorageDisk($this->disk, $this->getPathRelativeToRoot($conversion))->as($this->file_name);
 
         if ($this->mime_type) {
-            $attachment->withMime($this->mime);
+            $attachment->withMime($this->mime_type);
         }
 
         return $attachment;

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -203,13 +203,23 @@ it('can get the path to first media in a collection', function () {
     expect($this->testModel->getFirstMediaPath('images'))->toEqual($firstMedia->getPath());
 });
 
-it('can get the default path to the first media in a collection', function () {
-    expect($this->testModel->getFirstMediaPath('avatar'))->toEqual('/default-path.jpg');
-});
+it('can get the default path to the first media in a collection', function ($conversionName, $expectedPath) {
+    expect($this->testModel->getFirstMediaPath('avatar', $conversionName))->toEqual($expectedPath);
+})->with([
+    ['', '/default-path.jpg'],
+    ['default', '/default-path.jpg'],
+    ['foo', '/default-path.jpg'],
+    ['avatar_thumb', '/default-avatar-thumb-path.jpg'],
+]);
 
-it('can get the default url to the first media in a collection', function () {
-    expect($this->testModel->getFirstMediaUrl('avatar'))->toEqual('/default-url.jpg');
-});
+it('can get the default url to the first media in a collection', function ($conversionName, $expectedUrl) {
+    expect($this->testModel->getFirstMediaUrl('avatar', $conversionName))->toEqual($expectedUrl);
+})->with([
+    ['', '/default-url.jpg'],
+    ['default', '/default-url.jpg'],
+    ['foo', '/default-url.jpg'],
+    ['avatar_thumb', '/default-avatar-thumb-url.jpg'],
+]);
 
 it('can get the default path to the first media in a collection if conversion not marked as generated yet', function () {
     $media = $this

--- a/tests/MediaCollections/FileAdderTest.php
+++ b/tests/MediaCollections/FileAdderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\MediaCollections;
+
+use Spatie\MediaLibrary\MediaCollections\FileAdder;
+
+it('sanitizes filenames correctly', function () {
+    /** @var FileAdder $adder */
+    $adder = app(FileAdder::class);
+
+    expect($adder->defaultSanitizer('valid-filename.jpg'))
+        ->toEqual('valid-filename.jpg');
+
+    expect($adder->defaultSanitizer('test one.pdf'))
+        ->toEqual('test-one.pdf');
+
+    expect($adder->defaultSanitizer('test#one.pdf'))
+        ->toEqual('test-one.pdf');
+
+    expect($adder->defaultSanitizer('some/test/file.pdf'))
+        ->toEqual('some-test-file.pdf');
+
+    expect($adder->defaultSanitizer('Scan-‎9‎.‎14‎.‎2022-‎7‎.‎23‎.‎28.pdf'))
+        ->toEqual('Scan-9.14.2022-7.23.28.pdf');
+});

--- a/tests/TestSupport/TestModels/TestModel.php
+++ b/tests/TestSupport/TestModels/TestModel.php
@@ -21,6 +21,8 @@ class TestModel extends Model implements HasMedia
         $this
             ->addMediaCollection('avatar')
             ->useFallbackUrl('/default-url.jpg')
-            ->useFallbackPath('/default-path.jpg');
+            ->useFallbackUrl('/default-avatar-thumb-url.jpg', 'avatar_thumb')
+            ->useFallbackPath('/default-path.jpg')
+            ->useFallbackPath('/default-avatar-thumb-path.jpg', 'avatar_thumb');
     }
 }


### PR DESCRIPTION
This is an update to #3031 as the original author was unable to complete the requirements for the PR, but the credit for this functionality belongs to @tommica, the original author.

This PR updates the #3031 PR functionality to include unit tests.

Original description:

Update the default filename sanitizer to handle funky whitespace characters in files - I had a case where a file was being uploaded, and it kepts throwing Flysystems `CorruptedPathDetected` exception. Not sure if copy-pasting the filename to github keeps the characters there: `Scan-‎9‎.‎14‎.‎2022-‎7‎.‎23‎.‎28.pdf`

![Screenshot 2022-09-14 at 08 57 37](https://user-images.githubusercontent.com/1391027/190083324-7387392d-b7de-4397-a1fe-735aaf86630c.png)

