### PR TITLE
Feature/new custom delete fix #3190 

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -66,6 +66,11 @@ return [
     'path_generator' => Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class,
 
     /*
+     * The class that contains the strategy for determining how to remove files.
+     */
+    'file_remover_class' => Spatie\MediaLibrary\Support\FileRemover\DefaultFileRemover::class,
+
+    /*
      * Here you can specify which path generator should be used for the given class.
      */
     'custom_path_generators' => [

--- a/docs/advanced-usage/using-a-custom-file-removal-strategy.md
+++ b/docs/advanced-usage/using-a-custom-file-removal-strategy.md
@@ -1,0 +1,80 @@
+---
+title: Using a custom file removal strategy
+weight: 5
+---
+
+By default, files will be stored inside a directory that uses the `id` of its `Media`-object as a name. Given this default file and folder structure, the `DefaultFileRemover` option simply gets the root folder name and deletes it.
+
+In cases where you need to use a custom directory structure, the `DefaultFileRemover` can cause problems. For example, if you have a directory structure like this:
+
+
+```
+media
+---- 2023/09
+------ file.jpg
+------ second.jpg
+------ conversions
+--------- file-small.jpg
+--------- file-medium.jpg
+--------- file-big.jpg
+--------- second-small.jpg
+--------- second-medium.jpg
+--------- second-big.jpg
+...
+```
+
+Using the `DefaultFileRemover` will delete the entire `2023` directory, which is not what you want. So we would use a custom file remover to delete only the files that are no longer needed.
+
+
+### Extending file remover functionality
+
+
+Let's take a look at the interface:
+
+```php
+<?php
+
+namespace Spatie\MediaLibrary\Support\FileRemover;
+
+use Illuminate\Contracts\Filesystem\Factory;
+use Spatie\MediaLibrary\MediaCollections\Filesystem;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+interface FileRemover
+{
+    public function __construct(Filesystem $mediaFileSystem, Factory $filesystem);
+
+    /*
+     * Remove all files relating to the media model.
+     */
+    public function removeAllFiles(Media $media): void;
+
+    /*
+     * Remove responsive files relating to the media model.
+     */
+    public function removeResponsiveImages(Media $media, string $conversionName): void;
+
+    /*
+     * Remove a file relating to the media model.
+     */
+    public function removeFile(string $path, string $disk): void;
+
+}
+
+```
+You may use create your own custom file remover by implementing the `FileRemover` interface.
+
+### Here to help
+
+There is also now a second option available within media library for file remover functionality. Based on the above directory structure, we can use `FileBaseFileRemover`.
+
+```php
+    // config/media-library.php
+
+    /*
+     * The class that contains the strategy for determining how to remove files.
+     */
+    'file_remover_class' => Spatie\MediaLibrary\Support\FileRemover\FileBaseFileRemover::class,
+```
+
+This strategy works by locating the exact path of the image and conversions, and explicitly removing those files only, instead of purging a base directory.

--- a/src/MediaCollections/Exceptions/InvalidFileRemover.php
+++ b/src/MediaCollections/Exceptions/InvalidFileRemover.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\MediaLibrary\MediaCollections\Exceptions;
+
+use Exception;
+use Spatie\MediaLibrary\Support\FileRemover\FileRemover;
+
+class InvalidFileRemover extends Exception
+{
+    public static function doesntExist(string $class): self
+    {
+        return new static("File remover class `{$class}` doesn't exist");
+    }
+
+    public static function doesNotImplementPathGenerator(string $class): self
+    {
+        $fileRemoverClass = FileRemover::class;
+
+        return new static("File remover class `{$class}` must implement `$fileRemoverClass}`");
+    }
+}

--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -225,9 +225,16 @@ class Filesystem
 
     public function removeResponsiveImages(Media $media, string $conversionName = 'media_library_original'): void
     {
-        $fileRemover = FileRemoverFactory::create($media);
+        $responsiveImagesDirectory = $this->getResponsiveImagesDirectory($media);
 
-        $fileRemover->removeResponsiveImages($media, $conversionName);
+        $allFilePaths = $this->filesystem->disk($media->disk)->allFiles($responsiveImagesDirectory);
+
+        $responsiveImagePaths = array_filter(
+            $allFilePaths,
+            fn (string $path) => Str::contains($path, $conversionName)
+        );
+
+        $this->filesystem->disk($media->disk)->delete($responsiveImagePaths);
     }
 
     public function syncFileNames(Media $media): void

--- a/src/Support/FileRemover/DefaultFileRemover.php
+++ b/src/Support/FileRemover/DefaultFileRemover.php
@@ -10,7 +10,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class DefaultFileRemover implements FileRemover
 {
-    public function __construct(private Filesystem $mediaFileSystem, private Factory $filesystem)
+    public function __construct(protected Filesystem $mediaFileSystem, protected Factory $filesystem)
     {}
 
     public function removeAllFiles(Media $media): void

--- a/src/Support/FileRemover/DefaultFileRemover.php
+++ b/src/Support/FileRemover/DefaultFileRemover.php
@@ -36,11 +36,6 @@ class DefaultFileRemover implements FileRemover
             });
     }
 
-    public function removeConvertedImages(Media $media): void
-    {
-        //
-    }
-
     public function removeResponsiveImages(Media $media, string $conversionName): void
     {
         $responsiveImagesDirectory = $this->mediaFileSystem->getResponsiveImagesDirectory($media);

--- a/src/Support/FileRemover/DefaultFileRemover.php
+++ b/src/Support/FileRemover/DefaultFileRemover.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Spatie\MediaLibrary\Support\FileRemover;
+
+use Exception;
+use Illuminate\Support\Str;
+use Illuminate\Contracts\Filesystem\Factory;
+use Spatie\MediaLibrary\MediaCollections\Filesystem;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class DefaultFileRemover implements FileRemover
+{
+    public function __construct(private Filesystem $mediaFileSystem, private Factory $filesystem)
+    {}
+
+    public function removeAllFiles(Media $media): void
+    {
+        $mediaDirectory = $this->mediaFileSystem->getMediaDirectory($media);
+
+        if ($media->disk !== $media->conversions_disk) {
+            $this->filesystem->disk($media->disk)->deleteDirectory($mediaDirectory);
+        }
+
+        $conversionsDirectory = $this->mediaFileSystem->getMediaDirectory($media, 'conversions');
+
+        $responsiveImagesDirectory = $this->mediaFileSystem->getMediaDirectory($media, 'responsiveImages');
+
+        collect([$mediaDirectory, $conversionsDirectory, $responsiveImagesDirectory])
+            ->unique()
+            ->each(function (string $directory) use ($media) {
+                try {
+                    $this->filesystem->disk($media->conversions_disk)->deleteDirectory($directory);
+                } catch (Exception $exception) {
+                    report($exception);
+                }
+            });
+    }
+
+    public function removeConvertedImages(Media $media): void
+    {
+        //
+    }
+
+    public function removeResponsiveImages(Media $media, string $conversionName): void
+    {
+        $responsiveImagesDirectory = $this->mediaFileSystem->getResponsiveImagesDirectory($media);
+
+        $allFilePaths = $this->filesystem->disk($media->disk)->allFiles($responsiveImagesDirectory);
+
+        $responsiveImagePaths = array_filter(
+            $allFilePaths,
+            fn (string $path) => Str::contains($path, $conversionName)
+        );
+
+        $this->filesystem->disk($media->disk)->delete($responsiveImagePaths);
+    }
+
+    public function removeFile(string $path, string $disk): void
+    {
+        $this->filesystem->disk($disk)->delete($path);
+    }
+}

--- a/src/Support/FileRemover/FileBaseFileRemover.php
+++ b/src/Support/FileRemover/FileBaseFileRemover.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\MediaLibrary\Support\FileRemover;
+
+use Illuminate\Contracts\Filesystem\Factory;
+use Spatie\MediaLibrary\MediaCollections\Filesystem;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Support\FileRemover\FileRemover;
+use Spatie\MediaLibrary\Support\FileRemover\DefaultFileRemover;
+
+class FileBaseFileRemover extends DefaultFileRemover implements FileRemover
+{
+    public function __construct(private Filesystem $mediaFileSystem, private Factory $filesystem)
+    {}
+
+    public function removeAllFiles(Media $media): void
+    {
+        $this->removeFile($this->mediaFileSystem->getMediaDirectory($media). $media->file_name, $media->disk);
+
+        $this->removeConvertedImages($media);
+    }
+
+    public function removeConvertedImages(Media $media): void
+    {
+        $conversionsDirectory = $this->mediaFileSystem->getConversionDirectory($media);
+        $mediaDirectory = $this->mediaFileSystem->getMediaDirectory($media);
+
+        collect($media->getMediaConversionNames())->each(function ($conversionName) use ($media) {
+            $this->removeFile(
+                path: $media->getPathRelativeToRoot($conversionName),
+                disk: $media->conversions_disk
+            );
+
+            $this->mediaFileSystem->removeResponsiveImages($media, $conversionName);
+        });
+    }
+
+    public function removeFile(string $path, string $disk): void
+    {
+        $this->filesystem->disk($disk)->delete($path);
+    }
+}

--- a/src/Support/FileRemover/FileBaseFileRemover.php
+++ b/src/Support/FileRemover/FileBaseFileRemover.php
@@ -10,7 +10,7 @@ use Spatie\MediaLibrary\Support\FileRemover\DefaultFileRemover;
 
 class FileBaseFileRemover extends DefaultFileRemover implements FileRemover
 {
-    public function __construct(private Filesystem $mediaFileSystem, private Factory $filesystem)
+    public function __construct(protected Filesystem $mediaFileSystem, protected Factory $filesystem)
     {}
 
     public function removeAllFiles(Media $media): void

--- a/src/Support/FileRemover/FileBaseFileRemover.php
+++ b/src/Support/FileRemover/FileBaseFileRemover.php
@@ -22,9 +22,6 @@ class FileBaseFileRemover extends DefaultFileRemover implements FileRemover
 
     public function removeConvertedImages(Media $media): void
     {
-        $conversionsDirectory = $this->mediaFileSystem->getConversionDirectory($media);
-        $mediaDirectory = $this->mediaFileSystem->getMediaDirectory($media);
-
         collect($media->getMediaConversionNames())->each(function ($conversionName) use ($media) {
             $this->removeFile(
                 path: $media->getPathRelativeToRoot($conversionName),

--- a/src/Support/FileRemover/FileRemover.php
+++ b/src/Support/FileRemover/FileRemover.php
@@ -21,11 +21,6 @@ interface FileRemover
     /*
      * Remove all converted files relating to the media model.
      */
-    public function removeConvertedImages(Media $media): void;
-
-    /*
-     * Remove all converted files relating to the media model.
-     */
     public function removeResponsiveImages(Media $media, string $conversionName): void;
 
     /*

--- a/src/Support/FileRemover/FileRemover.php
+++ b/src/Support/FileRemover/FileRemover.php
@@ -16,12 +16,12 @@ interface FileRemover
     public function removeAllFiles(Media $media): void;
 
     /*
-     * Remove all converted files relating to the media model.
+     * Remove responsive files relating to the media model.
      */
     public function removeResponsiveImages(Media $media, string $conversionName): void;
 
     /*
-     * Remove all responsive image files relating to the media model.
+     * Remove a file relating to the media model.
      */
     public function removeFile(string $path, string $disk): void;
 

--- a/src/Support/FileRemover/FileRemover.php
+++ b/src/Support/FileRemover/FileRemover.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spatie\MediaLibrary\Support\FileRemover;
+
+use Illuminate\Contracts\Filesystem\Factory;
+use Spatie\MediaLibrary\MediaCollections\Filesystem;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+interface FileRemover
+{
+    /*
+     * Create a new file remover instance, using the media library file system and illuminate filesystem.
+     */
+    public function __construct(Filesystem $mediaFileSystem, Factory $filesystem);
+
+    /*
+     * Remove all files relating to the media model.
+     */
+    public function removeAllFiles(Media $media): void;
+
+    /*
+     * Remove all converted files relating to the media model.
+     */
+    public function removeConvertedImages(Media $media): void;
+
+    /*
+     * Remove all converted files relating to the media model.
+     */
+    public function removeResponsiveImages(Media $media, string $conversionName): void;
+
+    /*
+     * Remove all responsive image files relating to the media model.
+     */
+    public function removeFile(string $path, string $disk): void;
+
+}

--- a/src/Support/FileRemover/FileRemover.php
+++ b/src/Support/FileRemover/FileRemover.php
@@ -8,9 +8,6 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 interface FileRemover
 {
-    /*
-     * Create a new file remover instance, using the media library file system and illuminate filesystem.
-     */
     public function __construct(Filesystem $mediaFileSystem, Factory $filesystem);
 
     /*

--- a/src/Support/FileRemover/FileRemoverFactory.php
+++ b/src/Support/FileRemover/FileRemoverFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\MediaLibrary\Support\FileRemover;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidFileRemover;
+
+class FileRemoverFactory
+{
+    public static function create(Media $media): FileRemover
+    {
+        $fileRemoverClass = config('media-library.file_remover_class');
+
+        static::guardAgainstInvalidFileRemover($fileRemoverClass);
+
+        return app($fileRemoverClass);
+    }
+
+    protected static function guardAgainstInvalidFileRemover(string $fileRemoverClass): void
+    {
+        if (!class_exists($fileRemoverClass)) {
+            throw InvalidFileRemover::doesntExist($fileRemoverClass);
+        }
+
+        if (!is_subclass_of($fileRemoverClass, FileRemover::class)) {
+            throw InvalidFileRemover::doesNotImplementFileRemover($fileRemoverClass);
+        }
+    }
+}

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Illuminate\Support\Facades\File;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestPathGenerator;
+use Spatie\MediaLibrary\Tests\Support\PathGenerator\CustomDirectoryStructurePathGenerator;
 
 it('will remove the files when deleting an object that has media', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
@@ -38,6 +40,41 @@ it('will remove files when deleting a media object with a custom path generator'
     $this->testModel->delete();
 
     expect(File::isDirectory($this->getTempDirectory($path)))->toBeFalse();
+});
+
+
+it('will remove files when deleting a media object with a custom path and directory generator', function () {
+    config(['media-library.path_generator' => CustomDirectoryStructurePathGenerator::class]);
+
+    $pathGenerator = new CustomDirectoryStructurePathGenerator();
+
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $path = $pathGenerator->getPath($media);
+
+    expect(File::exists($media->getPath()))->toBeTrue();
+
+    $this->testModel->delete();
+
+    expect(File::exists($media->getPath()))->toBeFalse();
+});
+
+it('will NOT remove other files within the same folder when deleting a media object with a custom path and directory generator', function () {
+    config(['media-library.path_generator' => CustomDirectoryStructurePathGenerator::class]);
+    config(['media-library.delete_media_directory' => false]);
+
+    $pathGenerator = new CustomDirectoryStructurePathGenerator();
+    // TODO: this is wrong - both files are deleted as they are attached to the same model
+    // either use two models or try to detach a file for deletion
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $media2 = $this->testModelWithConversion->addMedia($this->getTestPng())->toMediaCollection('images');
+
+    expect(File::exists($media->getPath()))->toBeTrue();
+    expect(File::exists($media2->getPath()))->toBeTrue();
+
+    $media->delete();
+
+    expect(File::exists($media->getPath()))->toBeFalse();
+    expect(File::exists($media2->getPath()))->toBeTrue();
 });
 
 it('will not remove the files when should delete preserving media returns true', function () {

--- a/tests/Support/PathGenerator/CustomDirectoryStructurePathGenerator.php
+++ b/tests/Support/PathGenerator/CustomDirectoryStructurePathGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\Support\PathGenerator;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Support\PathGenerator\PathGenerator;
+
+class CustomDirectoryStructurePathGenerator implements PathGenerator
+{
+    public function getPath(Media $media): string
+    {
+        return 'my-images/';
+    }
+
+    public function getPathForConversions(Media $media): string
+    {
+        return $this->getPath($media) . 'c/';
+    }
+
+    public function getPathForResponsiveImages(Media $media): string
+    {
+        return $this->getPath($media) . '/cri/';
+    }
+}

--- a/tests/Support/PathGenerator/CustomDirectoryStructurePathGenerator.php
+++ b/tests/Support/PathGenerator/CustomDirectoryStructurePathGenerator.php
@@ -19,6 +19,6 @@ class CustomDirectoryStructurePathGenerator implements PathGenerator
 
     public function getPathForResponsiveImages(Media $media): string
     {
-        return $this->getPath($media) . '/cri/';
+        return $this->getPath($media) . 'cri/';
     }
 }


### PR DESCRIPTION
This adds a test, using a custom path generator which uses a shared folder (i.e. not individual /1/ folder per image)

Once the test was failing, I extracted out the 'removeFile' and 'removeAllFiles' logic into a FileRemover class using a FileRemover Factory, to work in the same way you currently swap out path generators.

I then added a new FileBasedFileRemover class, which fixes the failing test created to demonstrate #3190.

This PR allows:
 - File removal logic can be swapped out
 - Existing file removal logic is maintaned in a DefaultFileRemoval class - ensuring everything works as before
 - New optional FileBasedFileRemover class allow us to use a custom directory path generator, which *does not* delete other files with is
 
 These are split into 3 commits to see each part. 