### PR TITLE
Use MimeTypes guessMimeType for better and more extensible MimeType detection

### DIFF
--- a/src/Support/File.php
+++ b/src/Support/File.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\MediaLibrary\Support;
 
-use Finfo;
 use Symfony\Component\Mime\MimeTypes;
 
 class File

--- a/src/Support/File.php
+++ b/src/Support/File.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Support;
 
 use Finfo;
+use Symfony\Component\Mime\MimeTypes;
 
 class File
 {
@@ -23,8 +24,6 @@ class File
 
     public static function getMimeType(string $path): string
     {
-        $finfo = new Finfo(FILEINFO_MIME_TYPE);
-
-        return $finfo->file($path);
+        return MimeTypes::getDefault()->guessMimeType($path);
     }
 }


### PR DESCRIPTION
Rather than calling for and using `Finfo` directly, this modifies the `Support/File@getMimeType` method to instead call `Symfony\Component\Mime\MimeTypes@guessMimeType`. Since by default the `vendor/symfony/mime/FileinfoMimeTypeGuesser` is registered last, it will be used. Resulting in the same functionality as before by default with a few added benefits.

First, the default and first Guesser `vendor/symfony/mime/FileinfoMimeTypeGuesser`, while virtually the same as the original implementation as it calls `finfo` in almost the same way, should be slightly more robust.

Second, for any reason if the `vendor/symfony/mime/FileinfoMimeTypeGuesser` is unable to be used or fails to recognize the `mime_type` the `vendor/symfony/mime/FileBinaryMimeTypeGuesser` is called.

Finally, the most important benefit, is this allows for extensibility in `mime_type` detection. A user can register a new Guesser which will be used first.
There are many reasons a user would want to do this, one of the most prominent and my personal use case is making and using a custom Guesser (using [getID3](https://github.com/JamesHeinrich/getID3)) that is better at recognizing `mp3`s. The default finfo and binary scan, while good for most use-cases, is not great at detecting all `mp3`s. With this change a User can add a custom Guesser to work how ever they need.

No additional tests were added as `tests/Support/FileTest.php` should be sufficient as it is still passing after this change. Though I can also add a test for registering a new Guesser if that is wanted.