### PR TITLE
Add count media functionality

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -241,11 +241,19 @@ trait InteractsWithMedia
     }
 
     /*
+     * Count media in the given collection.
+     */
+    public function countMedia(string $collectionName = 'default', array $filters = []): int
+    {
+        return count($this->getMedia($collectionName, $filters));
+    }
+
+    /*
      * Determine if there is media in the given collection.
      */
     public function hasMedia(string $collectionName = 'default', array $filters = []): bool
     {
-        return count($this->getMedia($collectionName, $filters)) ? true : false;
+        return $this->countMedia($collectionName, $filters) ? true : false;
     }
 
     /**

--- a/tests/Feature/InteractsWithMedia/CountMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/CountMediaTest.php
@@ -1,0 +1,46 @@
+<?php
+
+it('returns zero for an empty collection', function () {
+    expect($this->testModel->countMedia())->toEqual(0);
+});
+
+it('returns count for a non empty collection', function () {
+    $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+    $this->testModel->addMedia($this->getTestPng())->toMediaCollection();
+
+    expect($this->testModel->countMedia())->toEqual(2);
+});
+
+it('returns count for a non empty collection in an unsaved model', function () {
+    $this->testUnsavedModel->addMedia($this->getTestJpg())->toMediaCollection();
+
+    expect($this->testUnsavedModel->countMedia())->toEqual(1);
+});
+
+it('returns count if any collection is not empty', function () {
+    $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+
+    expect($this->testModel->countMedia('images'))->toEqual(1);
+});
+
+it('returns zero for an empty named collection', function () {
+    expect($this->testModel->countMedia('images'))->toEqual(0);
+});
+
+it('returns count for a non empty named collection', function () {
+    $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+
+    expect($this->testModel->countMedia('images'))->toEqual(1);
+    expect($this->testModel->countMedia('downloads'))->toEqual(0);
+});
+
+it('returns count for a filtered collection', function () {
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withCustomProperties(['test' => true])
+        ->toMediaCollection();
+
+    expect($this->testModel->countMedia('default'))->toEqual(1);
+    expect($this->testModel->countMedia('default', ['test' => true]))->toEqual(1);
+    expect($this->testModel->countMedia('default', ['test' => false]))->toEqual(0);
+});


### PR DESCRIPTION
I would like to add `countMedia` as a fluent alternative to
- `count($this->getMedia($collectionName, $filters))`
- `$this->getMedia($collectionName)->count();`

Here's my use case in blade
```php

// before
@if($model->getMedia()->count() > 1)
@endif

// after
@if($model->countMedia() > 1)
@endif
```

A similar PR #1582 closed 5 years ago but I wish this is reconsidered