### PR TITLE
Fixed error when config is cached

### DIFF
--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -8,6 +8,7 @@ use Spatie\MediaLibrary\MediaCollections\Commands\CleanCommand;
 use Spatie\MediaLibrary\MediaCollections\Commands\ClearCommand;
 use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\MediaCollections\Models\Observers\MediaObserver;
 use Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\TinyPlaceholderGenerator;
 use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\WidthCalculator;
@@ -18,7 +19,7 @@ class MediaLibraryServiceProvider extends ServiceProvider
     {
         $this->registerPublishables();
 
-        $mediaClass = config('media-library.media_model');
+        $mediaClass = config('media-library.media_model', Media::class);
 
         $mediaClass::observe(new MediaObserver());
 


### PR DESCRIPTION
This is one I came across when deploying to production after adding media library. I had an error because my config was cached, media-library wasn't in the cache yet, I coudn't config:clear or config:cache because you cannot run `null::observe()`, which kept the app crashing before the command could be run.

Having a sensible default fixes this issue. (or manually `rm bootstrap/cache/config.php`, which was my solution for now)