### PR TITLE
Refinement & Fix bugs

### DIFF
--- a/src/MediaCollections/FileAdderFactory.php
+++ b/src/MediaCollections/FileAdderFactory.php
@@ -40,7 +40,7 @@ class FileAdderFactory
     {
         return collect($keys)
             ->map(function (string $key) use ($subject) {
-                $key = preg_replace('/[^A-Za-z0-9_]/', '', $key);
+                $key =  trim(basename($key), './');
 
                 if (! request()->hasFile($key)) {
                     throw RequestDoesNotHaveFile::create($key);

--- a/src/MediaCollections/FileAdderFactory.php
+++ b/src/MediaCollections/FileAdderFactory.php
@@ -40,10 +40,7 @@ class FileAdderFactory
     {
         return collect($keys)
             ->map(function (string $key) use ($subject) {
-                $search = ['[', ']', '"', "'"];
-                $replace = ['.', '', '', ''];
-
-                $key = str_replace($search, $replace, $key);
+                $key = preg_replace('/[^A-Za-z0-9_]/', '', $key);
 
                 if (! request()->hasFile($key)) {
                     throw RequestDoesNotHaveFile::create($key);

--- a/src/Support/File.php
+++ b/src/Support/File.php
@@ -6,19 +6,13 @@ use Symfony\Component\Mime\MimeTypes;
 
 class File
 {
-    public static function getHumanReadableSize(int $sizeInBytes): string
+    public static function getHumanReadableSize(int|float $sizeInBytes): string
     {
-        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-        if ($sizeInBytes == 0) {
-            return '0 '.$units[1];
-        }
+        $index = min(count($units) - 1, floor(log(abs($sizeInBytes), 1024)));
 
-        for ($i = 0; $sizeInBytes > 1024; $i++) {
-            $sizeInBytes /= 1024;
-        }
-
-        return round($sizeInBytes, 2).' '.$units[$i];
+        return sprintf("%s %s", round(num: abs($sizeInBytes) / (1024 ** $index), precision: 2), $units[$index]);
     }
 
     public static function getMimeType(string $path): string

--- a/tests/Support/FileTest.php
+++ b/tests/Support/FileTest.php
@@ -8,6 +8,7 @@ it('can determine a human readable filesize', function () {
     expect(File::getHumanReadableSize(1000))->toEqual('1000 B');
     expect(File::getHumanReadableSize(10000))->toEqual('9.77 KB');
     expect(File::getHumanReadableSize(10000))->toEqual('9.77 KB');
+    expect(File::getHumanReadableSize(-10000))->toEqual('9.77 KB');
     $this->assertEquals('976.56 KB', File::getHumanReadableSize(1_000_000));
     $this->assertEquals('9.54 MB', File::getHumanReadableSize(10_000_000));
     $this->assertEquals('9.31 GB', File::getHumanReadableSize(10_000_000_000));
@@ -16,6 +17,7 @@ it('can determine a human readable filesize', function () {
     $this->assertEquals('86.74 EB', File::getHumanReadableSize(100_000_000_000_000_000_000));
     $this->assertEquals('84.7 ZB', File::getHumanReadableSize(100_000_000_000_000_000_000_000));
     $this->assertEquals('82.72 YB', File::getHumanReadableSize(100_000_000_000_000_000_000_000_000));
+    $this->assertEquals('82.72 YB', File::getHumanReadableSize(-100_000_000_000_000_000_000_000_000));
 });
 
 it('can determine the mime type of a file', function () {

--- a/tests/Support/FileTest.php
+++ b/tests/Support/FileTest.php
@@ -7,9 +7,15 @@ it('can determine a human readable filesize', function () {
     expect(File::getHumanReadableSize(100))->toEqual('100 B');
     expect(File::getHumanReadableSize(1000))->toEqual('1000 B');
     expect(File::getHumanReadableSize(10000))->toEqual('9.77 KB');
+    expect(File::getHumanReadableSize(10000))->toEqual('9.77 KB');
     $this->assertEquals('976.56 KB', File::getHumanReadableSize(1_000_000));
     $this->assertEquals('9.54 MB', File::getHumanReadableSize(10_000_000));
     $this->assertEquals('9.31 GB', File::getHumanReadableSize(10_000_000_000));
+    $this->assertEquals('9.09 TB', File::getHumanReadableSize(10_000_000_000_000));
+    $this->assertEquals('8.88 PB', File::getHumanReadableSize(10_000_000_000_000_000));
+    $this->assertEquals('86.74 EB', File::getHumanReadableSize(100_000_000_000_000_000_000));
+    $this->assertEquals('84.7 ZB', File::getHumanReadableSize(100_000_000_000_000_000_000_000));
+    $this->assertEquals('82.72 YB', File::getHumanReadableSize(100_000_000_000_000_000_000_000_000));
 });
 
 it('can determine the mime type of a file', function () {


### PR DESCRIPTION
During my research on the `laravelmedia-library` package source I figured out that two helper/Support functions on this package making problems in real-life cases, The first one was `getHumanReadable()` support function which if it receives a negative value or 0, the value will still be negative or it will return the (0) value as (0 KB) which is not relevant because the value of (0) means that there's no data inside a file so it should display (0 B) as it's more relevant and describe that the file has no data on it like it may be an empty .txt file, I know this may not happen in real life development as the function is being used internally, but the calculation of the function is wrong and may cause problems in future, So the function has been refactored and the mentioned bugs have been fixed you can test it in `php artisan tinker` command from both my fixes & the previous code to assure that it's a good commit.

Second, the `createMultipleFromRequest()` function from the `FileAdderFactory::class` seems to be vulnerable with an LFI (Local File Inclusion) vulnerability, to prove it you can execute this part of the code on the `php artisan tinker` console:

```md
file_get_contents(str_replace(['[', ']', '"', "'"], ['.', '', '', ''], "../../../../../../../etc/hosts"))
```

I know that this command is just an execution of a malicious payload and not related to the function somehow, but I've provide that to prove that the filtration that has been done on the file is not working well and it's vulnerable to LFI, so thinking of the vulnerable function pushes me to fork the repo to make the package safer as it's the biggest one that is mostly being used on laravel applications.

And it's worth mentioning to say that if you chain the above payload mechanism you can actually bypass the filtration and force the function to upload an internal server file like `/etc[/hosts, /passwd, /shadow, ...etc]` to the storage bucket of the Laravel application that is using this file, it can be done by manipulating the HTTP POST request that accepting the `multipart/formdata` header, it's doable as the user has access over the `createMultipleFromRequest()` method using some other methods on the Traits.

In the end, thanks for your time in reading my explanation, I'll be happy to be a collaborator in this repo if it finds me creative and reasonable to be.

Cheers,
Ehsan Faramarz - TheXerr0r