### PR TITLE
Fix wrong deletions

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -242,7 +242,7 @@ class Filesystem
 
         $responsiveImagePaths = array_filter(
             $allFilePaths,
-            fn (string $path) => Str::contains($path, $conversionName)
+            fn (string $path) => Str::contains($path, $media->name) && Str::contains($path, $conversionName)
         );
 
         $this->filesystem->disk($media->disk)->delete($responsiveImagePaths);

--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -242,7 +242,7 @@ class Filesystem
 
         $responsiveImagePaths = array_filter(
             $allFilePaths,
-            fn (string $path) => Str::contains($path, $media->name) && Str::contains($path, $conversionName)
+            fn (string $path) => Str::contains($path, $media->name."___". $conversionName)
         );
 
         $this->filesystem->disk($media->disk)->delete($responsiveImagePaths);

--- a/src/Support/FileRemover/DefaultFileRemover.php
+++ b/src/Support/FileRemover/DefaultFileRemover.php
@@ -37,7 +37,7 @@ class DefaultFileRemover implements FileRemover
                         $this->filesystem->disk($media->conversions_disk)->delete($imagePath);
                     }
 
-                    if ($this->filesystem->disk($media->conversions_disk)->allFiles($directory)->isEmpty()) {
+                    if (!$this->filesystem->disk($media->conversions_disk)->allFiles($directory)) {
                         $this->filesystem->disk($media->conversions_disk)->deleteDirectory($directory);
                     }
                 } catch (Exception $exception) {

--- a/src/Support/FileRemover/DefaultFileRemover.php
+++ b/src/Support/FileRemover/DefaultFileRemover.php
@@ -16,49 +16,55 @@ class DefaultFileRemover implements FileRemover
 
     public function removeAllFiles(Media $media): void
     {
-        $this->removeFromMediaDirectory($media);
 
-        $this->removeFromConversionsDirectory($media);
+        if ($media->disk !== $media->conversions_disk) {
+            $this->removeFromMediaDirectory($media,$media->conversions_disk);
+            $this->removeFromConversionsDirectory($media,$media->conversions_disk);
+            $this->removeFromResponsiveImagesDirectory($media,$media->conversions_disk);
+        }
 
-        $this->removeFromResponsiveImagesDirectory($media);
+        $this->removeFromMediaDirectory($media,$media->disk);
+        $this->removeFromConversionsDirectory($media,$media->disk);
+        $this->removeFromResponsiveImagesDirectory($media,$media->disk);
     }
 
-    public function removeFromMediaDirectory(Media $media): void
+    public function removeFromMediaDirectory(Media $media, string $disk): void
     {
         $mediaDirectory = $this->mediaFileSystem->getMediaDirectory($media);
 
 
         collect([$mediaDirectory])
-            ->each(function (string $directory) use ($media) {
+            ->each(function (string $directory) use ($media, $disk) {
                 try {
-                    $allFilePaths = $this->filesystem->disk($media->conversions_disk)->allFiles($directory);
+                    $allFilePaths = $this->filesystem->disk($disk)->allFiles($directory);
                     $imagePaths = array_filter(
                         $allFilePaths,
                         function (string $path) use ($media) {
-                            return Str::contains($path, $media->name.".");
+                            return Str::contains($path, pathinfo($media->file_name, PATHINFO_FILENAME).".");
                         }
                     );
                     foreach ($imagePaths as $imagePath) {
-                        $this->filesystem->disk($media->conversions_disk)->delete($imagePath);
+                        $this->filesystem->disk($disk)->delete($imagePath);
                     }
 
-                    if (!$this->filesystem->disk($media->conversions_disk)->allFiles($directory)) {
-                        $this->filesystem->disk($media->conversions_disk)->deleteDirectory($directory);
+                    if (!$this->filesystem->disk($disk)->allFiles($directory)) {
+                        $this->filesystem->disk($disk)->deleteDirectory($directory);
                     }
                 } catch (Exception $exception) {
                     report($exception);
                 }
             });
+
     }
 
-    public function removeFromConversionsDirectory(Media $media): void
+    public function removeFromConversionsDirectory(Media $media, string $disk): void
     {
         $conversionsDirectory = $this->mediaFileSystem->getMediaDirectory($media, 'conversions');
 
         collect([$conversionsDirectory])
-            ->each(function (string $directory) use ($media) {
+            ->each(function (string $directory) use ($media, $disk) {
                 try {
-                    $allFilePaths = $this->filesystem->disk($media->conversions_disk)->allFiles($directory);
+                    $allFilePaths = $this->filesystem->disk($disk)->allFiles($directory);
 
                     $conversions = array_keys($media->generated_conversions);
 
@@ -66,7 +72,7 @@ class DefaultFileRemover implements FileRemover
                         $allFilePaths,
                         function (string $path) use ($conversions, $media) {
                             foreach ($conversions as $conversion) {
-                                if (Str::contains($path, $media->name . "-" . $conversion)) {
+                                if (Str::contains($path, pathinfo($media->file_name, PATHINFO_FILENAME) . "-" . $conversion)) {
                                     return true;
                                 }
                             }
@@ -74,11 +80,11 @@ class DefaultFileRemover implements FileRemover
                         }
                     );
                     foreach ($imagePaths as $imagePath) {
-                        $this->filesystem->disk($media->conversions_disk)->delete($imagePath);
+                        $this->filesystem->disk($disk)->delete($imagePath);
                     }
 
-                    if (!$this->filesystem->disk($media->conversions_disk)->allFiles($directory)) {
-                        $this->filesystem->disk($media->conversions_disk)->deleteDirectory($directory);
+                    if (!$this->filesystem->disk($disk)->allFiles($directory)) {
+                        $this->filesystem->disk($disk)->deleteDirectory($directory);
                     }
                 } catch (Exception $exception) {
                     report($exception);
@@ -86,15 +92,15 @@ class DefaultFileRemover implements FileRemover
             });
     }
 
-    public function removeFromResponsiveImagesDirectory(Media $media): void
+    public function removeFromResponsiveImagesDirectory(Media $media, string $disk): void
     {
         $responsiveImagesDirectory = $this->mediaFileSystem->getMediaDirectory($media, 'responsiveImages');
 
         collect([ $responsiveImagesDirectory])
             ->unique()
-            ->each(function (string $directory) use ($media) {
+            ->each(function (string $directory) use ($media,$disk) {
                 try {
-                    $allFilePaths = $this->filesystem->disk($media->conversions_disk)->allFiles($directory);
+                    $allFilePaths = $this->filesystem->disk($disk)->allFiles($directory);
 
                     $conversions = array_keys($media->generated_conversions);
                     $conversions[] = "media_library_original";
@@ -103,7 +109,7 @@ class DefaultFileRemover implements FileRemover
                         $allFilePaths,
                         function (string $path) use ($conversions, $media) {
                             foreach ($conversions as $conversion) {
-                                if (Str::contains($path, $media->name . "___" . $conversion)) {
+                                if (Str::contains($path, pathinfo($media->file_name, PATHINFO_FILENAME) . "___" . $conversion)) {
                                     return true;
                                 }
                             }
@@ -111,11 +117,11 @@ class DefaultFileRemover implements FileRemover
                         }
                     );
                     foreach ($imagePaths as $imagePath) {
-                        $this->filesystem->disk($media->conversions_disk)->delete($imagePath);
+                        $this->filesystem->disk($disk)->delete($imagePath);
                     }
 
-                    if (!$this->filesystem->disk($media->conversions_disk)->allFiles($directory)) {
-                        $this->filesystem->disk($media->conversions_disk)->deleteDirectory($directory);
+                    if (!$this->filesystem->disk($disk)->allFiles($directory)) {
+                        $this->filesystem->disk($disk)->deleteDirectory($directory);
                     }
                 } catch (Exception $exception) {
                     report($exception);

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -8,6 +8,8 @@ use Spatie\MediaLibrary\Support\FileRemover\FileBaseFileRemover;
 use Spatie\MediaLibrary\Tests\Support\PathGenerator\CustomDirectoryStructurePathGenerator;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestPathGenerator;
+use Spatie\MediaLibrary\Tests\TestSupport\TestCustomPathGenerator;
+
 
 it('will remove the files when deleting an object that has media', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
@@ -102,6 +104,23 @@ it('will NOT remove other files within the same folder when deleting a media obj
 
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
     $media2 = $this->testModel->addMedia($this->getTestPng())->toMediaCollection('images');
+
+    expect(File::exists($media->getPath()))->toBeTrue();
+    expect(File::exists($media2->getPath()))->toBeTrue();
+
+    $media->delete();
+
+    expect(File::exists($media->getPath()))->toBeFalse();
+    expect(File::exists($media2->getPath()))->toBeTrue();
+});
+
+it('will NOT remove other files within the same folder when deleting a media object with similar image names saved on same custom path and directory generator', function () {
+
+    config(['media-library.path_generator' => TestCustomPathGenerator::class]);
+    config(['media-library.file_remover_class' => FileBaseFileRemover::class]);
+
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $media2 = $this->testModel->addMedia($this->getTestImageEndingWithUnderscore())->toMediaCollection('images');
 
     expect(File::exists($media->getPath()))->toBeTrue();
     expect(File::exists($media2->getPath()))->toBeTrue();

--- a/tests/TestSupport/TestCustomPathGenerator.php
+++ b/tests/TestSupport/TestCustomPathGenerator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Support\PathGenerator\PathGenerator;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
+
+class TestCustomPathGenerator implements PathGenerator
+{
+    public function getPath(Media $media): string
+    {
+        $entry = TestModel::find($media->model_id);
+
+        return "some_user/{$media->model_id}";
+    }
+
+    public function getPathForConversions(Media $media): string
+    {
+        return $this->getPath($media).'/custom_conversions/';
+    }
+
+    public function getPathForResponsiveImages(Media $media): string
+    {
+        return $this->getPath($media).'/custom_responsive_images/';
+    }
+}

--- a/tests/TestSupport/TestCustomPathGenerator.php
+++ b/tests/TestSupport/TestCustomPathGenerator.php
@@ -12,16 +12,16 @@ class TestCustomPathGenerator implements PathGenerator
     {
         $entry = TestModel::find($media->model_id);
 
-        return "some_user/{$media->model_id}";
+        return "some_user/{$media->model_id}/";
     }
 
     public function getPathForConversions(Media $media): string
     {
-        return $this->getPath($media).'/custom_conversions/';
+        return $this->getPath($media).'custom_conversions/';
     }
 
     public function getPathForResponsiveImages(Media $media): string
     {
-        return $this->getPath($media).'/custom_responsive_images/';
+        return $this->getPath($media).'custom_responsive_images/';
     }
 }


### PR DESCRIPTION
In case of custom paths setup to save the images in the same subdirectory ex. username/post_id/photos/somefile.ext when a file is removed from the media directory it wipes all the directory content.

This commit fixes this problem only deleting the proper images (and related conversions and responsive images) and delete the directory only if is empty.