### PR TITLE
Fix InteractsWithMedia serialization

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -613,4 +613,19 @@ trait InteractsWithMedia
 
         $this->registerMediaConversions($media);
     }
+
+    public function __sleep(): array
+    {
+        // do not serialize properties from the trait
+        return collect(parent::__sleep())
+            ->reject(fn($key) => in_array(
+                $key,
+                [
+                    'mediaConversions',
+                    'mediaCollections',
+                    'unAttachedMediaLibraryItems',
+                    'deletePreservingMedia'
+                ])
+            )->toArray();
+    }
 }

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -315,3 +315,10 @@ it('will cache loaded media', function () {
 it('returns null when getting first media for an empty collection', function () {
     expect($this->testModel->getFirstMedia())->toBeNull();
 });
+
+it('can serialize model', function() {
+    expect(unserializeAndSerializeModel($this->testModel))->toEqual($this->testModel);
+    $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+    expect(unserializeAndSerializeModel($this->testModel))->toEqual($this->testModel->fresh());
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -50,3 +50,8 @@ function cleanUpS3(): void
             Storage::disk('s3_disk')->deleteDirectory($directory);
         });
 }
+
+function unserializeAndSerializeModel($model)
+{
+    return unserialize(serialize($model));
+}


### PR DESCRIPTION
Fixes `Exception : Serialization of 'Closure' is not allowed` when attempting to serialize a Model that employs InteractsWithMedia.