### PR TITLE
Media Downloader Verify SSL Config Added

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -200,7 +200,7 @@ return [
 
     /*
      * When using the addMediaFromUrl method the SSL is verified by default.
-     * This is option disables SSL verification when downloading remote media locally.
+     * This is option disables SSL verification when downloading remote media.
      * Please note that this is a security risk and should only be false in a local environment.
      */
     'media_downloader_ssl' => env('MEDIA_DOWNLOADER_SSL', true),

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -198,6 +198,13 @@ return [
      */
     'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
 
+    /*
+     * When using the addMediaFromUrl method the SSL is verified by default.
+     * This is option disables SSL verification when downloading remote media locally.
+     * Please note that this is a security risk and should only be false in a local environment.
+     */
+    'media_downloader_ssl' => env('MEDIA_DOWNLOADER_SSL', true),
+
     'remote' => [
         /*
          * Any extra headers that should be included when uploading media to

--- a/src/Downloaders/DefaultDownloader.php
+++ b/src/Downloaders/DefaultDownloader.php
@@ -9,6 +9,10 @@ class DefaultDownloader implements Downloader
     public function getTempFile(string $url): string
     {
         $context = stream_context_create([
+            "ssl" => [
+                "verify_peer" => config('media-library.ssl'),
+                "verify_peer_name" => config('media-library.ssl')
+            ],
             'http' => [
                 'header' => 'User-Agent: Spatie MediaLibrary',
             ],


### PR DESCRIPTION
Added the option to disable verify for media downloader. This affects addMediaFromUrl as trying to download media locally from another app/site will cause the file not to be found. fopen which the downloader uses will always verify the SSL which locally will fail when using a self certificate.