### PR TITLE
Adds `FileAdder@setFileSize()`

### DIFF
--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -132,7 +132,7 @@ it('will have access the model instance when register media conversions using mo
     expect($conversionManipulations['width'])->toEqual(123);
 });
 
-it('can set filesize', function() {
+it('can set filesize', function () {
     $media = $this->testModelWithoutMediaConversions
         ->copyMedia($this->getTestFilesDirectory('test.jpg'))
         ->setFileSize(99999)

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -131,3 +131,12 @@ it('will have access the model instance when register media conversions using mo
 
     expect($conversionManipulations['width'])->toEqual(123);
 });
+
+it('can set filesize', function() {
+    $media = $this->testModelWithoutMediaConversions
+        ->copyMedia($this->getTestFilesDirectory('test.jpg'))
+        ->setFileSize(99999)
+        ->toMediaCollection();
+
+    expect($media->size)->toEqual(99999);
+});


### PR DESCRIPTION
This PR makes it possible to set the filesize via FileAdder. My thinking is that we may already have this information (such as from the headers of a request) and having to either call `filesize()` or `Storage::size()` can be avoided.

Also, I refactored it a bit so file size is only fetched one time.