### PR TITLE
Make `Filesystem@copyToMediaLibraryFromRemote()` more extensible

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -54,6 +54,11 @@ class Filesystem
         return true;
     }
 
+    public function prepareCopyFileOnDisk(RemoteFile $file, Media $media, string $destination): void
+    {
+        $this->copyFileOnDisk($file->getKey(), $destination, $media->disk);
+    }
+
     public function copyToMediaLibraryFromRemote(RemoteFile $file, Media $media, ?string $type = null, ?string $targetFileName = null): void
     {
         $destinationFileName = $targetFileName ?: $file->getFilename();
@@ -65,7 +70,7 @@ class Filesystem
             : $media->getDiskDriverName();
 
         if ($this->shouldCopyFileOnDisk($file, $media, $diskDriverName)) {
-            $this->copyFileOnDisk($file->getKey(), $destination, $media->disk);
+            $this->prepareCopyFileOnDisk($file, $media, $destination);
 
             return;
         }


### PR DESCRIPTION
We have a situation where we have two separate AWS buckets and we need to be able to copy data from one to the other. They are both registered in the filesystem. One is named `s3` and the other is named `s3_upload`, which serves as a temporary storage for user uploaded files.

Once a document is uploaded and the filekey is passed in a request, our code relies on InteractsWithMedia@addMediaFromDisk() to copy the data from `s3_upload` to its permanent home within `s3`.

Unfortunately, after some playing around this week, I see that we are actually streaming the file through our server rather than relying on the AWS to copy the object for us.

Luckily, Filesystem is always built from the container. So there's two changes that need to take place.

```php

class CustomFilesystem extends Spatie\MediaLibrary\MediaCollections\Filesystem
{
    protected function shouldCopyFileOnDisk(RemoteFile $file, Media $media, string $diskDriverName): bool
    {
        if ($file->getDisk() === 's3_upload' && $media->disk === 's3') {
            return true;
        }
        return parent::shouldCopyFileOnDisk($file, $media, $diskDriverName);
    }
}
```

It would look like we could just change `Filesystem@copyFileOnDisk()`, but unfortunately to use the S3Client how we want, we need to know: origin bucket, origin file key, destination bucket, and destination file key.

The parameters passed to this method currently are origin file key, destination file key, and the destination disk.

What's proposed here is simply a "go-between" method that can be more easily overridden. I've named it `prepareCopyFileOnDisk` which is truly not a great name, but 🤷 .

I think a better addition might be to create some sort of comparator class that would handle this. Maybe even a configuration to say "you should stream from one disk to the other."

Look forward to hearing your thoughts on this @freekmurze and will gladly PR any ideas/suggestions you may want to throw out here. 👍 

edit: I realize that the idea of a separate class to handle this is a nice idea, but it would be a BC to remove or move the methods in the Filesystem class 😓 