### PR TITLE
Fix manipulations not applying to non default collections

### DIFF
--- a/src/Conversions/ConversionCollection.php
+++ b/src/Conversions/ConversionCollection.php
@@ -96,7 +96,7 @@ class ConversionCollection extends Collection
     {
         /** @var Conversion|null $conversion */
         $conversion = $this->first(function (Conversion $conversion) use ($conversionName) {
-            if (! in_array($this->media->collection_name, $conversion->getPerformOnCollections())) {
+            if (! $conversion->shouldBePerformedOn($this->media->collection_name)) {
                 return false;
             }
 

--- a/tests/Conversions/ConversionCollectionTest.php
+++ b/tests/Conversions/ConversionCollectionTest.php
@@ -19,8 +19,17 @@ beforeEach(function () {
     $secondMedia->manipulations = ['thumb' => ['greyscale' => [], 'height' => [20]]];
     $secondMedia->save();
 
+    $avatarMedia = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('avatar');
+
+    $avatarMedia->manipulations = ['thumb' => ['greyscale' => [], 'height' => [10]]];
+    $avatarMedia->save();
+
     $this->media = $media->fresh();
     $this->secondMedia = $media->fresh();
+    $this->avatarMedia = $avatarMedia->fresh();
 });
 
 it('will prepend the manipulation saved on the model and the wildmark manipulations', function () {
@@ -56,6 +65,29 @@ it('will prepend the manipulation saved on the model', function () {
     $conversionCollection = ConversionCollection::createForMedia($this->media);
 
     $conversion = $conversionCollection->getConversions()->first();
+
+    expect($conversion->getName())->toEqual('thumb');
+
+    $manipulations = $conversion
+        ->getManipulations()
+        ->toArray();
+
+    $this->assertArrayHasKey('optimize', $manipulations);
+
+    unset($manipulations['optimize']);
+
+    $this->assertEquals([
+        'greyscale' => [],
+        'height' => [10],
+        'format' => ['jpg'],
+        'width' => [50],
+    ], $manipulations);
+});
+
+it('will prepend the manipulation saved on the model with non default collection', function () {
+    $conversionCollection = ConversionCollection::createForMedia($this->avatarMedia);
+
+    $conversion = $conversionCollection->getConversions()[0];
 
     expect($conversion->getName())->toEqual('thumb');
 

--- a/tests/Feature/Media/UpdateManipulationsTest.php
+++ b/tests/Feature/Media/UpdateManipulationsTest.php
@@ -23,8 +23,8 @@ it('will create derived files when manipulations have changed', function () {
 
     $media->manipulations = [
         'update_test' => [
-            'width' => 1,
-            'height' => 1,
+            'width' => [1],
+            'height' => [1],
         ],
     ];
 
@@ -51,9 +51,10 @@ it('will not create derived files when manipulations have not changed', function
 
     $media->manipulations = [
         'update_test' => [
-            'width' => 1,
-            'height' => 1,
-        ], ];
+            'width' => [1],
+            'height' => [1],
+        ],
+    ];
 
     $media->save();
 
@@ -63,9 +64,10 @@ it('will not create derived files when manipulations have not changed', function
 
     $media->manipulations = [
         'update_test' => [
-            'width' => 1,
-            'height' => 1,
-        ], ];
+            'width' => [1],
+            'height' => [1],
+        ],
+    ];
 
     $media->updated_at = now()->addSecond();
 


### PR DESCRIPTION
When adding manipulations to non default collections they silently not applying, because method `getPerformOnCollections` returns `['default']` then conversion created without specifying on which collections it should be run. Method `shouldBePerformedOn` checks that.
Test I added should fail without this fix.

Also while writing test I noticed `$this->secondMedia` get populated with `$media` rather than `$secondMedia`. Seems like bug