### PR TITLE
Remove unnecessary directory creation

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -332,18 +332,6 @@ class Filesystem
             $directory = $pathGenerator->getPathForResponsiveImages($media);
         }
 
-        $diskDriverName = in_array($type, ['conversions', 'responsiveImages'])
-            ? $media->getConversionsDiskDriverName()
-            : $media->getDiskDriverName();
-
-        $diskName = in_array($type, ['conversions', 'responsiveImages'])
-            ? $media->conversions_disk
-            : $media->disk;
-
-        if (! Str::contains($diskDriverName, ['s3', 'gcs'], true)) {
-            $this->filesystem->disk($diskName)->makeDirectory($directory);
-        }
-
         return $directory;
     }
 


### PR DESCRIPTION
This PR suggests to remove the conditional directory creation logic in the `getMediaLibrary()` function.
Unless it's a very specific reason to do it, I think it would be better to avoid checking for a specific driver to run the logic for creating a directory or not (since that can cause unexpected issues). 
In our case we ran into an issue with the solution since another library was masking the real driver name (so it wasn't called anything with "s3" anymore), and since our S3 permission setup only allowed writing files, not creating an empty directory, the storing of the file caused an exception to be thrown.
See relevant comment at https://github.com/spatie/laravel-medialibrary/pull/3389/files#r1338270714.

According to [Flysystem](https://flysystem.thephpleague.com/docs/usage/filesystem-api/), the actual driver creates the required directory when attempting to write a file;
> When writing files, the directory you’re writing to will be created automatically if and when that is required in the filesystem you’re writing to. If your filesystem does not require directories to exist (like AWS S3), the directory is not created. This is a performance consideration. Of course, you can always create the directory yourself by using the createDirectory operation.