### PR TITLE
[11.x] Support spatie/pdf-to-image v3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         php: [8.3, 8.2]
         laravel: [10.*, 11.*]
+        pdf: [^2.2, ^3.0]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -49,7 +50,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" "spatie/pdf-to-image:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         php: [8.3, 8.2]
         laravel: [10.*, 11.*]
-        pdf: [^2.2, ^3.0]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -18,7 +17,7 @@ jobs:
           - laravel: 11.*
             testbench: ^9.0
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - PtI${{ matrix.pdf }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Update apt
@@ -50,7 +49,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" "spatie/pdf-to-image:${{ matrix.pdf }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
           - laravel: 11.*
             testbench: ^9.0
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - PtI${{ matrix.pdf }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Update apt
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" "spatie/pdf-to-image:${{ matrix.laravel }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.62.1" "spatie/pdf-to-image:${{ matrix.pdf }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "pestphp/pest": "^2.28",
         "phpstan/extension-installer": "^1.3.1",
         "spatie/laravel-ray": "^1.33",
-        "spatie/pdf-to-image": "^3.0",
+        "spatie/pdf-to-image": "^2.2|^3.0",
         "spatie/pest-plugin-snapshots": "^2.1"
     },
     "conflict": {
@@ -60,7 +60,7 @@
     "suggest": {
         "league/flysystem-aws-s3-v3": "Required to use AWS S3 file storage",
         "php-ffmpeg/php-ffmpeg": "Required for generating video thumbnails",
-        "spatie/pdf-to-image": "Required for generating thumbnails of PDFs and SVGs (^3.0)"
+        "spatie/pdf-to-image": "Required for generating thumbnails of PDFs and SVGs"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "pestphp/pest": "^2.28",
         "phpstan/extension-installer": "^1.3.1",
         "spatie/laravel-ray": "^1.33",
-        "spatie/pdf-to-image": "^2.2",
+        "spatie/pdf-to-image": "^3.0",
         "spatie/pest-plugin-snapshots": "^2.1"
     },
     "conflict": {
@@ -60,7 +60,7 @@
     "suggest": {
         "league/flysystem-aws-s3-v3": "Required to use AWS S3 file storage",
         "php-ffmpeg/php-ffmpeg": "Required for generating video thumbnails",
-        "spatie/pdf-to-image": "Required for generating thumbnails of PDFs and SVGs"
+        "spatie/pdf-to-image": "Required for generating thumbnails of PDFs and SVGs (^3.0)"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Conversions/ImageGenerators/Pdf.php
+++ b/src/Conversions/ImageGenerators/Pdf.php
@@ -14,7 +14,7 @@ class Pdf extends ImageGenerator
 
         $pageNumber = $conversion ? $conversion->getPdfPageNumber() : 1;
 
-        (new \Spatie\PdfToImage\Pdf($file))->setPage($pageNumber)->saveImage($imageFile);
+        (new \Spatie\PdfToImage\Pdf($file))->selectPage($pageNumber)->save($imageFile);
 
         return $imageFile;
     }

--- a/src/Conversions/ImageGenerators/Pdf.php
+++ b/src/Conversions/ImageGenerators/Pdf.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\MediaLibrary\Conversions\ImageGenerators;
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Illuminate\Support\Collection;
 use Imagick;
 use Spatie\MediaLibrary\Conversions\Conversion;
@@ -14,9 +16,18 @@ class Pdf extends ImageGenerator
 
         $pageNumber = $conversion ? $conversion->getPdfPageNumber() : 1;
 
-        (new \Spatie\PdfToImage\Pdf($file))->selectPage($pageNumber)->save($imageFile);
+        if ($this->usesPdfToImageV3()) {
+            (new \Spatie\PdfToImage\Pdf($file))->selectPage($pageNumber)->save($imageFile);
+        } else {
+            (new \Spatie\PdfToImage\Pdf($file))->setPage($pageNumber)->saveImage($imageFile);
+        }
 
         return $imageFile;
+    }
+
+    private function usesPdfToImageV3(): bool
+    {
+        return InstalledVersions::satisfies(new VersionParser, 'spatie/pdf-to-image', '^3.0');
     }
 
     public function requirementsAreInstalled(): bool


### PR DESCRIPTION
With the release of spatie/pdf-to-image v3, the spatie media library is no longer compatible with the current implementation.

This PR makes a breaking change by needing v3 instead of v2 and using the corresponding new methods.