### PR TITLE
Fix - Supported format from original file

### DIFF
--- a/src/Conversions/Actions/PerformManipulationsAction.php
+++ b/src/Conversions/Actions/PerformManipulationsAction.php
@@ -25,7 +25,7 @@ class PerformManipulationsAction
 
         File::copy($imageFile, $conversionTempFile);
 
-        $supportedFormats = ['jpg', 'pjpg', 'png', 'gif'];
+        $supportedFormats = ['jpg', 'jpeg', 'pjpg', 'png', 'gif', 'webp'];
         if ($conversion->shouldKeepOriginalImageFormat() && in_array($media->extension, $supportedFormats)) {
             $conversion->format($media->extension);
         }


### PR DESCRIPTION
This PR fix supported format when regenerate images from original file. The driver support webp and jpeg since a long time.

Currently if the dev regenerate images from 'webp' extension the driver use 'jpg' default format and generate black paint in a background. This PR also fix #3502 
