### PR TITLE
Refactored how download file name is determined within MediaStream

### DIFF
--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -93,6 +93,7 @@ class MediaStream implements Responsable
 
     protected function getZipStreamContents(): Collection
     {
+
         return $this->mediaItems->map(fn (Media $media, $mediaItemIndex) => [
             'fileNameInZip' => $this->getZipFileNamePrefix($this->mediaItems, $mediaItemIndex).$this->getFileNameWithSuffix($this->mediaItems, $mediaItemIndex),
             'media' => $media,
@@ -103,14 +104,14 @@ class MediaStream implements Responsable
     {
         $fileNameCount = 0;
 
-        $fileName = $mediaItems[$currentIndex]->file_name;
+        $fileName = $mediaItems[$currentIndex]->getDownloadFilename();
 
         foreach ($mediaItems as $index => $media) {
             if ($index >= $currentIndex) {
                 break;
             }
 
-            if ($this->getZipFileNamePrefix($mediaItems, $index).$media->file_name === $this->getZipFileNamePrefix($mediaItems, $currentIndex).$fileName) {
+            if ($this->getZipFileNamePrefix($mediaItems, $index).$media->getDownloadFilename() === $this->getZipFileNamePrefix($mediaItems, $currentIndex).$fileName) {
                 $fileNameCount++;
             }
         }

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Support\MediaStream;
+use Spatie\MediaLibrary\Tests\TestSupport\TestMediaModel;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -42,6 +43,25 @@ it('can return a stream of multiple files with the same filename', function () {
     $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');
     $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test (1).jpg');
     $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test (2).jpg');
+});
+
+it('will respect the filename set by getDownloadFilename method', function () {
+    $zipStreamResponse = MediaStream::create('my-media.zip')
+        ->addMedia(Media::find(1))
+        ->addMedia(TestMediaModel::find(2))
+        ->addMedia(TestMediaModel::find(2));
+
+    ob_start();
+    @$zipStreamResponse->toResponse(request())->sendContent();
+    $content = ob_get_contents();
+    ob_end_clean();
+
+    $temporaryDirectory = (new TemporaryDirectory())->create();
+    file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+    $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');
+    $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'overriden_testing.jpg');
+    $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'overriden_testing (1).jpg');
 });
 
 test('media can be added to it one by one', function () {

--- a/tests/TestSupport/TestMediaModel.php
+++ b/tests/TestSupport/TestMediaModel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class TestMediaModel extends Media
+{
+    public function getDownloadFilename(): string
+    {
+        return 'overriden_testing.jpg';
+    }
+}


### PR DESCRIPTION
In addition to PR #3504, I have added the `getDownloadFilename()` method to the MediaStream download.

This allows custom file names to be utilised within the MediaStream zip generation, while not impacting number appends, etc. I've also written a test to cover this.

Thanks to @justmetalcake for pointing out this issue!

Cheers.