### PR TITLE
FIX create migration

### DIFF
--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -48,7 +48,7 @@ class MediaLibraryServiceProvider extends ServiceProvider
             __DIR__.'/../config/media-library.php' => config_path('media-library.php'),
         ], 'config');
 
-        if (! class_exists('CreateMediaTable')) {
+        if (empty(glob(database_path('migrations/*_create_media_table.php')))) {
             $this->publishes([
                 __DIR__.'/../database/migrations/create_media_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_media_table.php'),
             ], 'migrations');


### PR DESCRIPTION
After running the php artisan `vendor:publish command ...`, the new migration file was still being created

the migration template was changed to an anonymous class without a classname