### PR TITLE
Update installation-setup.md

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -8,7 +8,7 @@ Media Library can be installed via Composer:
 If you only use the base package issue this command:
 
 ```bash
-composer require "spatie/laravel-medialibrary:^10.0.0"
+composer require spatie/laravel-medialibrary
 ```
 
 If you have a license for Media Library Pro, you should install `spatie/laravel-media-library-pro` instead. Please refer to our [Media Library Pro installation instructions](https://spatie.be/docs/laravel-medialibrary/v10/handling-uploads-with-media-library-pro/installation) to continue.


### PR DESCRIPTION
Specifying version will return requirements problem:

Problem 1
 - Root composer.json requires spatie/laravel-medialibrary 10.0.0 -> satisfiable by spatie/laravel-medialibrary[10.0.0].
 - spatie/laravel-medialibrary 10.0.0 requires illuminate/bus ^9.0 -> found illuminate/bus[v9.0.0, ..., v9.52.7] but these were not loaded, likely because it conflicts with another require.
