### PR TITLE
Unwanted deletion fixes

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -242,7 +242,7 @@ class Filesystem
 
         $responsiveImagePaths = array_filter(
             $allFilePaths,
-            fn (string $path) => Str::contains($path, $conversionName)
+            fn (string $path) => Str::contains($path, $media->name) && Str::contains($path, $conversionName)
         );
 
         $this->filesystem->disk($media->disk)->delete($responsiveImagePaths);

--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -242,7 +242,7 @@ class Filesystem
 
         $responsiveImagePaths = array_filter(
             $allFilePaths,
-            fn (string $path) => Str::contains($path, $media->name) && Str::contains($path, $conversionName)
+            fn (string $path) => Str::contains($path, $media->name."___". $conversionName)
         );
 
         $this->filesystem->disk($media->disk)->delete($responsiveImagePaths);


### PR DESCRIPTION
I tried to regenerate 350K+ images conversions  with responsive images, i spotted some cases that lead to wrong deletions on some generated images that have a part of the name included in other filenames, so the Str::contains should be more specific and i fixed the issue borrowing the addPropertiesToFileName pattern to check "{$fileName}___{$conversionName}";
Now all the unwanted missing conversion that appeared randomly are gone away.