### PR TITLE
Don't include soft deleted models as orphaned media

### DIFF
--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -91,14 +91,14 @@ class MediaRepository
     public function getOrphans(): DbCollection
     {
         return $this->query()
-            ->whereDoesntHave('model')
+            ->whereDoesntHave('model', fn (Builder $q) => $q->hasMacro('withTrashed') ? $q->withTrashed() : $q)
             ->get();
     }
 
     public function getOrphansByCollectionName(string $collectionName): DbCollection
     {
         return $this->query()
-            ->whereDoesntHave('model')
+            ->whereDoesntHave('model', fn (Builder $q) => $q->hasMacro('withTrashed') ? $q->withTrashed() : $q)
             ->where('collection_name', $collectionName)
             ->get();
     }

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -90,15 +90,13 @@ class MediaRepository
 
     public function getOrphans(): DbCollection
     {
-        return $this->query()
-            ->whereDoesntHave('model', fn (Builder $q) => $q->hasMacro('withTrashed') ? $q->withTrashed() : $q)
+        return $this->orphansQuery()
             ->get();
     }
 
     public function getOrphansByCollectionName(string $collectionName): DbCollection
     {
-        return $this->query()
-            ->whereDoesntHave('model', fn (Builder $q) => $q->hasMacro('withTrashed') ? $q->withTrashed() : $q)
+        return $this->orphansQuery()
             ->where('collection_name', $collectionName)
             ->get();
     }
@@ -106,6 +104,15 @@ class MediaRepository
     protected function query(): Builder
     {
         return $this->model->newQuery();
+    }
+
+    protected function orphansQuery(): Builder
+    {
+        return $this->query()
+            ->whereDoesntHave(
+                'model',
+                fn (Builder $q) => $q->hasMacro('withTrashed') ? $q->withTrashed() : $q,
+            );
     }
 
     protected function getDefaultFilterFunction(array $filters): Closure


### PR DESCRIPTION
This follows on from @mbardelmeijer's great work in #3419. 

When cascading deletes are used the media should definitely be removed from the database and storage as it's relationship no longer exists. However, when a model is soft deleted it has the option of being restored and the accompanying media needs to be available.