### PR TITLE
Make media lazy loading configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ phpunit.xml
 .php-cs-fixer.cache
 phpstan.neon
 tests/Support/temp/
+.idea/

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -266,4 +266,10 @@ return [
      * If you set this to `/my-subdir`, all your media will be stored in a `/my-subdir` directory.
      */
     'prefix' => env('MEDIA_PREFIX', ''),
+
+    /*
+     * When forcing lazy loading, media will be loaded even if you don't eager load media and you have
+     * disabled lazy loading globally in the service provider.
+     */
+    'force_lazy_loading' => env('FORCE_MEDIA_LIBRARY_LAZY_LOADING', true),
 ];

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -266,7 +266,13 @@ return [
      * You can specify a prefix for that is used for storing all media.
      * If you set this to `/my-subdir`, all your media will be stored in a `/my-subdir` directory.
      */
-      'prefix' => env('MEDIA_PREFIX', ''),
+     'prefix' => env('MEDIA_PREFIX', ''),
+
+    /*
+     * When forcing lazy loading, media will be loaded even if you don't eager load media and you have
+     * disabled lazy loading globally in the service provider.
+     */
+    'force_lazy_loading' => env('FORCE_MEDIA_LIBRARY_LAZY_LOADING', true),
 ];
 ```
 

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -530,8 +530,12 @@ trait InteractsWithMedia
 
     public function loadMedia(string $collectionName): Collection
     {
+        if (config('media-library.enable_lazy_loading') && $this->exists) {
+            $this->loadMissing('media');
+        }
+
         $collection = $this->exists
-            ? $this->loadMissing('media')->media
+            ? $this->media
             : collect($this->unAttachedMediaLibraryItems)->pluck('media');
 
         $collection = new MediaCollections\Models\Collections\MediaCollection($collection);

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -530,7 +530,7 @@ trait InteractsWithMedia
 
     public function loadMedia(string $collectionName): Collection
     {
-        if (config('media-library.enable_lazy_loading') && $this->exists) {
+        if (config('media-library.force_lazy_loading') && $this->exists) {
             $this->loadMissing('media');
         }
 

--- a/tests/Feature/Performance/PerformanceTest.php
+++ b/tests/Feature/Performance/PerformanceTest.php
@@ -1,5 +1,9 @@
 <?php
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\LazyLoadingViolationException;
+use Illuminate\Support\Facades\Config;
+
 it('can use eagerly loaded media', function () {
     foreach (range(1, 10) as $index) {
         $testModel = $this->testModelWithConversion->create(['name' => "test{$index}"]);
@@ -16,4 +20,38 @@ it('can use eagerly loaded media', function () {
     }
 
     expect(DB::getQueryLog())->toHaveCount(2);
+});
+
+it('can lazy load media by default even prevent lazy loading globally enabled', function () {
+    foreach (range(1, 10) as $index) {
+        $testModel = $this->testModelWithConversion->create(['name' => "test{$index}"]);
+        $testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    }
+
+    Model::preventLazyLoading();
+
+    DB::connection()->enableQueryLog();
+
+    $testModels = $this->testModelWithConversion->get();
+
+    foreach ($testModels as $testModel) {
+        $testModel->getFirstMediaUrl('images', 'thumb');
+    }
+
+    expect(DB::getQueryLog())->toHaveCount(12);
+});
+
+it('throws an exception when lazy loading is disabled on both the config and globally', function () {
+    foreach (range(1, 10) as $index) {
+        $testModel = $this->testModelWithConversion->create(['name' => "test{$index}"]);
+        $testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    }
+
+    Model::preventLazyLoading();
+
+    Config::set('media-library.force_lazy_loading', false);
+
+    $testModels = $this->testModelWithConversion->get();
+
+    expect(fn() => $testModels->first()->getFirstMediaUrl('images', 'thumb'))->toThrow(LazyLoadingViolationException::class);
 });


### PR DESCRIPTION
### References

Related issue: https://github.com/spatie/laravel-medialibrary/issues/3554

### Story

In our legacy admin we noticed a lot of lazy loaded media relations that causes an n+1 issue silently without throwing an exception even with `Model::preventLazyLoading()` enabled globally.

The related issue referenced above gives more details.

### Changes

- Add new config parameter `force_lazy_loading` to allow enable/disable media lazy loading. Enabled by default, so it will not require any changes for those happy with the current behavior.
- Update the `InteractsWithMedia` trait to load media based on `force_lazy_loading` value.
- Update the docs to show the new config parameter.
- Add new test to check that media still lazy loaded even with `Model::preventLazyLoading()` enabled globally, but `force_lazy_loading` still on it's default value.
- Add new test to check that it throws a `LazyLoadingViolationException` exception when `Model::preventLazyLoading()` enabled globally and `force_lazy_loading` set to `true`.