### PR TITLE
fix png transparent bug

### DIFF
--- a/src/Conversions/Actions/PerformManipulationsAction.php
+++ b/src/Conversions/Actions/PerformManipulationsAction.php
@@ -31,8 +31,7 @@ class PerformManipulationsAction
         }
 
         $image = Image::useImageDriver(config('media-library.image_driver'))
-            ->loadFile($conversionTempFile)
-            ->format('jpg');
+            ->loadFile($conversionTempFile);
 
         try {
             $conversion->getManipulations()->apply($image);


### PR DESCRIPTION
There is an unnecessary format change when doing conversation that makes some weird bug when we use the GD driver.
This one line of code made me read the whole system of the image, image-optimizer, and laravel media library package 😊

the image input:
![image](https://github.com/spatie/laravel-medialibrary/assets/15873972/5150f73e-c26f-4f63-af1c-94ec11f2f090)

the result after converting to webp format with a white background before this PR:
![image](https://github.com/spatie/laravel-medialibrary/assets/15873972/8e8d8380-e542-43fe-af3e-f579aa8d808d)

and after this PR:
![image](https://github.com/spatie/laravel-medialibrary/assets/15873972/ec6a0ec5-b615-4260-86b5-bbe2c01ceca5)
