### PR TITLE
Do not limit the maximum execution time if the queue connection is "sync"

### DIFF
--- a/src/Conversions/Commands/RegenerateCommand.php
+++ b/src/Conversions/Commands/RegenerateCommand.php
@@ -38,13 +38,17 @@ class RegenerateCommand extends Command
 
         $this->fileManipulator = $fileManipulator;
 
-        if (! $this->confirmToProceed()) {
+        if (!$this->confirmToProceed()) {
             return;
         }
 
         $mediaFiles = $this->getMediaToBeRegenerated();
 
         $progressBar = $this->output->createProgressBar($mediaFiles->count());
+
+        if (config('media-library.queue_connection_name') == 'sync') {
+            set_time_limit(0);
+        }
 
         $mediaFiles->each(function (Media $media) use ($progressBar) {
             try {
@@ -104,7 +108,7 @@ class RegenerateCommand extends Command
     {
         $mediaIds = $this->option('ids');
 
-        if (! is_array($mediaIds)) {
+        if (!is_array($mediaIds)) {
             $mediaIds = explode(',', (string) $mediaIds);
         }
 

--- a/src/Conversions/Commands/RegenerateCommand.php
+++ b/src/Conversions/Commands/RegenerateCommand.php
@@ -38,7 +38,7 @@ class RegenerateCommand extends Command
 
         $this->fileManipulator = $fileManipulator;
 
-        if (!$this->confirmToProceed()) {
+        if (! $this->confirmToProceed()) {
             return;
         }
 
@@ -46,7 +46,7 @@ class RegenerateCommand extends Command
 
         $progressBar = $this->output->createProgressBar($mediaFiles->count());
 
-        if (config('media-library.queue_connection_name') == 'sync') {
+        if (config('media-library.queue_connection_name') === 'sync') {
             set_time_limit(0);
         }
 
@@ -108,7 +108,7 @@ class RegenerateCommand extends Command
     {
         $mediaIds = $this->option('ids');
 
-        if (!is_array($mediaIds)) {
+        if (! is_array($mediaIds)) {
             $mediaIds = explode(',', (string) $mediaIds);
         }
 


### PR DESCRIPTION
When regenerating the conversions and if the queue connection is set to "sync", the jobs are not handled "asynchronously". So the execution time can be very long depending on the number of medias to handle. And in some cases, the script reached the maximum execution time defined in php.ini and exit with an error code.

This PR disable the maximum execution time if the queue connection is "sync".