### PR TITLE
Avoid creating temporary directory until needed

### DIFF
--- a/src/Support/TemporaryFile.php
+++ b/src/Support/TemporaryFile.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Spatie\MediaLibrary\Support;
+
+use Illuminate\Support\Str;
+use Spatie\MediaLibrary\MediaCollections\Filesystem;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Support\TemporaryDirectory as SupportTemporaryDirectory;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
+
+class TemporaryFile
+{
+    protected string $file;
+
+    protected TemporaryDirectory $temporaryDirectory;
+
+    protected Media $media;
+
+    public function __construct(Media $media)
+    {
+        $this->media = $media;
+    }
+
+    public function getFile(): string
+    {
+        if (! isset($this->file)) {
+            $this->copyFile();
+        }
+
+        return $this->file;
+    }
+
+    protected function copyFile(): void
+    {
+        if (! isset($this->temporaryDirectory)) {
+            $this->createTemporaryDirectory();
+        }
+
+        $this->file = app(Filesystem::class)->copyFromMediaLibrary(
+            $this->media,
+            $this->temporaryDirectory->path(Str::random(32) . '.' . $this->media->extension)
+        );
+    }
+
+    protected function createTemporaryDirectory(): void
+    {
+        $this->temporaryDirectory = SupportTemporaryDirectory::create();
+    }
+
+    public function __destruct()
+    {
+        if (isset($this->temporaryDirectory)) {
+            $this->temporaryDirectory->delete();
+        }
+    }
+}


### PR DESCRIPTION
In performing conversions, a temporary directory is created and then the original file is copied to the temp directory. It's possible that this is never needed (since there may be no new conversions to create). I've created a simple wrapper that handles creating the temporary directory and copying the file only when first requested.

Not sure about tests here. Let me know if you have any ideas on what you would like to see on that front.