### PR TITLE
Issue delete command once per unique directory

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -200,6 +200,7 @@ class Filesystem
         $responsiveImagesDirectory = $this->getMediaDirectory($media, 'responsiveImages');
 
         collect([$mediaDirectory, $conversionsDirectory, $responsiveImagesDirectory])
+            ->unique()
             ->each(function (string $directory) use ($media) {
                 try {
                     $this->filesystem->disk($media->conversions_disk)->deleteDirectory($directory);


### PR DESCRIPTION
If a custom PathGenerator has been set which stores conversions and/or responsive images in the same directory, there is no point making the delete call to that directory multiple times.