### PR TITLE
Update preparing-your-model.md - manipulations class has been replaced with `Fit` enum

### DIFF
--- a/docs/basic-usage/preparing-your-model.md
+++ b/docs/basic-usage/preparing-your-model.md
@@ -23,14 +23,14 @@ The `Collection` component will show a preview thumbnail for items in the collec
 To generate that thumbnail, you must add a conversion like this one to your model.
 
 ```php
-use Spatie\Image\Manipulations;
+use Spatie\Image\Enums\Fit;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 public function registerMediaConversions(Media $media = null): void
 {
     $this
         ->addMediaConversion('preview')
-        ->fit(Manipulations::FIT_CROP, 300, 300)
+        ->fit(Fit::Contain, 300, 300)
         ->nonQueued();
 }
 ```


### PR DESCRIPTION
It seems the manipulations class has been replaced with `Fit` enum