### PR TITLE
New 'getDownloadFilename' method for extensibility

### DIFF
--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Mail\Attachment;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
@@ -31,7 +32,6 @@ use Spatie\MediaLibrary\Support\TemporaryDirectory;
 use Spatie\MediaLibrary\Support\UrlGenerator\UrlGenerator;
 use Spatie\MediaLibrary\Support\UrlGenerator\UrlGeneratorFactory;
 use Spatie\MediaLibraryPro\Models\TemporaryUpload;
-use Symfony\Component\HttpFoundation\HeaderUtils;
 
 /**
  * @property string $uuid
@@ -321,11 +321,13 @@ class Media extends Model implements Attachable, Htmlable, Responsable
 
     private function buildResponse($request, string $contentDispositionType)
     {
+        $filename = str_replace('"', '\'', Str::ascii($this->getDownloadFilename()));
+
         $downloadHeaders = [
             'Cache-Control' => 'must-revalidate, post-check=0, pre-check=0',
             'Content-Type' => $this->mime_type,
             'Content-Length' => $this->size,
-            'Content-Disposition' => HeaderUtils::makeDisposition($contentDispositionType, $this->getDownloadFilename()),
+            'Content-Disposition' => $contentDispositionType . '; filename="' . $filename . '"',
             'Pragma' => 'public',
         ];
 

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -31,6 +31,7 @@ use Spatie\MediaLibrary\Support\TemporaryDirectory;
 use Spatie\MediaLibrary\Support\UrlGenerator\UrlGenerator;
 use Spatie\MediaLibrary\Support\UrlGenerator\UrlGeneratorFactory;
 use Spatie\MediaLibraryPro\Models\TemporaryUpload;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 
 /**
  * @property string $uuid
@@ -134,6 +135,11 @@ class Media extends Model implements Attachable, Htmlable, Responsable
         }
 
         return $this->getUrl();
+    }
+
+    public function getDownloadFilename(): string
+    {
+        return $this->file_name;
     }
 
     public function getAvailableFullUrl(array $conversionNames): string
@@ -319,7 +325,7 @@ class Media extends Model implements Attachable, Htmlable, Responsable
             'Cache-Control' => 'must-revalidate, post-check=0, pre-check=0',
             'Content-Type' => $this->mime_type,
             'Content-Length' => $this->size,
-            'Content-Disposition' => $contentDispositionType.'; filename="'.$this->file_name.'"',
+            'Content-Disposition' => HeaderUtils::makeDisposition($contentDispositionType, $this->getDownloadFilename()),
             'Pragma' => 'public',
         ];
 


### PR DESCRIPTION
When downloading a file by utilising Responsable, the file naming at the point of download isn't very flexible.

I've added a method that allows extending the Media class, and in turn the download file name, rather than having to create my own download controller for a filament project I'm working on (for some reason in Filament the file names are by default obfuscated). I can then simply extend the functionality by overriding the method

```php
    public function getDownloadFilename(): string
    {
        return $this->name . '.' . pathinfo($this->file_name, PATHINFO_EXTENSION);
    }
```

In addition I've utilised Symfony's HeaderUtils class (as Laravel does) to generate the disposition, ensuring it's sanitised and always correctly formatted.

Thanks!