### PR TITLE
fix: widen version constraint for illuminate/conditionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 10.7.13 - 2023-03-06
+
+### What's Changed
+
+- Add Conditionable to Conversion by @tomwelch in https://github.com/spatie/laravel-medialibrary/pull/3162
+
+### New Contributors
+
+- @tomwelch made their first contribution in https://github.com/spatie/laravel-medialibrary/pull/3162
+
+**Full Changelog**: https://github.com/spatie/laravel-medialibrary/compare/10.7.12...10.7.13
+
 ## 10.7.12 - 2023-03-06
 
 ### What's Changed

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-fileinfo": "*",
         "ext-json": "*",
         "illuminate/bus": "^9.18|^10.0",
-        "illuminate/conditionable": "9.18|^10.0",
+        "illuminate/conditionable": "^9.18|^10.0",
         "illuminate/console": "^9.18|^10.0",
         "illuminate/database": "^9.18|^10.0",
         "illuminate/pipeline": "^9.18|^10.0",

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -12,7 +12,7 @@ use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
 class Conversion
 {
     use Conditionable;
-    
+
     protected FileNamer $fileNamer;
 
     protected float $extractVideoFrameAtSecond = 0;


### PR DESCRIPTION
The PR (https://github.com/spatie/laravel-medialibrary/pull/3162) introduced `illuminate/conditionable` as a dependency, but with a small missing character.

The tight version prevented us from upgrading  `spatie/laravel-medialibrary`.