### PR TITLE
Remove failed DB record even when using SoftDeletes

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -447,7 +447,7 @@ class FileAdder
         }
 
         if (! $addedMediaSuccessfully) {
-            $media->delete();
+            $media->forceDelete();
 
             throw DiskCannotBeAccessed::create($media->disk);
         }


### PR DESCRIPTION
This is a tiny improvement on top of #3139. Basically, on the backtrack scenario, the failed DB record should be removed even when using SoftDeletes (i.e. custom Media model).

SoftDeletes are for _intended delete but keep in the trashcan scenario_. In this specific case, it is cleaning up after a failure.