### PR TITLE
Delete orphaned media in clean command

### DIFF
--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -23,8 +23,8 @@ class CleanCommand extends Command
     protected $signature = 'media-library:clean {modelType?} {collectionName?} {disk?}
     {--dry-run : List files that will be removed without removing them},
     {--force : Force the operation to run when in production},
-    {--rate-limit= : Limit the number of requests per second },
-    {--skip-orphaned : Do not remove orphaned media items},
+    {--rate-limit= : Limit the number of requests per second},
+    {--delete-orphaned : Delete orphaned media items},
     {--skip-conversions : Do not remove deprecated conversions}';
 
     protected $description = 'Clean deprecated conversions and files without related model.';
@@ -55,7 +55,7 @@ class CleanCommand extends Command
         $this->isDryRun = $this->option('dry-run');
         $this->rateLimit = (int) $this->option('rate-limit');
 
-        if (! $this->option('skip-orphaned')) {
+        if ($this->option('delete-orphaned')) {
             $this->deleteOrphanedMediaItems();
         }
 

--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -94,7 +94,7 @@ class CleanCommand extends Command
 
     protected function deleteOrphanedMediaItems(): void
     {
-        $this->mediaRepository->getOrphans()->each(function (Media $media) {
+        $this->getOrphanedMediaItems()->each(function (Media $media): void {
             if ($this->isDryRun) {
                 $this->info("Orphaned Media[id={$media->id}] found");
 
@@ -105,6 +105,18 @@ class CleanCommand extends Command
 
             $this->info("Orphaned Media[id={$media->id}] has been removed");
         });
+    }
+
+    /** @return Collection<int, Media> */
+    protected function getOrphanedMediaItems(): Collection
+    {
+        $collectionName = $this->argument('collectionName');
+
+        if (is_string($collectionName)) {
+            return $this->mediaRepository->getOrphansByCollectionName($collectionName);
+        }
+
+        return $this->mediaRepository->getOrphans();
     }
 
     protected function deleteFilesGeneratedForDeprecatedConversions(): void

--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -103,6 +103,10 @@ class CleanCommand extends Command
 
             $media->delete();
 
+            if ($this->rateLimit) {
+                usleep((1 / $this->rateLimit) * 1_000_000);
+            }
+
             $this->info("Orphaned Media[id={$media->id}] has been removed");
         });
     }

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -95,6 +95,14 @@ class MediaRepository
             ->get();
     }
 
+    public function getOrphansByCollectionName(string $collectionName): DbCollection
+    {
+        return $this->query()
+            ->whereDoesntHave('model')
+            ->where('collection_name', $collectionName)
+            ->get();
+    }
+
     protected function query(): Builder
     {
         return $this->model->newQuery();

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -88,6 +88,13 @@ class MediaRepository
             ->get();
     }
 
+    public function getOrphans(): DbCollection
+    {
+        return $this->query()
+            ->whereDoesntHave('model')
+            ->get();
+    }
+
     protected function query(): Builder
     {
         return $this->model->newQuery();

--- a/tests/Conversions/Commands/CleanCommandTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest.php
@@ -287,7 +287,7 @@ it('can clean orphaned media items when enabled', function () {
         ->toMediaCollection('collection1');
 
     // Delete quietly to avoid deleting the related media file.
-    $mediaToDelete->model->deleteQuietly();
+    $mediaToDelete->model->deletePreservingMedia();
 
     $this->artisan('media-library:clean', [
         '--delete-orphaned' => 'true',

--- a/tests/Conversions/Commands/CleanCommandTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest.php
@@ -335,7 +335,7 @@ it('can clean orphaned media items when enabled for specific collections', funct
     ]);
 });
 
-it('can won\'t clean orphaned media items when disabled', function () {
+it('will not clean orphaned media items when disabled', function () {
     $media = TestModel::create(['name' => 'test.jpg'])
         ->addMedia($this->getTestJpg())
         ->preservingOriginal()

--- a/tests/Conversions/Commands/CleanCommandTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest.php
@@ -316,8 +316,8 @@ it('can clean orphaned media items when enabled for specific collections', funct
         ->toMediaCollection('collection-to-keep');
 
     // Delete quietly to avoid deleting the related media file.
-    $mediaToClean->model->deleteQuietly();
-    $mediaToKeep->model->deleteQuietly();
+    $mediaToClean->model->deletePreservingMedia();
+    $mediaToKeep->model->deletePreservingMedia();
 
     $this->artisan('media-library:clean', [
         '--delete-orphaned' => 'true',
@@ -342,7 +342,7 @@ it('can won\'t clean orphaned media items when disabled', function () {
         ->toMediaCollection('collection1');
 
     // Delete quietly to avoid deleting the related media file.
-    $media->model->deleteQuietly();
+    $media->model->deletePreservingMedia();
 
     // Without the `--delete-orphaned` flag, the orphaned media should remain.
     $this->artisan('media-library:clean');


### PR DESCRIPTION
The use-case here is to automatically delete orphaned media objects, which also deletes them from the disk.

In database structure, it's common to use cascading deletes via foreign keys. When deleting database records like that, the `Media` object isn't automatically deleted due to its morphed relation. This delete action should be implemented by the developer to delete the related media objects in the `deleting` event, but this can be easily missed. No direct effects are visible on application level, but deleted storage objects remain indefinitely in the `medias` table, as well as on storage, which might infringe on GDPR requirements, as well as unnessesary storage used.

This PR adds logic to automatically delete orphaned models in the clean command. ~I've added it as an opt-out, but if a safer opt-in option (`--delete-orphaned` instead of `--skip-orphaned`)~ I've added it as an opt-in option, where `--delete-orphaned` needs to be included to delete orphaned models.

Happy to chat about other approaches if preferred :)