### PR TITLE
Update create_media_table.php.stub

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -12,7 +12,7 @@ return new class extends Migration
             $table->id();
 
             $table->morphs('model');
-            $table->uuid('uuid')->nullable()->unique();
+            $table->uuid()->nullable()->unique();
             $table->string('collection_name');
             $table->string('name');
             $table->string('file_name');


### PR DESCRIPTION
Clean up the migration stub by removing unneeded argument.
![image](https://github.com/spatie/laravel-medialibrary/assets/23425456/58ad03eb-7d4c-4d8e-9f70-570c29a569d9)
No breaking change as we require a minimum of Laravel 10.x. Just a small cleanup.
