### PR TITLE
update config instructions for custom_path_generators

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -70,6 +70,8 @@ return [
      */
     'custom_path_generators' => [
         // Model::class => PathGenerator::class
+        // or
+        // 'model_morph_alias' => PathGenerator::class
     ],
 
     /*


### PR DESCRIPTION
It is not obvious that I need to use a string if I have declared `Relation::morphMap([...])`