### PR TITLE
feat: add user agent to stream context in DefaultDownloader

### DIFF
--- a/src/Downloaders/DefaultDownloader.php
+++ b/src/Downloaders/DefaultDownloader.php
@@ -8,7 +8,13 @@ class DefaultDownloader implements Downloader
 {
     public function getTempFile(string $url): string
     {
-        if (! $stream = @fopen($url, 'r')) {
+        $context = stream_context_create([
+            "http" => [
+                "header" => "User-Agent: Spatie MediaLibrary",
+            ],
+        ]);
+
+        if (! $stream = @fopen($url, 'r', false, $context)) {
             throw UnreachableUrl::create($url);
         }
 


### PR DESCRIPTION
Some random image sources (including https://picsum.photos ) refuse to serve images when there is no user agent header in the request. See https://laracasts.com/discuss/channels/laravel/why-spatielaravel-medialibrary-raise-error-on-uploding-image-uploaded-with-faker-images for more context.

This PR adds a user agent to all requests in the `DefaultDownloader` to solve this problem.