### PR TITLE
Handle null extensions and mimetypes with ImageGeneratorFactory

### DIFF
--- a/src/Conversions/ImageGenerators/ImageGeneratorFactory.php
+++ b/src/Conversions/ImageGenerators/ImageGeneratorFactory.php
@@ -24,12 +24,20 @@ class ImageGeneratorFactory
 
     public static function forExtension(?string $extension): ?ImageGenerator
     {
+        if (is_null($extension)) {
+            return null;
+        }
+
         return static::getImageGenerators()
             ->first(fn (ImageGenerator $imageGenerator) => $imageGenerator->canHandleExtension(strtolower($extension)));
     }
 
     public static function forMimeType(?string $mimeType): ?ImageGenerator
     {
+        if (is_null($mimeType)) {
+            return null;
+        }
+
         return static::getImageGenerators()
             ->first(fn (ImageGenerator $imageGenerator) => $imageGenerator->canHandleMime($mimeType));
     }

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Storage;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskCannotBeAccessed;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileDoesNotExist;
@@ -652,4 +653,12 @@ it('will throw an exception and revert database when file cannot be added and mo
     )->toThrow(DiskCannotBeAccessed::class);
 
     expect(Media::count())->toBe(1);
+});
+
+it('will return null instead of an ImageGeneratorFactory when mimetype is null', function(){
+    expect(ImageGeneratorFactory::forMimeType(null))->toBeNull();
+});
+
+it('will return null instead of an ImageGeneratorFactory when extension is null', function(){
+    expect(ImageGeneratorFactory::forExtension(null))->toBeNull();
 });


### PR DESCRIPTION
In our test suite @inflcr, some of our factories were lacking mime_types and filenames.

This causes and exception to be thrown when attempting to access the Media attribute accessor `type()` (because `ImageGenerator@canHandleExtension()` and `ImageGenerator@canHandleMime()` both require a string).

I have fixed that in this PR by exiting early in their respective factory methods when null is passed in.