### PR TITLE
Support drivers containing gcs or s3 in driver name

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -340,7 +340,7 @@ class Filesystem
             ? $media->conversions_disk
             : $media->disk;
 
-        if (! in_array($diskDriverName, ['s3', 'gcs'], true)) {
+        if (! Str::contains($diskDriverName, ['s3', 'gcs'], true)) {
             $this->filesystem->disk($diskName)->makeDirectory($directory);
         }
 


### PR DESCRIPTION
We have multiple gcs drivers (Ex. `gcs-private`, `gcs-public`).

This PR detects GCS as long as it's in the driver name.