### PR TITLE
add feature: getLastMedia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ phpunit.xml
 .php-cs-fixer.cache
 phpstan.neon
 tests/Support/temp/
+/.idea

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Downloaders\DefaultDownloader;
 use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenCleared;
@@ -26,7 +27,6 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\MediaLibraryPro;
 use Spatie\MediaLibraryPro\PendingMediaLibraryRequestHandler;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use InvalidArgumentException;
 
 trait InteractsWithMedia
 {
@@ -284,7 +284,7 @@ trait InteractsWithMedia
             throw new InvalidArgumentException('position must be "first" or "last".');
         }
 
-        $media = $this->getMedia($collectionName,$filters);
+        $media = $this->getMedia($collectionName, $filters);
 
         return $position === 'first' ? $media->first() : $media->last();
     }
@@ -296,17 +296,17 @@ trait InteractsWithMedia
 
     public function getFirstMedia(string $collectionName = 'default', $filters = []): ?Media
     {
-        return $this->getSingleOfMedia($collectionName,$filters);
+        return $this->getSingleOfMedia($collectionName, $filters);
     }
 
-    public function getLastMedia(string $collectionName = 'default',$filters = []): ?Media
+    public function getLastMedia(string $collectionName = 'default', $filters = []): ?Media
     {
-        return $this->getSingleOfMedia($collectionName,$filters,'last');
+        return $this->getSingleOfMedia($collectionName, $filters, 'last');
     }
 
-    protected function getSingleOfMediaUrl(string $collectionName = 'default', string $conversionName = '',string $position = 'first'): string
+    protected function getSingleOfMediaUrl(string $collectionName = 'default', string $conversionName = '', string $position = 'first'): string
     {
-        $media = $this->getSingleOfMedia($collectionName,[],$position);
+        $media = $this->getSingleOfMedia($collectionName, [], $position);
 
         if (! $media) {
             return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
@@ -326,7 +326,7 @@ trait InteractsWithMedia
      */
     public function getFirstMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return $this->getSingleOfMediaUrl($collectionName,$conversionName);
+        return $this->getSingleOfMediaUrl($collectionName, $conversionName);
     }
 
     /*
@@ -336,7 +336,7 @@ trait InteractsWithMedia
      */
     public function getLastMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return $this->getSingleOfMediaUrl($collectionName,$conversionName,'last');
+        return $this->getSingleOfMediaUrl($collectionName, $conversionName, 'last');
     }
 
     protected function getSingleOfMediaTemporaryUrl(
@@ -344,9 +344,8 @@ trait InteractsWithMedia
         string $collectionName = 'default',
         string $conversionName = '',
         string $position = 'first'
-    )
-    {
-        $media = $this->getSingleOfMedia($collectionName,[],$position);
+    ) {
+        $media = $this->getSingleOfMedia($collectionName, [], $position);
 
         if (! $media) {
             return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
@@ -370,7 +369,7 @@ trait InteractsWithMedia
         string $collectionName = 'default',
         string $conversionName = ''
     ): string {
-        return $this->getSingleOfMediaTemporaryUrl($expiration,$collectionName,$conversionName);
+        return $this->getSingleOfMediaTemporaryUrl($expiration, $collectionName, $conversionName);
     }
 
     /*
@@ -384,7 +383,7 @@ trait InteractsWithMedia
         string $collectionName = 'default',
         string $conversionName = ''
     ): string {
-        return $this->getSingleOfMediaTemporaryUrl($expiration,$collectionName,$conversionName,'last');
+        return $this->getSingleOfMediaTemporaryUrl($expiration, $collectionName, $conversionName, 'last');
     }
 
     public function getRegisteredMediaCollections(): Collection
@@ -424,9 +423,9 @@ trait InteractsWithMedia
         return $fallbackPaths[$conversionName] ?? $fallbackPaths['default'] ?? '';
     }
 
-    protected function getSingleOfMediaPath(string $collectionName = 'default', string $conversionName = '',string $position = 'first'): string
+    protected function getSingleOfMediaPath(string $collectionName = 'default', string $conversionName = '', string $position = 'first'): string
     {
-        $media = $this->getSingleOfMedia($collectionName,[],$position);
+        $media = $this->getSingleOfMedia($collectionName, [], $position);
 
         if (! $media) {
             return $this->getFallbackMediaPath($collectionName, $conversionName) ?: '';
@@ -446,7 +445,7 @@ trait InteractsWithMedia
      */
     public function getFirstMediaPath(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return $this->getSingleOfMediaPath($collectionName,$conversionName);
+        return $this->getSingleOfMediaPath($collectionName, $conversionName);
     }
 
     /*
@@ -457,7 +456,7 @@ trait InteractsWithMedia
      */
     public function getLastMediaPath(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return $this->getSingleOfMediaPath($collectionName,$conversionName,'last');
+        return $this->getSingleOfMediaPath($collectionName, $conversionName, 'last');
     }
 
     /*

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -272,6 +272,20 @@ trait InteractsWithMedia
             ->collectionName($collectionName);
     }
 
+    /**
+     * @throws \Throwable
+     */
+    protected function getSingleOfMedia(string $collectionName = 'default', array|callable $filters = [], string $direction = 'asc' | 'desc'): ?Media
+    {
+        $direction = strtolower($direction);
+
+        throw_unless(in_array($direction,['asc','desc']),new \LogicException('direction should equal asc or desc'));
+
+        $media = $this->getMedia($collectionName,$filters);
+
+        return $direction == 'asc' ? $media->first() : $media->last();
+    }
+
     public function getMediaRepository(): MediaRepository
     {
         return app(MediaRepository::class);
@@ -279,19 +293,17 @@ trait InteractsWithMedia
 
     public function getFirstMedia(string $collectionName = 'default', $filters = []): ?Media
     {
-        $media = $this->getMedia($collectionName, $filters);
-
-        return $media->first();
+        return $this->getSingleOfMedia($collectionName,$filters,'asc');
     }
 
-    /*
-     * Get the url of the image for the given conversionName
-     * for first media for the given collectionName.
-     * If no profile is given, return the source's url.
-     */
-    public function getFirstMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
+    public function getLastMedia(string $collectionName = 'default',$filters = []): ?Media
     {
-        $media = $this->getFirstMedia($collectionName);
+        return $this->getSingleOfMedia($collectionName,$filters,'desc');
+    }
+
+    protected function getSingleOfMediaUrl(string $collectionName = 'default', string $conversionName = '',string $direction = 'asc' | 'desc'): string
+    {
+        $media = $this->getSingleOfMedia($collectionName,[],$direction);
 
         if (! $media) {
             return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
@@ -307,15 +319,31 @@ trait InteractsWithMedia
     /*
      * Get the url of the image for the given conversionName
      * for first media for the given collectionName.
-     *
      * If no profile is given, return the source's url.
      */
-    public function getFirstTemporaryUrl(
+    public function getFirstMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        return $this->getSingleOfMediaUrl($collectionName,$conversionName,'asc');
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for last media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getLastMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        return $this->getSingleOfMediaUrl($collectionName,$conversionName,'desc');
+    }
+
+    protected function getSingleOfMediaTemporaryUrl(
         DateTimeInterface $expiration,
         string $collectionName = 'default',
-        string $conversionName = ''
-    ): string {
-        $media = $this->getFirstMedia($collectionName);
+        string $conversionName = '',
+        string $direction = 'asc'
+    )
+    {
+        $media = $this->getSingleOfMedia($collectionName,[],$direction);
 
         if (! $media) {
             return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
@@ -326,6 +354,33 @@ trait InteractsWithMedia
         }
 
         return $media->getTemporaryUrl($expiration, $conversionName);
+    }
+    /*
+     * Get the url of the image for the given conversionName
+     * for first media for the given collectionName.
+     *
+     * If no profile is given, return the source's url.
+     */
+    public function getFirstTemporaryUrl(
+        DateTimeInterface $expiration,
+        string $collectionName = 'default',
+        string $conversionName = ''
+    ): string {
+        return $this->getSingleOfMediaTemporaryUrl($expiration,$collectionName,$conversionName,'asc');
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for last media for the given collectionName.
+     *
+     * If no profile is given, return the source's url.
+     */
+    public function getLastMediaTemporaryUrl(
+        DateTimeInterface $expiration,
+        string $collectionName = 'default',
+        string $conversionName = ''
+    ): string {
+        return $this->getSingleOfMediaTemporaryUrl($expiration,$collectionName,$conversionName,'desc');
     }
 
     public function getRegisteredMediaCollections(): Collection
@@ -365,14 +420,9 @@ trait InteractsWithMedia
         return $fallbackPaths[$conversionName] ?? $fallbackPaths['default'] ?? '';
     }
 
-    /*
-     * Get the url of the image for the given conversionName
-     * for first media for the given collectionName.
-     * If no profile is given, return the source's url.
-     */
-    public function getFirstMediaPath(string $collectionName = 'default', string $conversionName = ''): string
+    protected function getSingleOfMediaPath(string $collectionName = 'default', string $conversionName = '',string $direction = 'asc' | 'desc'): string
     {
-        $media = $this->getFirstMedia($collectionName);
+        $media = $this->getSingleOfMedia($collectionName,[],$direction);
 
         if (! $media) {
             return $this->getFallbackMediaPath($collectionName, $conversionName) ?: '';
@@ -383,6 +433,27 @@ trait InteractsWithMedia
         }
 
         return $media->getPath($conversionName);
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for first media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getFirstMediaPath(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        return $this->getSingleOfMediaPath($collectionName,$conversionName,'asc');
+    }
+
+    /*
+     *
+     * Get the url of the image for the given conversionName
+     * for last media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getLastMediaPath(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        return $this->getSingleOfMediaPath($collectionName,$conversionName,'desc');
     }
 
     /*

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -26,6 +26,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\MediaLibraryPro;
 use Spatie\MediaLibraryPro\PendingMediaLibraryRequestHandler;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use InvalidArgumentException;
 
 trait InteractsWithMedia
 {
@@ -275,15 +276,17 @@ trait InteractsWithMedia
     /**
      * @throws \Throwable
      */
-    protected function getSingleOfMedia(string $collectionName = 'default', array|callable $filters = [], string $direction = 'asc' | 'desc'): ?Media
+    protected function getSingleOfMedia(string $collectionName = 'default', array|callable $filters = [], string $position = 'first'): ?Media
     {
-        $direction = strtolower($direction);
+        $position = strtolower($position);
 
-        throw_unless(in_array($direction,['asc','desc']),new \LogicException('direction should equal asc or desc'));
+        if (! in_array($position, ['first', 'last'], true)) {
+            throw new InvalidArgumentException('position must be "first" or "last".');
+        }
 
         $media = $this->getMedia($collectionName,$filters);
 
-        return $direction == 'asc' ? $media->first() : $media->last();
+        return $position === 'first' ? $media->first() : $media->last();
     }
 
     public function getMediaRepository(): MediaRepository
@@ -293,17 +296,17 @@ trait InteractsWithMedia
 
     public function getFirstMedia(string $collectionName = 'default', $filters = []): ?Media
     {
-        return $this->getSingleOfMedia($collectionName,$filters,'asc');
+        return $this->getSingleOfMedia($collectionName,$filters);
     }
 
     public function getLastMedia(string $collectionName = 'default',$filters = []): ?Media
     {
-        return $this->getSingleOfMedia($collectionName,$filters,'desc');
+        return $this->getSingleOfMedia($collectionName,$filters,'last');
     }
 
-    protected function getSingleOfMediaUrl(string $collectionName = 'default', string $conversionName = '',string $direction = 'asc' | 'desc'): string
+    protected function getSingleOfMediaUrl(string $collectionName = 'default', string $conversionName = '',string $position = 'first'): string
     {
-        $media = $this->getSingleOfMedia($collectionName,[],$direction);
+        $media = $this->getSingleOfMedia($collectionName,[],$position);
 
         if (! $media) {
             return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
@@ -323,7 +326,7 @@ trait InteractsWithMedia
      */
     public function getFirstMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return $this->getSingleOfMediaUrl($collectionName,$conversionName,'asc');
+        return $this->getSingleOfMediaUrl($collectionName,$conversionName);
     }
 
     /*
@@ -333,17 +336,17 @@ trait InteractsWithMedia
      */
     public function getLastMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return $this->getSingleOfMediaUrl($collectionName,$conversionName,'desc');
+        return $this->getSingleOfMediaUrl($collectionName,$conversionName,'last');
     }
 
     protected function getSingleOfMediaTemporaryUrl(
         DateTimeInterface $expiration,
         string $collectionName = 'default',
         string $conversionName = '',
-        string $direction = 'asc'
+        string $position = 'first'
     )
     {
-        $media = $this->getSingleOfMedia($collectionName,[],$direction);
+        $media = $this->getSingleOfMedia($collectionName,[],$position);
 
         if (! $media) {
             return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
@@ -355,6 +358,7 @@ trait InteractsWithMedia
 
         return $media->getTemporaryUrl($expiration, $conversionName);
     }
+
     /*
      * Get the url of the image for the given conversionName
      * for first media for the given collectionName.
@@ -366,7 +370,7 @@ trait InteractsWithMedia
         string $collectionName = 'default',
         string $conversionName = ''
     ): string {
-        return $this->getSingleOfMediaTemporaryUrl($expiration,$collectionName,$conversionName,'asc');
+        return $this->getSingleOfMediaTemporaryUrl($expiration,$collectionName,$conversionName);
     }
 
     /*
@@ -380,7 +384,7 @@ trait InteractsWithMedia
         string $collectionName = 'default',
         string $conversionName = ''
     ): string {
-        return $this->getSingleOfMediaTemporaryUrl($expiration,$collectionName,$conversionName,'desc');
+        return $this->getSingleOfMediaTemporaryUrl($expiration,$collectionName,$conversionName,'last');
     }
 
     public function getRegisteredMediaCollections(): Collection
@@ -420,9 +424,9 @@ trait InteractsWithMedia
         return $fallbackPaths[$conversionName] ?? $fallbackPaths['default'] ?? '';
     }
 
-    protected function getSingleOfMediaPath(string $collectionName = 'default', string $conversionName = '',string $direction = 'asc' | 'desc'): string
+    protected function getSingleOfMediaPath(string $collectionName = 'default', string $conversionName = '',string $position = 'first'): string
     {
-        $media = $this->getSingleOfMedia($collectionName,[],$direction);
+        $media = $this->getSingleOfMedia($collectionName,[],$position);
 
         if (! $media) {
             return $this->getFallbackMediaPath($collectionName, $conversionName) ?: '';
@@ -442,7 +446,7 @@ trait InteractsWithMedia
      */
     public function getFirstMediaPath(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return $this->getSingleOfMediaPath($collectionName,$conversionName,'asc');
+        return $this->getSingleOfMediaPath($collectionName,$conversionName);
     }
 
     /*
@@ -453,7 +457,7 @@ trait InteractsWithMedia
      */
     public function getLastMediaPath(string $collectionName = 'default', string $conversionName = ''): string
     {
-        return $this->getSingleOfMediaPath($collectionName,$conversionName,'desc');
+        return $this->getSingleOfMediaPath($collectionName,$conversionName,'last');
     }
 
     /*


### PR DESCRIPTION
As the `getFirstMedia` feature is popular to use in many cases, I think also one of the most popular cases to retrieve the **last media.** 
for example: 
- Get the profile picture.
- Get the uploaded CV.
- Get the project proposal doc .
- I think in the previous examples, usually the default media is the **last** one, not the first **one**.
so I had added `getLastMedia`, `getLastMediaUrl`, `getLastMediaPath`, and `getLastMediaTemporaryUrl`.