### PR TITLE
Leave the ability to override media model in InteractsWithMedia trait

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -58,7 +58,7 @@ trait InteractsWithMedia
 
     public function media(): MorphMany
     {
-        return $this->morphMany(config('media-library.media_model'), 'model');
+        return $this->morphMany($this->getMediaModel(), 'model');
     }
 
     /**
@@ -263,6 +263,11 @@ trait InteractsWithMedia
         return app(MediaRepository::class);
     }
 
+    public function getMediaModel(): string
+    {
+        return config('media-library.media_model');
+    }
+
     public function getFirstMedia(string $collectionName = 'default', $filters = []): ?Media
     {
         $media = $this->getMedia($collectionName, $filters);
@@ -378,7 +383,7 @@ trait InteractsWithMedia
     {
         $this->removeMediaItemsNotPresentInArray($newMediaArray, $collectionName);
 
-        $mediaClass = config('media-library.media_model');
+        $mediaClass = $this->getMediaModel();
         $mediaInstance = new $mediaClass();
         $keyName = $mediaInstance->getKeyName();
 


### PR DESCRIPTION
This PR add the (little) ability to override media model in trait (like MediaRepository), this can facilitate some cases of applications with package used on multiple databases (without the need to modify the configuration at runtime).