### PR TITLE
Adjust installation documentation for publishing migrations and config files

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -18,7 +18,7 @@ If you have a license for Media Library Pro, you should install `spatie/laravel-
 You need to publish the migration to create the `media` table:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="migrations"
+php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="medialibrary-migrations"
 ```
 
 After that, you need to run migrations.
@@ -32,7 +32,7 @@ php artisan migrate
 Publishing the config file is optional:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="config"
+php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="medialibrary-config"
 ```
 
 This is the default content of the config file:


### PR DESCRIPTION
In order to publish migrations or config files using the 'php artisan vendor:publish --tag='' " ' command, it is necessary to adjust the tag by adding the 'package short name' with a slash (in this case, 'medialibrary-'). This adjustment is required for compatibility with the following code snippet in the PackageServiceProvider from Spatie\LaravelPackageTools:
                $this->publishes([
                    $filePath => $this->generateMigrationName(
                        $migrationFileName,
                        $now->addSecond()
                    ), ], "{$this->package->shortName()}-migrations");

                $this->publishes([
                    $this->package->basePath("/../config/{$configFileName}.php") => config_path("{$configFileName}.php"),
                ], "{$this->package->shortName()}-config");