### PR TITLE
Update 'queue_name' configuration to use environment variable

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -24,7 +24,7 @@ return [
      * This queue will be used to generate derived and responsive images.
      * Leave empty to use the default queue.
      */
-    'queue_name' => '',
+    'queue_name' => env('MEDIA_QUEUE', ''),
 
     /*
      * By default all conversions will be performed on a queue.


### PR DESCRIPTION
This PR updates the ﻿`queue_name` configuration in ﻿`spatie/laravel-medialibrary` to make use of the ﻿`MEDIA_QUEUE` environment variable. By leveraging environment variables, we enhance flexibility and simplify configuration management without the need to publish the configuration file every time a value change is required. This change ensures seamless integration with environmental settings while maintaining the ability to customize the queue name as needed.