### PR TITLE
Improve defaultSanitizer

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -396,9 +396,16 @@ class FileAdder
 
     public function defaultSanitizer(string $fileName): string
     {
-        $fileName = preg_replace('#\p{C}+#u', '', $fileName);
+        $extension = pathinfo($fileName, PATHINFO_EXTENSION);
+        
+        $fileName = str($fileName)
+            ->basename(".{$extension}")
+            ->matchAll('/[\p{L}\p{N}]+/u')
+            ->implode('-');
 
-        return str_replace(['#', '/', '\\', ' '], '-', $fileName);
+        return str($fileName)
+            ->append(".{$extension}")
+            ->value();
     }
 
     public function sanitizingFileName(callable $fileNameSanitizer): self

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -400,10 +400,11 @@ class FileAdder
         
         $fileName = str($fileName)
             ->basename(".{$extension}")
-            ->matchAll('/[\p{L}\p{N}]+/u')
+            ->matchAll('/[\p{L}\p{N}\.]+/u')
             ->implode('-');
 
         return str($fileName)
+            ->trim('.')
             ->append(".{$extension}")
             ->value();
     }

--- a/tests/MediaCollections/FileAdderTest.php
+++ b/tests/MediaCollections/FileAdderTest.php
@@ -14,6 +14,18 @@ it('sanitizes filenames correctly', function () {
     expect($adder->defaultSanitizer('test one.pdf'))
         ->toEqual('test-one.pdf');
 
+    expect($adder->defaultSanitizer('test    one.pdf'))
+        ->toEqual('test-one.pdf');
+
+    expect($adder->defaultSanitizer('test one 😀.pdf'))
+        ->toEqual('test-one.pdf');
+
+    expect($adder->defaultSanitizer('test/\/\one.pdf'))
+        ->toEqual('test-one.pdf');
+
+    expect($adder->defaultSanitizer('test|one.pdf'))
+        ->toEqual('test-one.pdf');
+
     expect($adder->defaultSanitizer('test#one.pdf'))
         ->toEqual('test-one.pdf');
 


### PR DESCRIPTION
This should replace double spaces, symbols, etc., but keep Unicode chars + dots.

It should also trim the last and first dot, to be sure it cannot contain hidden (Linux), and possible extension conflicts.

Maybe `p{S}` could be added, this allows specials symbols and emoji.