### PR TITLE
Added when() method to FileAdder

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -541,4 +541,15 @@ class FileAdder
             ? $file.'.'.$extension
             : $file;
     }
+
+    public function when(bool $value, callable $callback = null, callable $default = null): self
+    {
+        if ($value === true) {
+            return $callback($this, $value) ?? $this;
+        } elseif ($default !== null) {
+            return $default($this, $value) ?? $this;
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
My pull request adds syntactic sugar like the one used in eloquent builder to allow the when() method to be used.

Example:

```php
$model->addMedia($file)
    ->preservingOriginal(false)
    ->when(in_array($file->getMimeType(), $availableMimeTypes), function (FileAdder $fileAdder) {
        $fileAdder->withCustomProperties([
            'property' => 'value',
        ]);
    })->toMediaCollection();
```

Instead:

```php
$media = $model->addMedia($file)->preservingOriginal(false);

if (in_array($file->getMimeType(), $availableMimeTypes)) {
    $media->withCustomProperties([
        'property' => 'value',
    ]);
}

$media->toMediaCollection();
```