### PR TITLE
Add webp extension. Fix: files with webp doesn't process responsive images

### DIFF
--- a/src/Conversions/ImageGenerators/Image.php
+++ b/src/Conversions/ImageGenerators/Image.php
@@ -19,7 +19,7 @@ class Image extends ImageGenerator
 
     public function supportedExtensions(): Collection
     {
-        $extensions = ['png', 'jpg', 'jpeg', 'gif'];
+        $extensions = ['png', 'jpg', 'jpeg', 'gif', 'webp'];
         if (config('media-library.image_driver') === 'imagick') {
             $extensions[] = 'tiff';
         }
@@ -29,7 +29,7 @@ class Image extends ImageGenerator
 
     public function supportedMimeTypes(): Collection
     {
-        $mimeTypes = ['image/jpeg', 'image/gif', 'image/png'];
+        $mimeTypes = ['image/jpeg', 'image/gif', 'image/png', 'image/webp'];
         if (config('media-library.image_driver') === 'imagick') {
             $mimeTypes[] = 'image/tiff';
         }


### PR DESCRIPTION
Fix for 
https://github.com/spatie/laravel-medialibrary/issues/3081