### PR TITLE
feat: add support for * ( ANY ) media collection

### DIFF
--- a/docs/basic-usage/retrieving-media.md
+++ b/docs/basic-usage/retrieving-media.md
@@ -9,6 +9,12 @@ To retrieve files you can use the `getMedia`-method:
 $mediaItems = $yourModel->getMedia();
 ```
 
+To retrieve files from all collections you can use the `getMedia`-method with `*`:
+
+```php
+$mediaItems = $yourModel->getMedia("*");
+```
+
 The method returns a collection of `Media`-objects.
 
 You can retrieve the URL and path to the file associated with the `Media`-object using  `getUrl`, `getTemporaryUrl` (for S3 only) and `getPath`:

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -547,7 +547,7 @@ trait InteractsWithMedia
         $collection = new MediaCollections\Models\Collections\MediaCollection($collection);
 
         return $collection
-            ->filter(fn (Media $mediaItem) => $mediaItem->collection_name === $collectionName)
+            ->filter(fn (Media $mediaItem) => $collectionName !== '*' ? $mediaItem->collection_name === $collectionName : true)
             ->sortBy('order_column')
             ->values();
     }

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -322,3 +322,17 @@ it('can serialize model', function () {
 
     expect(unserializeAndSerializeModel($this->testModel))->toEqual($this->testModel->fresh());
 });
+
+it('will get media from the all collections', function () {
+    expect($this->testModel->getMedia('images'))->toHaveCount(0);
+    expect($this->testModel->getMedia('downloads'))->toHaveCount(0);
+    expect($this->testModel->getMedia())->toHaveCount(0);
+
+    $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection('images');
+    $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection('downloads');
+    $this->testModel->addMedia($this->getTestFilesDirectory('test.jpg'))->preservingOriginal()->toMediaCollection();
+
+    $this->testModel = $this->testModel->fresh();
+
+    expect($this->testModel->getMedia('*'))->toHaveCount(3);
+});


### PR DESCRIPTION
There should be an option to fetch all associated media records regardless of the collection they are associated with.

We can pass the asterisk or "star" symbol (*)  to function for loading all media that belongs to the caller model.
 
`$model->getMedia('*')`