### PR TITLE
Add Additional Filename Sanitization

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -396,6 +396,7 @@ class FileAdder
 
     public function defaultSanitizer(string $fileName): string
     {
+        $fileName = preg_replace('#\p{C}+#u', '', $fileName);
         return str_replace(['#', '/', '\\', ' '], '-', $fileName);
     }
 

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -397,6 +397,7 @@ class FileAdder
     public function defaultSanitizer(string $fileName): string
     {
         $fileName = preg_replace('#\p{C}+#u', '', $fileName);
+
         return str_replace(['#', '/', '\\', ' '], '-', $fileName);
     }
 

--- a/tests/MediaCollections/FileAdderTest.php
+++ b/tests/MediaCollections/FileAdderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\MediaCollections;
+
+use Spatie\MediaLibrary\MediaCollections\FileAdder;
+
+it('sanitizes filenames correctly', function () {
+    /** @var FileAdder $adder */
+    $adder = app(FileAdder::class);
+
+    expect($adder->defaultSanitizer('valid-filename.jpg'))
+        ->toEqual('valid-filename.jpg');
+
+    expect($adder->defaultSanitizer('test one.pdf'))
+        ->toEqual('test-one.pdf');
+
+    expect($adder->defaultSanitizer('test#one.pdf'))
+        ->toEqual('test-one.pdf');
+
+    expect($adder->defaultSanitizer('some/test/file.pdf'))
+        ->toEqual('some-test-file.pdf');
+
+    expect($adder->defaultSanitizer('Scan-‎9‎.‎14‎.‎2022-‎7‎.‎23‎.‎28.pdf'))
+        ->toEqual('Scan-9.14.2022-7.23.28.pdf');
+});


### PR DESCRIPTION
This is an update to #3031 as the original author was unable to complete the requirements for the PR, but the credit for this functionality belongs to @tommica, the original author.

This PR updates the #3031 PR functionality to include unit tests.

Original description:

Update the default filename sanitizer to handle funky whitespace characters in files - I had a case where a file was being uploaded, and it kepts throwing Flysystems `CorruptedPathDetected` exception. Not sure if copy-pasting the filename to github keeps the characters there: `Scan-‎9‎.‎14‎.‎2022-‎7‎.‎23‎.‎28.pdf`

![Screenshot 2022-09-14 at 08 57 37](https://user-images.githubusercontent.com/1391027/190083324-7387392d-b7de-4397-a1fe-735aaf86630c.png)

