### PR TITLE
Add Conditionable to Conversion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "ext-fileinfo": "*",
         "ext-json": "*",
         "illuminate/bus": "^9.18|^10.0",
+        "illuminate/conditionable": "9.18|^10.0",
         "illuminate/console": "^9.18|^10.0",
         "illuminate/database": "^9.18|^10.0",
         "illuminate/pipeline": "^9.18|^10.0",

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Conversions;
 
 use BadMethodCallException;
+use Illuminate\Support\Traits\Conditionable;
 use Spatie\Image\Manipulations;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
@@ -10,6 +11,8 @@ use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
 /** @mixin \Spatie\Image\Manipulations */
 class Conversion
 {
+    use Conditionable;
+    
     protected FileNamer $fileNamer;
 
     protected float $extractVideoFrameAtSecond = 0;


### PR DESCRIPTION
I currently have the need to adjust the format of conversions depending on the original image format.

While currently it is possible to do something like this:

```php
public function registerMediaConversions(Media $media = null): void
{
    if ($media->mime_type === 'image/svg+xml') {
        $this
            ->addMediaConversion('thumb')
            ->fit(Manipulations::FIT_CONTAIN, 300, 200)
            // other methods omitted for brevity
            ->format(Manipulations::FORMAT_PNG);
    } else {
        $this
            ->addMediaConversion('thumb')
            ->fit(Manipulations::FIT_CONTAIN, 300, 200)
            // other methods omitted for brevity
            ->keepOriginalImageFormat();
    }
```

Adding the Laravel Conditionable Trait allow for something cleaner:

```php
public function registerMediaConversions(Media $media = null): void
{
    $this
        ->addMediaConversion('thumb')
        ->fit(Manipulations::FIT_CONTAIN, 300, 200)
        // other methods omitted for brevity
        ->when(
            $media->mime_type === 'image/svg+xml',
            fn ($conversion) => $conversion->format(Manipulations::FORMAT_PNG),
            fn ($conversion) => $conversion->keepOriginalImageFormat()
        );
```