### PR TITLE
Updated doc block for $media->model_id

### DIFF
--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -35,7 +35,7 @@ use Spatie\MediaLibraryPro\Models\TemporaryUpload;
 /**
  * @property string $uuid
  * @property string $model_type
- * @property string $model_id
+ * @property string|int $model_id
  * @property string $collection_name
  * @property string $name
  * @property string $file_name


### PR DESCRIPTION
The change made in https://github.com/spatie/laravel-medialibrary/pull/3341/files#diff-8adff69d13774eb09fba1b9b993d0be0d466cf8d43523c9d8050884207cd5901R38 breaks our Larastan checks.

We use strict comparison checks between the `$media->model_id` and an integer (eg: `$media->model_id === $model->id`) and since the doc block in the above PR says it's a `string` only, it breaks. But that column can of course also be an integer, so I guess that this was just missed in the PR.

This PR updates the doc block to be `@property string|int` instead.