### PR TITLE
Fix DivisionByZeroError in getHumanReadable

### DIFF
--- a/src/Support/File.php
+++ b/src/Support/File.php
@@ -10,6 +10,10 @@ class File
     {
         $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
+        if ($sizeInBytes == 0) {
+            return '0 '.$units[0];
+        }
+
         $index = min(count($units) - 1, floor(log(abs($sizeInBytes), 1024)));
 
         return sprintf('%s %s', round(num: abs($sizeInBytes) / (1024 ** $index), precision: 2), $units[$index]);


### PR DESCRIPTION
After updating to the latest media library I got this Divide by Zero error

Think this commit broke it https://github.com/spatie/laravel-medialibrary/commit/81876c36c09d717e99e7c07cad8dd2775e25504e

