### PR TITLE
Update installation-setup.md

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -8,7 +8,7 @@ Media Library can be installed via Composer:
 If you only use the base package issue this command:
 
 ```bash
-composer require "spatie/laravel-medialibrary:^11.0.0"
+composer require "spatie/laravel-medialibrary"
 ```
 
 If you have a license for Media Library Pro, you should install `spatie/laravel-media-library-pro` instead. Please refer to our [Media Library Pro installation instructions](https://spatie.be/docs/laravel-medialibrary/v11/handling-uploads-with-media-library-pro/installation) to continue.


### PR DESCRIPTION
Fixes error `spatie/laravel-medialibrary 11.0.0 requires illuminate/bus ^10.0 -> found illuminate/bus[v10.0.0, ..., v10.48.4] but these were not loaded` with fresh installation