### PR TITLE
fix: Add drop functionality to media table migration on rollback

### DIFF
--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -29,4 +29,9 @@ return new class extends Migration
             $table->nullableTimestamps();
         });
     }
+
+    public function down(): void
+        {
+            Schema::dropIfExists('media');
+        }
 };


### PR DESCRIPTION
Hi @freekmurze,

The package is fantastic and saves a lot of time on media handling. However, I encountered an issue when rolling back and re-running migrations. It caused an exception: **General error: 1 table "media" already exists.** This indicates the table isn't dropped on rollback.

This PR adds the drop table functionality during rollback to resolve the issue.

Thanks