### PR TITLE
Fix handling of dots in conversion names for clean command

### DIFF
--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -218,6 +218,7 @@ class CleanCommand extends Command
         $generatedConversionName = null;
 
         $media->getGeneratedConversions()
+            ->dot()
             ->filter(
                 fn (bool $isGenerated, string $generatedConversionName) => Str::contains($conversionFile, $generatedConversionName)
             )

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -306,9 +306,9 @@ class Media extends Model implements Attachable, Htmlable, Responsable
 
     public function hasGeneratedConversion(string $conversionName): bool
     {
-        $generatedConversions = $this->getGeneratedConversions();
+        $generatedConversions = $this->generated_conversions;
 
-        return $generatedConversions[$conversionName] ?? false;
+        return Arr::get($generatedConversions, $conversionName, false);
     }
 
     public function setStreamChunkSize(int $chunkSize)

--- a/tests/Conversions/Commands/CleanCommandTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest.php
@@ -65,20 +65,25 @@ test('generated conversion are cleared after cleanup', function () {
     Media::where('id', '<>', $media->id)->delete();
 
     $media->markAsConversionGenerated('test-deprecated');
+    $media->markAsConversionGenerated('test.deprecated');
 
     $media->save();
 
     expect($media->refresh()->hasGeneratedConversion('test-deprecated'))->toBeTrue();
+    expect($media->refresh()->hasGeneratedConversion('test.deprecated'))->toBeTrue();
 
-    $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-deprecated.jpg");
+    $deprecatedImage1 = $this->getMediaDirectory("{$media->id}/conversions/test-deprecated.jpg");
+    $deprecatedImage2 = $this->getMediaDirectory("{$media->id}/conversions/test.deprecated.jpg");
 
-    touch($deprecatedImage);
+    touch($deprecatedImage1);
+    touch($deprecatedImage2);
 
     $this->artisan('media-library:clean');
 
     $media->refresh();
 
     expect($media->hasGeneratedConversion('test-deprecated'))->toBeFalse();
+    expect($media->hasGeneratedConversion('test.deprecated'))->toBeFalse();
 });
 
 it('can clean deprecated conversion files from a specific model type', function () {


### PR DESCRIPTION
The clean command had an issue with conversions that contain a dot because their status is saved in a multidimensional array in the database. The clean command expected a one-dimensional array.