### PR TITLE
Fixed custom path generators for Media with morphed map relations

### DIFF
--- a/src/Support/PathGenerator/PathGeneratorFactory.php
+++ b/src/Support/PathGenerator/PathGeneratorFactory.php
@@ -22,7 +22,12 @@ class PathGeneratorFactory
         $defaultPathGeneratorClass = config('media-library.path_generator');
 
         foreach (config('media-library.custom_path_generators', []) as $modelClass => $customPathGeneratorClass) {
-            if (is_a($media->model_type, $modelClass, true)
+            if (
+                // model doesn't have morphMap
+                is_a($media->model_type, $modelClass, true)
+                // config is set via morphMap alias
+                || $media->model_type === $modelClass
+                // config is set via morphMap class name
                 || is_a((string)Relation::getMorphedModel($media->model_type), $modelClass, true)
             ) {
                 return $customPathGeneratorClass;

--- a/src/Support/PathGenerator/PathGeneratorFactory.php
+++ b/src/Support/PathGenerator/PathGeneratorFactory.php
@@ -22,7 +22,7 @@ class PathGeneratorFactory
         $defaultPathGeneratorClass = config('media-library.path_generator');
 
         foreach (config('media-library.custom_path_generators', []) as $modelClass => $customPathGeneratorClass) {
-            if (static::assertMediaModelTypeEqualsTo($media, $modelClass)) {
+            if (static::mediaBelongToModelClass($media, $modelClass)) {
                 return $customPathGeneratorClass;
             }
         }
@@ -30,7 +30,7 @@ class PathGeneratorFactory
         return $defaultPathGeneratorClass;
     }
 
-    protected static function assertMediaModelTypeEqualsTo(Media $media, string $modelClass): bool
+    protected static function mediaBelongToModelClass(Media $media, string $modelClass): bool
     {
         // model doesn't have morphMap, so morph type and class are equal
         if (is_a($media->model_type, $modelClass, true)) {

--- a/src/Support/PathGenerator/PathGeneratorFactory.php
+++ b/src/Support/PathGenerator/PathGeneratorFactory.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\Support\PathGenerator;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidPathGenerator;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
@@ -21,7 +22,9 @@ class PathGeneratorFactory
         $defaultPathGeneratorClass = config('media-library.path_generator');
 
         foreach (config('media-library.custom_path_generators', []) as $modelClass => $customPathGeneratorClass) {
-            if (is_a($media->model_type, $modelClass, true) || $media->model_type === $modelClass) {
+            if (is_a($media->model_type, $modelClass, true)
+                || is_a((string)Relation::getMorphedModel($media->model_type), $modelClass, true)
+            ) {
                 return $customPathGeneratorClass;
             }
         }

--- a/tests/Support/PathGenerator/BasePathGeneratorTest.php
+++ b/tests/Support/PathGenerator/BasePathGeneratorTest.php
@@ -4,6 +4,7 @@ use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
 use Spatie\MediaLibrary\Tests\Support\PathGenerator\CustomPathGenerator;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMorphMap;
 
 beforeEach(function () {
     $this->config = app('config');
@@ -53,6 +54,18 @@ it('can use a custom path generator on the model', function () {
 it('can use a custom path generator on a morph map model', function () {
     config()->set('media-library.custom_path_generators', [
         'test-model-with-morph-map' => CustomPathGenerator::class,
+    ]);
+
+    $media = $this->testModelWithMorphMap
+        ->addMedia($this->getTestFilesDirectory('test.jpg'))
+        ->toMediaCollection();
+
+    expect($media->getUrl())->toEqual('/media/c4ca4238a0b923820dcc509a6f75849b/test.jpg');
+});
+
+it('can use a custom path generator on a morph map model via class', function () {
+    config()->set('media-library.custom_path_generators', [
+        TestModelWithMorphMap::class => CustomPathGenerator::class,
     ]);
 
     $media = $this->testModelWithMorphMap


### PR DESCRIPTION
Hi, we already reported this issue for v9 version and created the Pull Request for v9. However, you asked then to create the PR for v10 first.

Finally, I had time to do that.

**Issue:**
When using custom path generators for models and Media model has morph map strings, not Model names it doesn't work.


Furthermore, I found the related discussions and I guess you had similar PR in the past:
https://github.com/spatie/laravel-medialibrary/discussions/3034