### PR TITLE
Set model relation on InteractsWithMedia@loadMedia()

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -549,7 +549,9 @@ trait InteractsWithMedia
         return $collection
             ->filter(fn (Media $mediaItem) => $mediaItem->collection_name === $collectionName)
             ->sortBy('order_column')
-            ->values();
+            ->values()
+            ->each
+            ->setRelation('model', $this);
     }
 
     public function prepareToAttachMedia(Media $media, FileAdder $fileAdder): void

--- a/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/DeleteMediaTest.php
@@ -60,8 +60,8 @@ it('can clear a collection excluding some media', function () {
     $this->testModelWithoutMediaConversions = $this->testModelWithoutMediaConversions->fresh();
 
     expect($this->testModelWithoutMediaConversions->getMedia('default'))->toHaveCount(3);
-    expect($excludedMedia[0])->toEqual($this->testModelWithoutMediaConversions->getMedia('images')[0]);
-    expect($excludedMedia[1])->toEqual($this->testModelWithoutMediaConversions->getMedia('images')[1]);
+    expect($excludedMedia[0]->withoutRelations())->toEqual($this->testModelWithoutMediaConversions->getMedia('images')[0]->withoutRelations());
+    expect($excludedMedia[1]->withoutRelations())->toEqual($this->testModelWithoutMediaConversions->getMedia('images')[1]->withoutRelations());
 });
 
 it('provides a chainable method for clearing a collection', function () {

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -294,6 +294,20 @@ it('will return preloaded media sorting on order column', function () {
         ->toArray());
 });
 
+it('will set model relation', function() {
+    DB::enableQueryLog();
+
+    $this->testModel->loadMedia('images');
+    expect(DB::getQueryLog())->toHaveCount(1);
+    $this->testModel->media->each(function(Media $media) {
+        expect($media->model)->toBeInstanceOf($this->testModel::class);
+    });
+
+    expect(DB::getQueryLog())->toHaveCount(1);
+
+    DB::DisableQueryLog();
+});
+
 it('will cache loaded media', function () {
     DB::enableQueryLog();
 


### PR DESCRIPTION
If ever media needs to reference its model (for instance, within a Resource), it will have to make a separate DB query to get the relationship (and this is especially annoying if you disable lazy loading).

When `loadMedia()` is called, it will set the model property for all Media within the Collection.