### PR TITLE
New config option to restore default laravel model serialization behaviour

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -71,6 +71,7 @@ class AddGeneratedConversionsToMediaTable extends Migration {
 - rename `conversion_file_namer` key in the `media-library` config to `file_namer`. This will support both the conversions and responsive images from now on. More info [in our docs](https://spatie.be/docs/laravel-medialibrary/v9/advanced-usage/naming-generated-files).
 - You will also need to change the value of this configuration key as the previous class was removed, the new default value is `Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer::class`
 - in several releases of v8 config options were added. We recommend going over your config file in `config/media-library.php` and add any options that are present in the default config file that ships with this package.
+- Media collection serialization has changed to support the newly introduced Media Library Pro components. If you are returning media collections directly from your controllers or serializing them to json manually then you can retain existing behaviour by setting `use_default_collection_serialization` to `true` inside `config/media-library.php`
 
 ## From v7 to v8
 

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -37,6 +37,14 @@ return [
     'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
 
     /*
+     * When enabled, media collections will be serialised using the default
+     * laravel model serialization behaviour.
+     * 
+     * Keep this option disabled if using Media Library Pro components (https://medialibrary.pro)
+     */
+    'use_default_collection_serialization' => false,
+
+    /*
      * The fully qualified class name of the model used for temporary uploads.
      *
      * This model is only used in Media Library Pro (https://medialibrary.pro)

--- a/src/MediaCollections/Models/Collections/MediaCollection.php
+++ b/src/MediaCollections/Models/Collections/MediaCollection.php
@@ -56,6 +56,10 @@ class MediaCollection extends Collection implements Htmlable
 
     public function jsonSerialize(): array
     {
+        if (config('media-library.use_default_collection_serialization')) {
+            return parent::jsonSerialize();
+        }
+        
         if (! ($this->formFieldName ?? $this->collectionName)) {
             return [];
         }


### PR DESCRIPTION
Relates to dicusssion https://github.com/spatie/laravel-medialibrary/discussions/3203

### Problem

When upgrading media library from v8 to the latest version there is an inadvertent change introduced in commit https://github.com/spatie/laravel-medialibrary/commit/07302270b9ddbeb1c58de51321d3d73545d21639 which adds a `jsonSerialize` function to the MediaCollection class. This overrides the default model `toJson()` behaviour and can result in a number of bugs for existing applications that expect the standard laravel model `toJson` behaviour for media models.

For example in v8 the following worked as one would expect:

```php
Route::get('test', fn () => Media::all());
```

In v9/v10 this behaviour is now broken and will always return an empty array `[]`

Below I have tested a bunch of other typical use-cases that are also affected when upgrading to v10. Basically anything that returns a `Spatie\MediaLibrary\MediaCollections\Models\Collections\MediaCollection::class`:

```php
// In v9/v10 always returns []
Route::get('media-test1', fn () => Media::all());

// In v9/v10 always returns []
Route::get('media-test2', fn () => Media::take(10)->get());

// In v9/v10 always returns []
Route::get('media-test3', fn () => MyModel::first()->media);

// In v9/v10 always returns []
Route::get('media-test4', fn () => MyModel::first()->media->toJson());

// Works fine in v9/v10 - not calling into jsonSerialize
Route::get('media-test5', fn () => MyModel::first()->media->toArray());

// In v9/v10 this actually returns something but only specific set of hardcoded media fields as per MediaCollection::jsonSerialize()
// Breaks any custom model usages that may have additional media fields
// Does not respect the hidden/visible fields of any custom media model
Route::get('media-test6', fn () => MyModel::first()->getMedia());

// Works fine in v9/v10 - eagerloads give us a regular laravel collection
Route::get('media-test7', fn () => MyModel::with('media')->first());
```

### Why is this problem not so widespread?

I suspect people have been using a manual workaround which is to call `toArray()` first or wrapping in a plain laravel `collect()`. Both these cases work fine but are cumbersome and can be difficult to track down all possible places and situations where media collections are serialized in large codebases.

```php
// Example workarounds:
Route::get('media-test1', fn () => Media::all()->toArray());
Route::get('media-test2', fn () => collect(MyModel::first()->media);
```

### What does this merge request do?

This merge request introduces a new config option `use_default_collection_serialization` which when enabled will restore the default laravel model jsonSerialize behaviour (also used in media library v8).

I have left this option as `false` by default so that there is no change in current v9/v10 behaviour from what the maintainers had originally planned.