### PR TITLE
Add `down` DB Migration to drop media table

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -29,4 +29,10 @@ return new class extends Migration
             $table->nullableTimestamps();
         });
     }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('media');
+    }
 };
+


### PR DESCRIPTION
This package publishes a migration to create the `media` table, but it only has an `up` method.

This means that if the migration is rolled back, and then migrated again, the migration will fail as the `media` table already exists.

This pull request adds a simple `down` method to the migration to drop the `media` table.