### PR TITLE
feat: add file name to addMediaFromString method

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -170,7 +170,7 @@ trait InteractsWithMedia
      *
      * @param string string
      */
-    public function addMediaFromString(string $text): FileAdder
+    public function addMediaFromString(string $text, string $fileName = 'text.txt'): FileAdder
     {
         $tmpFile = tempnam(sys_get_temp_dir(), 'media-library');
 
@@ -178,7 +178,7 @@ trait InteractsWithMedia
 
         $file = app(FileAdderFactory::class)
             ->create($this, $tmpFile)
-            ->usingFileName('text.txt');
+            ->usingFileName($fileName);
 
         return $file;
     }

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -517,6 +517,18 @@ test('a string can be accepted to be added to the media library', function () {
     expect(file_get_contents($media->getPath()))->toEqual($string);
 });
 
+test('a string can added to the media library with a specific file name', function () {
+    $string = 'test123';
+    $fileName = 'test.jpg';
+
+    $media = $this->testModel
+        ->addMediaFromString($string, $fileName)
+        ->toMediaCollection();
+
+    expect(file_get_contents($media->getPath()))->toEqual($string);
+    expect($media->file_name)->toBe($fileName);
+});
+
 test('a stream can be accepted to be added to the media library', function () {
     $string = 'test123';
     $stream = fopen('php://temp', 'w+');


### PR DESCRIPTION
This PR adds the ability to set a specific file name instead of the default "text.txt" when adding a media from a string

```
$media = $model->addMediaFromString($imageContent, 'profile_photo.jpg')->toMediaCollection('image');
```