### PR TITLE
laravel-pint-action to major version

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -13,7 +13,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Fix styling issues
-        uses: aglipanci/laravel-pint-action@2.3.0
+        uses: aglipanci/laravel-pint-action@v2
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
https://github.com/aglipanci/laravel-pint-action/releases/tag/v2
major version tag avoids "bumps" on every menor release