### PR TITLE
update docs to align with the latest changes in medialibrary-pro

### DIFF
--- a/docs/advanced-usage/disable-cdn.md
+++ b/docs/advanced-usage/disable-cdn.md
@@ -3,23 +3,23 @@ title: Disable CDN
 weight: 12
 ---
 
-Media Library Pro uses a CDN to load the [Dragula](https://github.com/bevacqua/dragula) library. Dragula provides the drag-and-drop-ability inside a Media Library Pro component.
+Media Library Pro uses a CDN to load the [Sortable](https://github.com/SortableJS/Sortable) library. Sortable provides the drag-and-drop-ability inside a Media Library Pro component.
 
-If you would like to disable the loading via CDN and want to take care by yourself of including Dragula you will need to add the following option to your `media-library.php` config file.
+If you would like to disable the loading via CDN and want to take care by yourself of including Sortable you will need to add the following option to your `media-library.php` config file.
 
 ```php
     ...
     /*
-    * When disabling this option, Media Library Pro don't include a script tag to load the dragula library via a CDN.
-    * You have to include the dragula library by yourself!
-    */
-    'include_dragula_cdn_script' => false,
+     * When disabling this option, Media Library Pro don't include a script tag to load the Sortable library via a CDN.
+     * You have to include the Sortable library by yourself!
+     */
+    'include_sortable_cdn_script' => false,
     ...
 ```
-You can install Dragula within your project dependencies and include it in your `app.js`.
+You can install Sortable within your project dependencies and include it in your `app.js`.
 
 ```js
-import dragula from 'dragula';
+import Sortable from 'sortablejs'
 
-window.dragula = dragula;
+window.Sortable = Sortable
 ```


### PR DESCRIPTION
The dragula library was replaced with Sortable. The PR updates the docs to the latest changes in medialibrary-pro.