### PR TITLE
Fix data corruption bug when storage disk becomes invalid

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -447,7 +447,7 @@ class FileAdder
         }
 
         if (! $addedMediaSuccessfully) {
-            $model->media()->delete($media->id);
+            $media->delete();
 
             throw DiskCannotBeAccessed::create($media->disk);
         }

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -598,6 +598,13 @@ it('can add an upload to the media library using dot notation', function () {
 });
 
 it('will throw and exception and not create a record in database if file cannot be added', function () {
+
+    $this->testModel
+            ->addMedia($this->getTestPng())
+            ->toMediaCollection();
+
+    expect(Media::count())->toBe(1);
+
     config()->set('filesystems.disks.invalid_disk', [
         'driver' => 's3',
         'secret' => 'test',
@@ -612,5 +619,5 @@ it('will throw and exception and not create a record in database if file cannot 
             ->toMediaCollection('default', 'invalid_disk')
     )->toThrow(DiskCannotBeAccessed::class);
 
-    expect(Media::count())->toBe(0);
+    expect(Media::count())->toBe(1);
 });

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -606,9 +606,11 @@ it('will throw and exception and not create a record in database if file cannot 
         'bucket' => 'test',
     ]);
 
-    $this->testModel
-        ->addMedia($this->getTestJpg())
-        ->toMediaCollection('default', 'invalid_disk');
+    expect(
+        fn () => $this->testModel
+            ->addMedia($this->getTestJpg())
+            ->toMediaCollection('default', 'invalid_disk')
+    )->toThrow(DiskCannotBeAccessed::class);
 
     expect(Media::count())->toBe(0);
-})->throws(DiskCannotBeAccessed::class);
+});


### PR DESCRIPTION
This fixes a bug when a storage disk becomes invalid. The [FileAdder.php#L450](https://github.com/spatie/laravel-medialibrary/blob/main/src/MediaCollections/FileAdder.php#L450) would "redo" already saved records in DB, unfortunately, the produced SQL delete query scopes to **all media belonging to a model** (not by id).

While `$model->media()->delete($media->id)` call looks ok, for some reason it actually ignores specific media id and scopes to all.

The was already a test case for this scenario, but it would run on the assumption there are no other media attached. So it would produce a false positive outcome.

Sample delete query **before**:
```
DELETE FROM `media`
WHERE `media`.`model_type` = 'App\\Models\\User' and `media`.`model_id` = 2 and `media`.`model_id` IS not NULL;
```

Sample delete query **after**:

```
DELETE FROM `media`
WHERE `id` = 16
```