### PR TITLE
fix: publish migration file only if it does not exist

### DIFF
--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Spatie\MediaLibrary\Conversions\Commands\RegenerateCommand;
 use Spatie\MediaLibrary\MediaCollections\Commands\CleanCommand;
 use Spatie\MediaLibrary\MediaCollections\Commands\ClearCommand;
@@ -44,7 +45,7 @@ class MediaLibraryServiceProvider extends ServiceProvider
             __DIR__.'/../config/media-library.php' => config_path('media-library.php'),
         ], 'config');
 
-        if (! class_exists('CreateMediaTable')) {
+        if ($this->migrationDoesntExist()) {
             $this->publishes([
                 __DIR__.'/../database/migrations/create_media_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_media_table.php'),
             ], 'migrations');
@@ -70,5 +71,22 @@ class MediaLibraryServiceProvider extends ServiceProvider
             'command.media-library:clear',
             'command.media-library:clean',
         ]);
+    }
+
+    protected function migrationExist(): bool
+    {
+        if (class_exists('CreateMediaTable')) {
+            return true;
+        }
+
+        return ! blank(
+            collect(scandir(database_path('migrations/')))
+                ->first(fn ($fileName) => Str::of($fileName)->contains('_create_media_table'))
+            );
+    }
+
+    protected function migrationDoesntExist(): bool
+    {
+        return ! $this->migrationExist();
     }
 }


### PR DESCRIPTION
With the adaptation of the migration file in the pull request #2907, the check in the `MediaLibraryServiceProvider` whether the class `CreateMediaTable` already exists is no longer effective, because the class is omitted in the above pull request, so that a new migration file is always created when the publication is executed, regardless of whether a migration file already exists.

This pull request now provides a method that checks whether the `CreateMediaTable` class exists or whether a migration with the string `_create_media_table` exists in the migration directory. If either case occurs, a new migration file is not created.  

The error occurred when testing a private package and using the `Illuminate\Foundation\Testing\LazilyRefreshDatabase` trait.