### PR TITLE
Adding example to docs to pass translation keys from Vue I18n in (pro) components

### DIFF
--- a/docs/handling-uploads-with-media-library-pro/handling-uploads-with-vue.md
+++ b/docs/handling-uploads-with-media-library-pro/handling-uploads-with-vue.md
@@ -687,6 +687,14 @@ window.mediaLibraryTranslations = {
 };
 ```
 
+If you use the [vue-i18n](https://vue-i18n.intlify.dev/) package from intlify, you can also pass the keys from a translation file like `lang/media-library.php` by using the [`$tm`-function](https://vue-i18n.intlify.dev/api/composition.html#tm-key).
+
+```js
+<MediaLibraryCollection
+    :translations="$tm('media-library')"
+/>
+```
+
 ## Props
 
 These props are available on both the `attachment` and the `collection` component.


### PR DESCRIPTION
The package vue-i18n (https://vue-i18n.intlify.dev/) offers a $tm-function to pass all keys at once as an array from a translation file. Maybe it's good to adapt this in the documentation.

See: https://vue-i18n.intlify.dev/api/composition.html#tm-key

`lang/media-library.php`
```php
<?php

return [
    'fileTypeNotAllowed' => 'Je moet een bestand van het type',
    'tooLarge' => 'Bestand te groot, maximaal',
    'tooSmall' => 'Bestand te klein, minimaal',
    'tryAgain' => 'probeer dit bestand opnieuw te uploaden',
    // ...
];
```


```vue
<MediaLibraryCollection
    :translations="$tm('media-library')"
/>
```