### PR TITLE
Update docs with correct tag for publishing package views

### DIFF
--- a/docs/advanced-usage/rendering-media.md
+++ b/docs/advanced-usage/rendering-media.md
@@ -60,7 +60,7 @@ Lazy loading this one: {{ $media()->lazy() }}
 You can customize the rendered output even further by publishing the `views` with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="views"
+php artisan vendor:publish --provider="Spatie\MediaLibrary\MediaLibraryServiceProvider" --tag="media-library-views"
 ```
 
 The following files will be published in the `resources/views/vendor/media-library` directory:


### PR DESCRIPTION
This PR updates the docs to include the correct tag when publishing the views for the package, see #3567.

ping @freekmurze 