### PR TITLE
Allow to clean orphaned media when the `registerMediaConversionsUsingModelInstance` property is set to `true` on the model

### DIFF
--- a/src/Conversions/ConversionCollection.php
+++ b/src/Conversions/ConversionCollection.php
@@ -60,7 +60,7 @@ class ConversionCollection extends Collection
          * instance so conversion parameters can depend on model
          * properties. This will causes extra queries.
          */
-        if ($model->registerMediaConversionsUsingModelInstance) {
+        if ($model->registerMediaConversionsUsingModelInstance && $media->model) {
             $model = $media->model;
 
             $model->mediaConversions = [];

--- a/tests/Conversions/Commands/CleanConversionsTest.php
+++ b/tests/Conversions/Commands/CleanConversionsTest.php
@@ -30,6 +30,11 @@ beforeEach(function () {
         ->preservingOriginal()
         ->toMediaCollection('collection2');
 
+    $this->media['model3']['collection1'] = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('collection1');
+
     mkdir($this->getMediaDirectory("{$this->media['model1']['collection1']->id}/conversions"));
     mkdir($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/conversions"));
 
@@ -140,6 +145,15 @@ it('can clean orphan files in the media disk', function () {
 
     $this->assertFileDoesNotExist($this->getMediaDirectory($this->media['model1']['collection1']->id));
     expect($this->getMediaDirectory("{$this->media['model1']['collection2']->id}/test.jpg"))->toBeFile();
+});
+
+it('can clean orphan files using `registerMediaConversionsUsingModelInstance` in the media disk', function () {
+    // Dirty delete
+    DB::table('media')->delete($this->media['model3']['collection1']->id);
+
+    $this->artisan('media-library:clean');
+
+    $this->assertFileDoesNotExist($this->getMediaDirectory($this->media['model3']['collection1']->id));
 });
 
 it('can clean responsive images for deprecated conversions', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,7 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionQueued;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionsOnOtherDisk;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionUsingModelInstance;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMorphMap;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMultipleConversions;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
@@ -43,6 +44,8 @@ abstract class TestCase extends Orchestra
 
     protected TestModelWithConversionsOnOtherDisk $testModelWithConversionsOnOtherDisk;
 
+    protected TestModelWithConversionUsingModelInstance $testModelWithConversionUsingModelInstance;
+
     protected function setUp(): void
     {
         $this->loadEnvironmentVariables();
@@ -63,6 +66,7 @@ abstract class TestCase extends Orchestra
         $this->testModelWithMorphMap = TestModelWithMorphMap::first();
         $this->testModelWithResponsiveImages = TestModelWithResponsiveImages::first();
         $this->testModelWithConversionsOnOtherDisk = TestModelWithConversionsOnOtherDisk::first();
+        $this->testModelWithConversionUsingModelInstance = TestModelWithConversionUsingModelInstance::first();
     }
 
     protected function loadEnvironmentVariables()

--- a/tests/TestSupport/TestModels/TestModelWithConversionUsingModelInstance.php
+++ b/tests/TestSupport/TestModels/TestModelWithConversionUsingModelInstance.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class TestModelWithConversionUsingModelInstance extends TestModelWithConversion
+{
+    public $registerMediaConversionsUsingModelInstance = true;
+
+    public function registerMediaConversions(Media $media = null): void
+    {
+        $this
+            ->addMediaConversion('lazy-conversion')
+            ->useLoadingAttributeValue('lazy')
+            ->nonQueued();
+
+        $this
+            ->addMediaConversion('eager-conversion')
+            ->useLoadingAttributeValue('eager')
+            ->nonQueued();
+    }
+}


### PR DESCRIPTION
This is a fix for the `media-library:clean` command.

Without the check if the model exists, the `$model->mediaConversions = []` would fail because `$model` would be `null`.

When `$model->registerMediaConversionsUsingModelInstance` is false, the `$media->model` check will not execute and not result in an extra query.