### PR TITLE
Prevent implicit conversion from float to int in FileSizeOptimizedWidthCalculator

### DIFF
--- a/src/ResponsiveImages/WidthCalculator/FileSizeOptimizedWidthCalculator.php
+++ b/src/ResponsiveImages/WidthCalculator/FileSizeOptimizedWidthCalculator.php
@@ -35,7 +35,7 @@ class FileSizeOptimizedWidthCalculator implements WidthCalculator
 
             $newWidth = (int) floor(sqrt(($predictedFileSize / $pixelPrice) / $ratio));
 
-            if ($this->finishedCalculating($predictedFileSize, $newWidth)) {
+            if ($this->finishedCalculating((int) $predictedFileSize, $newWidth)) {
                 return $targetWidths;
             }
 


### PR DESCRIPTION
Hi,

Super simple PR to prevent  implicit conversion from float to int and so, prevent a warning to be log.
Example of a warning:
> Implicit conversion from float 7616.5962599999975 to int loses precision in ...\vendor\spatie\laravel-medialibrary\src\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator.php on line 46