### PR TITLE
Don't pull all media models from DB when performing cleanup

### DIFF
--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -186,11 +186,8 @@ class CleanCommand extends Command
         if (is_null(config("filesystems.disks.{$diskName}"))) {
             throw DiskDoesNotExist::create($diskName);
         }
-        $mediaClass = config('media-library.media_model');
-        $mediaInstance = new $mediaClass();
-        $keyName = $mediaInstance->getKeyName();
 
-        $mediaIds = collect($this->mediaRepository->all()->pluck($keyName)->toArray());
+        $mediaIds = $this->mediaRepository->allIds();
 
         /** @var array<int, string> */
         $directories = $this->fileSystem->disk($diskName)->directories();

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -46,6 +46,11 @@ class MediaRepository
         return $this->query()->get();
     }
 
+    public function allIds(): Collection
+    {
+        return $this->query()->pluck($this->model->getKeyName());
+    }
+
     public function getByModelType(string $modelType): DbCollection
     {
         return $this->query()->where('model_type', $modelType)->get();


### PR DESCRIPTION
Hi!
I've noticed that when you do a clean-up, it pulls out all models from the database, just to get the IDs, which is a bit wasteful. This is a small change that changes this behaviour so that it pulls out only IDs.
