### PR TITLE
Bump maennchen/zipstream-php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "illuminate/pipeline": "^9.18|^10.0",
         "illuminate/support": "^9.18|^10.0",
         "intervention/image": "^2.7",
-        "maennchen/zipstream-php": "^2.0",
+        "maennchen/zipstream-php": "^2.0|^3.0",
         "spatie/image": "^2.2.2",
         "spatie/temporary-directory": "^2.0",
         "symfony/console": "^6.0"

--- a/docs/downloading-media/downloading-multiple-files.md
+++ b/docs/downloading-media/downloading-multiple-files.md
@@ -30,13 +30,12 @@ class DownloadMediaController
 
 You can also pass any custom options to the `ZipStream` instance using the `useZipOptions` method.
 
-All the available options are listed on the [ZipStream-PHP wiki](https://github.com/maennchen/ZipStream-PHP/wiki/Available-options).
+All the available options are listed on the [ZipStream-PHP guide](https://maennchen.dev/ZipStream-PHP/guide/Options.html).
 
 Here's an example on how it can be used:
 
 ```php
 use Spatie\MediaLibrary\Support\MediaStream;
-use ZipStream\Option\Archive as ArchiveOptions;
 
 class DownloadMediaController
 {
@@ -48,8 +47,15 @@ class DownloadMediaController
         // Download the files associated with the media in a streamed way.
         // No prob if your files are very large.
         return MediaStream::create('my-files.zip')
-            ->useZipOptions(function(ArchiveOptions $zipOptions) {
-                $zipOptions->setZeroHeader(true);
+            ->useZipOptions(function(&$zipOptions) {
+                if (is_array($zipOptions)) {
+                    // ZipStream ^3.0 uses array                    
+                    $zipOptions['defaultEnableZeroHeader'] = true;
+                } else {
+                    // ZipStream ^2.0 uses \ZipStream\Option\Archive
+                    /** @var \ZipStream\Option\Archive $zipOptions */
+                    $zipOptions->setZeroHeader(true);
+                }
             })
             ->addMedia($downloads);
    }

--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -13,7 +13,7 @@ class MediaStream implements Responsable
 {
     protected Collection $mediaItems;
 
-    protected ArchiveOptions $zipOptions;
+    protected array|ArchiveOptions $zipOptions;
 
     public static function create(string $zipName): self
     {
@@ -24,7 +24,7 @@ class MediaStream implements Responsable
     {
         $this->mediaItems = collect();
 
-        $this->zipOptions = new ArchiveOptions();
+        $this->zipOptions = class_exists(ArchiveOptions::class) ? new ArchiveOptions() : [];
     }
 
     public function useZipOptions(callable $zipOptionsCallable): self
@@ -74,7 +74,12 @@ class MediaStream implements Responsable
 
     public function getZipStream(): ZipStream
     {
-        $zip = new ZipStream($this->zipName, $this->zipOptions);
+        if (class_exists(ArchiveOptions::class)) {
+            $zip = new ZipStream($this->zipName, $this->zipOptions);
+        } else {
+            $this->zipOptions['outputName'] = $this->zipName;
+            $zip = new ZipStream(...$this->zipOptions);
+        }
 
         $this->getZipStreamContents()->each(function (array $mediaInZip) use ($zip) {
             $stream = $mediaInZip['media']->stream();


### PR DESCRIPTION
Closes #3244
https://github.com/maennchen/ZipStream-PHP/pull/224/commits/db28d2dc4de4adc018e12aa1a4d5454f8815d4d6#diff-4a4a40b9325e51f552c112a8000682a8190a794038c2ec2b30997d501185f76e
On `ZipStream:^3.0`,  `ZipStream\Option\Archive` class was removed, now they use named args
Removing `^2.0` could be a breaking change, Is there a way to handle this correctly?