### PR TITLE
Automatically set model relationship on media

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -546,8 +546,11 @@ trait InteractsWithMedia
 
         $collection = new MediaCollections\Models\Collections\MediaCollection($collection);
 
+        $modelWithoutMedia = (clone $this)->unsetRelation('media');
+
         return $collection
             ->filter(fn (Media $mediaItem) => $collectionName !== '*' ? $mediaItem->collection_name === $collectionName : true)
+            ->each(fn (Media $mediaItem) => $mediaItem->setRelation('model', $modelWithoutMedia))
             ->sortBy('order_column')
             ->values();
     }


### PR DESCRIPTION
The purpose of this PR is to automatically set the `model` relationship on the Media model. This avoids unnecessary queries, especially when [`$registerMediaConversionsUsingModelInstance = true`](https://spatie.be/docs/laravel-medialibrary/v10/converting-images/defining-conversions#content-using-model-properties-in-a-conversion) is used.

@cosmastech already created [a similar PR](https://github.com/spatie/laravel-medialibrary/pull/3219) a while ago. It was merged, but then rolled back because of issues with serialization.

Since then, @cosmastech has fixed the serialization issue in [this PR](https://github.com/spatie/laravel-medialibrary/pull/3258).