### PR TITLE
Ability to use morphed map model with custom path generator

### DIFF
--- a/src/Support/PathGenerator/PathGeneratorFactory.php
+++ b/src/Support/PathGenerator/PathGeneratorFactory.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\Support\PathGenerator;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidPathGenerator;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
@@ -21,7 +22,7 @@ class PathGeneratorFactory
         $defaultPathGeneratorClass = config('media-library.path_generator');
 
         foreach (config('media-library.custom_path_generators', []) as $modelClass => $customPathGeneratorClass) {
-            if (is_a($media->model_type, $modelClass, true)) {
+            if (is_a($media->model_type, $modelClass, true) || $media->model_type === $modelClass) {
                 return $customPathGeneratorClass;
             }
         }

--- a/tests/Support/PathGenerator/BasePathGeneratorTest.php
+++ b/tests/Support/PathGenerator/BasePathGeneratorTest.php
@@ -49,3 +49,15 @@ it('can use a custom path generator on the model', function () {
 
     expect($media->getUrl())->toEqual('/media/c4ca4238a0b923820dcc509a6f75849b/test.jpg');
 });
+
+it('can use a custom path generator on a morph map model', function () {
+    config()->set('media-library.custom_path_generators', [
+        'test-model-with-morph-map' => CustomPathGenerator::class,
+    ]);
+
+    $media = $this->testModelWithMorphMap
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection();
+
+    expect($media->getUrl())->toEqual('/media/c4ca4238a0b923820dcc509a6f75849b/test.jpg');
+});


### PR DESCRIPTION
This add the ability to to use morphed map model enforced by Eloquent enforce morph map
```php 
Relation::enforceMorphMap([
    'user' => User::class,       
 ]);
```

Now you can do:
```php
'custom_path_generators' => [
        'user' => \App\Domain\Media\Support\UserPathGenerator::class,
    ],
```