### PR TITLE
Adds the HttpFacadeDownloader

### DIFF
--- a/docs/advanced-usage/using-a-custom-media-downloader.md
+++ b/docs/advanced-usage/using-a-custom-media-downloader.md
@@ -46,3 +46,48 @@ class CustomDownloader implements Downloader {
 
 }
 ```
+
+## Using the Laravel Downloader
+
+You may configure the medialibrary config to use a downloader compatible more
+with Laravel that makes use of the built-in HTTP client. This is the quickest way
+to mock any requests made to external URLs.
+
+```php
+    // config/media-library.php
+
+    /*
+     * When using the addMediaFromUrl method you may want to replace the default downloader.
+     * This is particularly useful when the url of the image is behind a firewall and
+     * need to add additional flags, possibly using curl.
+     */
+    'media_downloader' => Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader::class,
+```
+
+This then makes it easier in tests to mock the download of files.
+
+```php
+$url = 'http://medialibrary.spatie.be/assets/images/mountain.jpg';
+$yourModel
+   ->addMediaFromUrl($url)
+   ->toMediaCollection();
+```
+
+with a test like this:
+
+```php
+Http::fake([
+    // Stub a response where the body will be the contents of the file
+    'http://medialibrary.spatie.be/assets/images/mountain.jpg' => Http::response('::file::'),
+]);
+
+// Execute code for the test
+
+// Then check that a request for the file was made
+Http::assertSent(function (Request $request) {
+    return $request->url() == 'http://medialibrary.spatie.be/assets/images/mountain.jpg';
+});
+
+// We may also assert that the contents of any files created
+// will contain `::file::`
+```

--- a/src/Downloaders/HttpFacadeDownloader.php
+++ b/src/Downloaders/HttpFacadeDownloader.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\MediaLibrary\Downloaders;
+
+use Illuminate\Support\Facades\Http;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
+
+class HttpFacadeDownloader implements Downloader
+{
+    public function getTempFile(string $url): string
+    {
+        $temporaryFile = tempnam(sys_get_temp_dir(), 'media-library');
+
+        Http::withUserAgent('Spatie MediaLibrary')
+            ->throw(fn () => throw new UnreachableUrl($url))
+            ->sink($temporaryFile)
+            ->get($url);
+
+        return $temporaryFile;
+    }
+}

--- a/tests/Downloader/HttpFacadeDownloaderTest.php
+++ b/tests/Downloader/HttpFacadeDownloaderTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
 it('can save a url to a temp location', function () {
-    $url = '';
+    $url = 'https://example.com';
 
     \Illuminate\Support\Facades\Http::shouldReceive('withUserAgent')
         ->with('Spatie MediaLibrary')
@@ -25,4 +28,28 @@ it('can save a url to a temp location', function () {
     $result = $downloader->getTempFile($url);
 
     expect($result)->toBeString();
+});
+
+it('can be mocked easily for tests', function () {
+    $url = 'https://example.com';
+
+    Http::fake([
+        // Stub a JSON response for GitHub endpoints...
+        'https://example.com' => Http::response('::file::'),
+    ]);
+
+    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader();
+
+    $result = $downloader->getTempFile($url);
+
+    expect($result)
+        ->toBeString()
+        ->and($result)
+        ->toBeFile()
+        ->and(\Illuminate\Support\Facades\File::get($result))
+        ->toBe('::file::');
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() == 'https://example.com';
+    });
 });

--- a/tests/Downloader/HttpFacadeDownloaderTest.php
+++ b/tests/Downloader/HttpFacadeDownloaderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+it('can save a url to a temp location', function () {
+    $url = '';
+
+    \Illuminate\Support\Facades\Http::shouldReceive('withUserAgent')
+        ->with('Spatie MediaLibrary')
+        ->once()
+        ->andReturnSelf()
+        ->getMock()
+        ->shouldReceive('throw')
+        ->once()
+        ->andReturnSelf()
+        ->getMock()
+        ->shouldReceive('sink')
+        ->once()
+        ->andReturnSelf()
+        ->getMock()
+        ->shouldReceive('get')
+        ->with($url)
+        ->once();
+
+    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader();
+
+    $result = $downloader->getTempFile($url);
+
+    expect($result)->toBeString();
+});


### PR DESCRIPTION
# Changes

- Adds a new HttpFacadeDownloader implementing the Downloader interface.
- Adds a test for the new Downloader.

# Why

I find it difficult to write tests with the current downloader as it can't even be mocked by the container and requires a config change. I thought at a minimum this might be a small improvement as the Http facade is pretty good for mocking HTTP calls.

# Usage

The downloader is used as normal.

```php
    // config/media-library.php

    /*
     * When using the addMediaFromUrl method you may want to replace the default downloader.
     * This is particularly useful when the url of the image is behind a firewall and
     * need to add additional flags, possibly using curl.
     */
    'media_downloader' => Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader::class,
```

This then makes it easier in tests to mock the download of files.

```php
$url = 'http://medialibrary.spatie.be/assets/images/mountain.jpg';
$yourModel
   ->addMediaFromUrl($url)
   ->toMediaCollection();
```

with a test like this:

```php
Http::fake([
    // Stub a response where the body will be the contents of the file
    'http://medialibrary.spatie.be/assets/images/mountain.jpg' => Http::response('::file::'),
]);

// Execute code for the test

// Then check that a request for the file was made
Http::assertSent(function (Request $request) {
    return $request->url() == 'http://medialibrary.spatie.be/assets/images/mountain.jpg';
});

// We may also assert that the contents of any files created
// will contain `::file::`
```