### PR TITLE
When streaming media, replace with feof/fread instead of fpassthru

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -206,6 +206,13 @@ class Filesystem
         return $this->filesystem->disk($media->disk)->readStream($sourceFile);
     }
 
+    public function getConversionStream(Media $media, string $conversion)
+    {
+        $sourceFile = $media->getPathRelativeToRoot($conversion);
+
+        return $this->filesystem->disk($media->conversions_disk)->readStream($sourceFile);
+    }
+
     public function copyFromMediaLibrary(Media $media, string $targetFile): string
     {
         file_put_contents($targetFile, $this->getStream($media));


### PR DESCRIPTION
Hi,

I ran into an issue where when returning a Media item directly in our controller, it was building our response as a stream but hitting memory allocation errors.

The reason for this is the functionality of fpassthru. It's designed to 'Output all remaining data on a file pointer' - https://www.php.net/manual/en/function.fpassthru.php

This update uses feof/fread to instead chunk the output and clear the buffers, preventing memory issues.

I've also added a setter to allow modification of the chunk size. Example usage:

```php
public function show(Media $media) {
    // stream our media out in 5MB chunks
    return $media->setStreamChunkSize((1024*1024)*5);
}
```

While I was in the project I've also added a helper method to get a stream for a conversion, this was something that we've been using in a project of ours.
