### PR TITLE
Correcting typographical and spelling mistakes in the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `laravel-medialibrary` will be documented in this file
 
+## 10.7.13 - 2023-03-06
+
+### What's Changed
+
+- Add Conditionable to Conversion by @tomwelch in https://github.com/spatie/laravel-medialibrary/pull/3162
+
+### New Contributors
+
+- @tomwelch made their first contribution in https://github.com/spatie/laravel-medialibrary/pull/3162
+
+**Full Changelog**: https://github.com/spatie/laravel-medialibrary/compare/10.7.12...10.7.13
+
 ## 10.7.12 - 2023-03-06
 
 ### What's Changed

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -94,7 +94,7 @@ return [
 
     /*
      * The media library will try to optimize all converted images by removing
-     * metadata and applying a little bit of compression. These are
+     * metadata and applying a bit of compression. These are
      * the optimizers that will be used by default.
      */
     'image_optimizers' => [

--- a/docs/about-us.md
+++ b/docs/about-us.md
@@ -2,7 +2,7 @@
 title: About us
 ---
 
-[Spatie](https://spatie.be) is a webdesign agency based in Antwerp, Belgium.
+[Spatie](https://spatie.be) is a web design agency based in Antwerp, Belgium.
 
 Open source software is used in all projects we deliver. Laravel, Nginx, Ubuntu are just a few 
 of the free pieces of software we use every single day. For this, we are very grateful. 

--- a/docs/advanced-usage/storing-media-specific-manipulations.md
+++ b/docs/advanced-usage/storing-media-specific-manipulations.md
@@ -3,7 +3,7 @@ title: Storing media specific manipulations
 weight: 3
 ---
 
-Imagine you need to apply a 90 degree rotation to a single image. So the rotation should be applied to one specific `Media` and not to all media linked to the given `$yourModel`.
+Imagine you need to apply a 90-degree rotation to a single image. So the rotation should be applied to one specific `Media` and not to all media linked to the given `$yourModel`.
 
 When adding an image to the media library, you can use `withManipulations` to set any media specific manipulations.
 

--- a/docs/api/adding-files.md
+++ b/docs/api/adding-files.md
@@ -3,7 +3,7 @@ title: Adding files
 weight: 1
 ---
 
-Adding a file to the media library is easy. Just pick one of the starting methods, optionally add some of the middle methods
+Adding a file to the media library is easy. Just pick one of the starting methods, optionally add some middle methods
 and finish with a finishing method. All start and middle methods are chainable.
 
 For example:

--- a/docs/downloading-media/downloading-multiple-files.md
+++ b/docs/downloading-media/downloading-multiple-files.md
@@ -7,7 +7,7 @@ You might want to let users be able to download multiple files at once. Traditio
 
 The media library is able to zip stream multiple files on the fly. So you don't need to create a zip archive on your server.
 
-The provided `MediaStream` class that allows you to respond with a stream. Files will be zipped on the fly and you can even include files from multiple filesystems.
+The provided `MediaStream` class that allows you to respond with a stream. Files will be zipped on the fly, and you can even include files from multiple filesystems.
 
 Here's an example on how it can be used:
 

--- a/docs/handling-uploads-with-media-library-pro/handling-uploads-with-vue.md
+++ b/docs/handling-uploads-with-media-library-pro/handling-uploads-with-vue.md
@@ -89,7 +89,7 @@ import { MediaLibraryAttachment } from "media-library-pro-vue2-attachment";
 import { MediaLibraryAttachment } from "media-library-pro-vue3-attachment";
 ```
 
-If you're using TypeScript, you will also have have to add this to your tsconfig:
+If you're using TypeScript, you will also have to add this to your tsconfig:
 
 ```json
 // tsconfig.json

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -117,7 +117,7 @@ return [
 
     /*
      * The media library will try to optimize all converted images by removing
-     * metadata and applying a little bit of compression. These are
+     * metadata and applying a bit of compression. These are
      * the optimizers that will be used by default.
      */
     'image_optimizers' => [
@@ -213,7 +213,7 @@ return [
     'responsive_images' => [
         /*
          * This class is responsible for calculating the target widths of the responsive
-         * images. By default we optimize for filesize and create variations that each are 20%
+         * images. By default, we optimize for filesize and create variations that each are 20%
          * smaller than the previous one. More info in the documentation.
          *
          * https://docs.spatie.be/laravel-medialibrary/v10/advanced-usage/generating-responsive-images
@@ -227,8 +227,8 @@ return [
         'use_tiny_placeholders' => true,
 
         /*
-         * This class will generate the tiny placeholder used for progressive image loading. By default
-         * the media library will use a tiny blurred jpg image.
+         * This class will generate the tiny placeholder used for progressive image loading. 
+         * By default, the media library will use a tiny blurred jpg image.
          */
         'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
     ],
@@ -313,7 +313,7 @@ sudo apt install jpegoptim optipng pngquant gifsicle
 npm install -g svgo
 ```
 
-Here's how to install the binaries on MacOS (using [Homebrew](https://brew.sh/)):
+Here's how to install the binaries on macOS (using [Homebrew](https://brew.sh/)):
 
 ```bash
 brew install jpegoptim

--- a/docs/responsive-images/getting-started-with-responsive-images.md
+++ b/docs/responsive-images/getting-started-with-responsive-images.md
@@ -3,9 +3,9 @@ title: Getting started with responsive images
 weight: 1
 ---
 
-Websites are viewed on various devices with widely differing screen sizes and connection speeds. When serving images it's best not to use the same image for all devices. A large image might be fine on a desktop computer with a fast internet connection, but on a small mobile device with limited bandwidth, the download might take a long time.
+Websites are viewed on various devices with widely differing screen sizes and connection speeds. When serving images its best not to use the same image for all devices. A large image might be fine on a desktop computer with a fast internet connection, but on a small mobile device with limited bandwidth, the download might take a long time.
 
-The media library has support for generating the necessary files and HTML markup for responsive images. In addition the medialibrary also has support for progressive image loading.
+The media library has support for generating the necessary files and HTML markup for responsive images. In addition, the medialibrary also has support for progressive image loading.
 
 [Try a demo of the concept here.](/laravel-medialibrary/v10/responsive-images/demo)
 

--- a/src/Conversions/Actions/PerformConversionAction.php
+++ b/src/Conversions/Actions/PerformConversionAction.php
@@ -16,7 +16,8 @@ class PerformConversionAction
         Conversion $conversion,
         Media $media,
         string $copiedOriginalFile
-    ) {
+    ): void
+    {
         $imageGenerator = ImageGeneratorFactory::forMedia($media);
 
         $copiedOriginalFile = $imageGenerator->convert($copiedOriginalFile, $conversion);

--- a/src/Conversions/Commands/RegenerateCommand.php
+++ b/src/Conversions/Commands/RegenerateCommand.php
@@ -16,7 +16,7 @@ class RegenerateCommand extends Command
 {
     use ConfirmableTrait;
 
-    protected $signature = 'media-library:regenerate {modelType?} {--ids=*}
+    protected string $signature = 'media-library:regenerate {modelType?} {--ids=*}
     {--only=* : Regenerate specific conversions}
     {--starting-from-id= : Regenerate media with an id equal to or higher than the provided value}
     {--X|exclude-starting-id : Exclude the provided id when regenerating from a specific id}
@@ -24,7 +24,7 @@ class RegenerateCommand extends Command
     {--with-responsive-images : Regenerate responsive images}
     {--force : Force the operation to run when in production}';
 
-    protected $description = 'Regenerate the derived images of media';
+    protected string $description = 'Regenerate the derived images of media';
 
     protected MediaRepository $mediaRepository;
 
@@ -83,7 +83,7 @@ class RegenerateCommand extends Command
 
         $startingFromId = (int)$this->option('starting-from-id');
         if ($startingFromId !== 0) {
-            $excludeStartingId = (bool) $this->option('exclude-starting-id') ?: false;
+            $excludeStartingId = (bool)$this->option('exclude-starting-id') || false;
 
             return $this->mediaRepository->getByIdGreaterThan($startingFromId, $excludeStartingId, is_string($modelType) ? $modelType : '');
         }

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -12,7 +12,7 @@ use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
 class Conversion
 {
     use Conditionable;
-    
+
     protected FileNamer $fileNamer;
 
     protected float $extractVideoFrameAtSecond = 0;

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -8,7 +8,7 @@ use Spatie\Image\Manipulations;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
 
-/** @mixin \Spatie\Image\Manipulations */
+/** @mixin Manipulations */
 class Conversion
 {
     use Conditionable;

--- a/src/Conversions/ConversionCollection.php
+++ b/src/Conversions/ConversionCollection.php
@@ -11,7 +11,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 /**
  * @template TKey of array-key
- * @template TValue of \Spatie\MediaLibrary\Conversions\Conversion
+ * @template TValue of Conversion
  *
  * @extends \Illuminate\Support\Collection<TKey, TValue>
  */
@@ -37,6 +37,9 @@ class ConversionCollection extends Collection
         return $this;
     }
 
+    /**
+     * @throws InvalidConversion
+     */
     public function getByName(string $name): Conversion
     {
         $conversion = $this->first(fn (Conversion $conversion) => $conversion->getName() === $name);
@@ -58,7 +61,7 @@ class ConversionCollection extends Collection
         /*
          * In some cases the user might want to get the actual model
          * instance so conversion parameters can depend on model
-         * properties. This will causes extra queries.
+         * properties. This will cause extra queries.
          */
         if ($model->registerMediaConversionsUsingModelInstance && $media->model) {
             $model = $media->model;
@@ -91,7 +94,7 @@ class ConversionCollection extends Collection
 
     protected function addManipulationToConversion(Manipulations $manipulations, string $conversionName)
     {
-        /** @var \Spatie\MediaLibrary\Conversions\Conversion|null $conversion */
+        /** @var Conversion|null $conversion */
         $conversion = $this->first(function (Conversion $conversion) use ($conversionName) {
             if (! in_array($this->media->collection_name, $conversion->getPerformOnCollections())) {
                 return false;

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -129,6 +129,6 @@ class FileManipulator
     {
         $imageGenerator = ImageGeneratorFactory::forMedia($media);
 
-        return $imageGenerator ? true : false;
+        return (bool)$imageGenerator;
     }
 }

--- a/src/Conversions/Jobs/PerformConversionsJob.php
+++ b/src/Conversions/Jobs/PerformConversionsJob.php
@@ -16,7 +16,7 @@ class PerformConversionsJob implements ShouldQueue
     use SerializesModels;
     use Queueable;
 
-    public $deleteWhenMissingModels = true;
+    public bool $deleteWhenMissingModels = true;
 
     public function __construct(protected ConversionCollection $conversions, protected Media $media, protected bool $onlyMissing = false)
     {

--- a/src/Downloaders/DefaultDownloader.php
+++ b/src/Downloaders/DefaultDownloader.php
@@ -6,6 +6,9 @@ use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
 
 class DefaultDownloader implements Downloader
 {
+    /**
+     * @throws UnreachableUrl
+     */
     public function getTempFile(string $url): string
     {
         if (! $stream = @fopen($url, 'r')) {

--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -20,13 +20,13 @@ class CleanCommand extends Command
 {
     use ConfirmableTrait;
 
-    protected $signature = 'media-library:clean {modelType?} {collectionName?} {disk?}
+    protected string $signature = 'media-library:clean {modelType?} {collectionName?} {disk?}
     {--dry-run : List files that will be removed without removing them},
     {--force : Force the operation to run when in production},
     {--rate-limit= : Limit the number of requests per second },
     {--skip-conversions : Do not remove deprecated conversions}';
 
-    protected $description = 'Clean deprecated conversions and files without related model.';
+    protected string $description = 'Clean deprecated conversions and files without related model.';
 
     protected MediaRepository $mediaRepository;
 
@@ -143,6 +143,9 @@ class CleanCommand extends Command
             });
     }
 
+    /**
+     * @throws DiskDoesNotExist
+     */
     protected function deleteOrphanedDirectories(): void
     {
         $diskName = $this->argument('disk') ?: config('media-library.disk_name');
@@ -156,7 +159,7 @@ class CleanCommand extends Command
 
         $mediaIds = collect($this->mediaRepository->all()->pluck($keyName)->toArray());
 
-        /** @var array<int, string> */
+        /** @var array<int, string> $directories */
         $directories = $this->fileSystem->disk($diskName)->directories();
 
         collect($directories)

--- a/src/MediaCollections/Commands/ClearCommand.php
+++ b/src/MediaCollections/Commands/ClearCommand.php
@@ -12,10 +12,10 @@ class ClearCommand extends Command
 {
     use ConfirmableTrait;
 
-    protected $signature = 'media-library:clear {modelType?} {collectionName?}
+    protected string $signature = 'media-library:clear {modelType?} {collectionName?}
     {-- force : Force the operation to run when in production}';
 
-    protected $description = 'Delete all items in a media collection.';
+    protected string $description = 'Delete all items in a media collection.';
 
     protected MediaRepository $mediaRepository;
 

--- a/src/MediaCollections/FileAdderFactory.php
+++ b/src/MediaCollections/FileAdderFactory.php
@@ -13,7 +13,7 @@ class FileAdderFactory
 {
     public static function create(Model $subject, string|UploadedFile $file): FileAdder
     {
-        /** @var \Spatie\MediaLibrary\MediaCollections\FileAdder $fileAdder */
+        /** @var FileAdder $fileAdder */
         $fileAdder = app(FileAdder::class);
 
         return $fileAdder
@@ -23,7 +23,7 @@ class FileAdderFactory
 
     public static function createFromDisk(Model $subject, string $key, string $disk): FileAdder
     {
-        /** @var \Spatie\MediaLibrary\MediaCollections\FileAdder $fileAdder */
+        /** @var FileAdder $fileAdder */
         $fileAdder = app(FileAdder::class);
 
         return $fileAdder
@@ -68,7 +68,7 @@ class FileAdderFactory
 
     public static function createForPendingMedia(Model $subject, PendingMediaItem $pendingMedia): FileAdder
     {
-        /** @var \Spatie\MediaLibrary\MediaCollections\FileAdder $fileAdder */
+        /** @var FileAdder $fileAdder */
         $fileAdder = app(FileAdder::class);
 
         return $fileAdder

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -20,8 +20,10 @@ class MediaRepository
     /**
      * Get all media in the collection.
      *
+     * @param HasMedia $model
+     * @param string $collectionName
      * @param array|callable $filter
-     *
+     * @return Collection
      */
     public function getCollection(
         HasMedia $model,
@@ -34,10 +36,10 @@ class MediaRepository
     /**
      * Apply given filters on media.
      *
-     * @param \Illuminate\Support\Collection $media
+     * @param Collection $media
      * @param array|callable $filter
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     protected function applyFilterToMediaCollection(
         Collection $media,

--- a/src/MediaCollections/Models/Collections/MediaCollection.php
+++ b/src/MediaCollections/Models/Collections/MediaCollection.php
@@ -8,11 +8,11 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 /**
  * @template TKey of array-key
- * @template TModel of \Spatie\MediaLibrary\MediaCollections\Models\Media
+ * @template TModel of Media
  *
  * @extends \Illuminate\Database\Eloquent\Collection<TKey, TModel>
  */
-class MediaCollection extends Collection implements Htmlable
+class MediaCollection extends Collection implements Htmlable, \Countable
 {
     public ?string $collectionName = null;
 

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -46,22 +46,22 @@ class Media extends Model implements Responsable, Htmlable, Attachable
     use CustomMediaProperties;
     use HasUuid;
 
-    protected $table = 'media';
+    protected string $table = 'media';
 
     public const TYPE_OTHER = 'other';
 
-    protected $guarded = [];
+    protected array $guarded = [];
 
-    protected $appends = ['original_url', 'preview_url'];
+    protected array $appends = ['original_url', 'preview_url'];
 
-    protected $casts = [
+    protected array $casts = [
         'manipulations' => 'array',
         'custom_properties' => 'array',
         'generated_conversions' => 'array',
         'responsive_images' => 'array',
     ];
 
-    public function newCollection(array $models = [])
+    public function newCollection(array $models = []): MediaCollection
     {
         return new MediaCollection($models);
     }
@@ -365,7 +365,7 @@ class Media extends Model implements Responsable, Htmlable, Attachable
 
         $temporaryFile = $temporaryDirectory->path('/') . DIRECTORY_SEPARATOR . $this->file_name;
 
-        /** @var \Spatie\MediaLibrary\MediaCollections\Filesystem $filesystem */
+        /** @var Filesystem $filesystem */
         $filesystem = app(Filesystem::class);
 
         $filesystem->copyFromMediaLibrary($this, $temporaryFile);
@@ -393,7 +393,7 @@ class Media extends Model implements Responsable, Htmlable, Attachable
 
     public function stream()
     {
-        /** @var \Spatie\MediaLibrary\MediaCollections\Filesystem $filesystem */
+        /** @var Filesystem $filesystem */
         $filesystem = app(Filesystem::class);
 
         return $filesystem->getStream($this);

--- a/src/MediaCollections/Models/Observers/MediaObserver.php
+++ b/src/MediaCollections/Models/Observers/MediaObserver.php
@@ -9,7 +9,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class MediaObserver
 {
-    public function creating(Media $media)
+    public function creating(Media $media): void
     {
         if ($media->shouldSortWhenCreating()) {
             if (is_null($media->order_column)) {
@@ -18,9 +18,9 @@ class MediaObserver
         }
     }
 
-    public function updating(Media $media)
+    public function updating(Media $media): void
     {
-        /** @var \Spatie\MediaLibrary\MediaCollections\Filesystem $filesystem */
+        /** @var Filesystem $filesystem */
         $filesystem = app(Filesystem::class);
 
         if (config('media-library.moves_media_on_update')) {
@@ -44,7 +44,7 @@ class MediaObserver
             $eventDispatcher = Media::getEventDispatcher();
             Media::unsetEventDispatcher();
 
-            /** @var \Spatie\MediaLibrary\Conversions\FileManipulator $fileManipulator */
+            /** @var FileManipulator $fileManipulator */
             $fileManipulator = app(FileManipulator::class);
 
             $fileManipulator->createDerivedFiles($media);
@@ -53,7 +53,7 @@ class MediaObserver
         }
     }
 
-    public function deleted(Media $media)
+    public function deleted(Media $media): void
     {
         if (in_array(SoftDeletes::class, class_uses_recursive($media))) {
             if (! $media->isForceDeleting()) {
@@ -61,7 +61,7 @@ class MediaObserver
             }
         }
 
-        /** @var \Spatie\MediaLibrary\MediaCollections\Filesystem $filesystem */
+        /** @var Filesystem $filesystem */
         $filesystem = app(Filesystem::class);
 
         $filesystem->removeAllFiles($media);

--- a/src/ResponsiveImages/Jobs/GenerateResponsiveImagesJob.php
+++ b/src/ResponsiveImages/Jobs/GenerateResponsiveImagesJob.php
@@ -21,7 +21,7 @@ class GenerateResponsiveImagesJob implements ShouldQueue
 
     public function handle(): bool
     {
-        /** @var \Spatie\MediaLibrary\ResponsiveImages\ResponsiveImageGenerator $responsiveImageGenerator */
+        /** @var ResponsiveImageGenerator $responsiveImageGenerator */
         $responsiveImageGenerator = app(ResponsiveImageGenerator::class);
 
         $responsiveImageGenerator->generateResponsiveImages($this->media);

--- a/src/Support/MediaLibraryPro.php
+++ b/src/Support/MediaLibraryPro.php
@@ -7,6 +7,9 @@ use Spatie\MediaLibraryPro\Models\TemporaryUpload;
 
 class MediaLibraryPro
 {
+    /**
+     * @throws FunctionalityNotAvailable
+     */
     public static function ensureInstalled(): void
     {
         if (! self::isInstalled()) {

--- a/src/Support/PathGenerator/PathGeneratorFactory.php
+++ b/src/Support/PathGenerator/PathGeneratorFactory.php
@@ -48,6 +48,9 @@ class PathGeneratorFactory
         return false;
     }
 
+    /**
+     * @throws InvalidPathGenerator
+     */
     protected static function guardAgainstInvalidPathGenerator(string $pathGeneratorClass): void
     {
         if (! class_exists($pathGeneratorClass)) {

--- a/src/Support/UrlGenerator/UrlGeneratorFactory.php
+++ b/src/Support/UrlGenerator/UrlGeneratorFactory.php
@@ -3,19 +3,24 @@
 namespace Spatie\MediaLibrary\Support\UrlGenerator;
 
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidConversion;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidUrlGenerator;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\PathGenerator\PathGeneratorFactory;
 
 class UrlGeneratorFactory
 {
+    /**
+     * @throws InvalidUrlGenerator
+     * @throws InvalidConversion
+     */
     public static function createForMedia(Media $media, string $conversionName = ''): UrlGenerator
     {
         $urlGeneratorClass = config('media-library.url_generator');
 
         static::guardAgainstInvalidUrlGenerator($urlGeneratorClass);
 
-        /** @var \Spatie\MediaLibrary\Support\UrlGenerator\UrlGenerator $urlGenerator */
+        /** @var UrlGenerator $urlGenerator */
         $urlGenerator = app($urlGeneratorClass);
 
         $pathGenerator = PathGeneratorFactory::create($media);
@@ -33,6 +38,9 @@ class UrlGeneratorFactory
         return $urlGenerator;
     }
 
+    /**
+     * @throws InvalidUrlGenerator
+     */
     public static function guardAgainstInvalidUrlGenerator(string $urlGeneratorClass): void
     {
         if (! class_exists($urlGeneratorClass)) {

--- a/tests/TestSupport/TestModels/TestCustomMediaModel.php
+++ b/tests/TestSupport/TestModels/TestCustomMediaModel.php
@@ -6,5 +6,5 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class TestCustomMediaModel extends Media
 {
-    protected $table = 'media';
+    protected string $table = 'media';
 }


### PR DESCRIPTION
I am interested in participating in your project. I'm reading documents. And I faced the above spelling bugs. Although there is no particular problem, this can be a start to our cooperation. I also saw some bugs in PHPDoc I want to correct them and add Typed properties.