### PR TITLE
Support for passing an array of styles as extra attributes

### DIFF
--- a/src/MediaCollections/HtmlableMedia.php
+++ b/src/MediaCollections/HtmlableMedia.php
@@ -28,6 +28,10 @@ class HtmlableMedia implements \Stringable, Htmlable
             $attributes['class'] = Arr::toCssClasses($attributes['class']);
         }
 
+        if (is_array($attributes['style'] ?? null)) {
+            $attributes['style'] = Arr::toCssStyles($attributes['style']);
+        }
+
         $this->extraAttributes = $attributes;
 
         return $this;


### PR DESCRIPTION
This PR adds support for passing an array of styles when rendering a Media Model:

Media::first()->img('thumb', ['styles' => [
    'rounded',
    'border' => true,
    'border-black' => false,
]]),

Under the hood, it uses Laravel's Arr::toCssStyles helper method.