### PR TITLE
fixes responsive images wiped on some circumstances

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -242,7 +242,7 @@ class Filesystem
 
         $responsiveImagePaths = array_filter(
             $allFilePaths,
-            fn (string $path) => Str::contains($path, $conversionName)
+            fn (string $path) => Str::contains($path, $media->name) && Str::contains($path, $conversionName)
         );
 
         $this->filesystem->disk($media->disk)->delete($responsiveImagePaths);


### PR DESCRIPTION
fixes too loose condition that cause to wipe out all generated responsive images if they are generated in the same output directory.
This can happens specially when using custom path generators, that point generated images the same subdirectory

Should fix  #3557