### PR TITLE
Remove temp/cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tests/temp
 composer.lock
 phpunit.xml
 .env
+.phpunit.cache/
 .phpunit.result.cache
 .php-cs-fixer.cache
 phpstan.neon

--- a/.phpunit.cache/test-results
+++ b/.phpunit.cache/test-results
@@ -1,1 +1,0 @@
-{"version":"pest_2.34.0","defects":{"P\\Tests\\Conversions\\ConversionOrientationTest::__pest_evaluable_it_can_correctly_convert_an_image_with_orientation_exif_data":7},"times":{"P\\Tests\\Conversions\\ConversionOrientationTest::__pest_evaluable_it_can_correctly_convert_an_image_with_orientation_exif_data":0.123}}


### PR DESCRIPTION
This PR removes the `.phpunit.cache/` directory and its files, which appear to have been committed accidentally. 

It also adds the path to the `.gitignore` file to avoid committing any cache/temp files in the future.

ping @freekmurze 