### PR TITLE
Suggest the installation of svgo through snap on Ubuntu

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -325,6 +325,13 @@ sudo apt install jpegoptim optipng pngquant gifsicle libavif-bin
 npm install -g svgo
 ```
 
+If you don't want to install `npm` on your Ubuntu server, you can use `snap` which is installed by default:
+
+```bash
+sudo apt install jpegoptim optipng pngquant gifsicle libavif-bin
+sudo snap install svgo
+```
+
 Here's how to install the binaries on MacOS (using [Homebrew](https://brew.sh/)):
 
 ```bash


### PR DESCRIPTION
I would like to suggest installing svgo through snap as an alternative to installing npm