### PR TITLE
Check for enum instances when applying manipulations

### DIFF
--- a/src/Conversions/Manipulations.php
+++ b/src/Conversions/Manipulations.php
@@ -59,17 +59,53 @@ class Manipulations
     public function apply(ImageDriver $image): void
     {
         foreach ($this->manipulations as $manipulationName => $parameters) {
-            match ($manipulationName) {
-                'border' => (isset($parameters['type'])) && $parameters['type'] = BorderType::from($parameters['type']),
-                'watermark' => (isset($parameters['fit'])) && $parameters['fit'] = Fit::from($parameters['fit']),
-                'watermark','resizeCanvas','insert' => (isset($parameters['position'])) && $parameters['position'] = AlignPosition::from($parameters['position']),
-                'pickColor' => (isset($parameters['colorFormat'])) && $parameters['colorFormat'] = ColorFormat::from($parameters['colorFormat']),
-                'resize','width','height' => (isset($parameters['constraints'])) && $parameters['constraints'] = Constraint::from($parameters['constraints']),
-                'crop' => (isset($parameters['position'])) && $parameters['position'] = CropPosition::from($parameters['position']),
-                'fit' => (isset($parameters['fit'])) && $parameters['fit'] = Fit::from($parameters['fit']),
-                'flip' => (isset($parameters['flip'])) && $parameters['flip'] = FlipDirection::from($parameters['flip']),
-                default => ''
-            };
+            switch ($manipulationName) {
+                case 'border':
+                    if (isset($parameters['type']) && !$parameters['type'] instanceof BorderType) {
+                        $parameters['type'] = BorderType::from($parameters['type']);
+                    }
+                    break;
+                case 'watermark':
+                    if (isset($parameters['fit']) && !$parameters['fit'] instanceof Fit) {
+                        $parameters['fit'] = Fit::from($parameters['fit']);
+                    }
+                // Fallthrough intended for position
+                case 'resizeCanvas':
+                case 'insert':
+                    if (isset($parameters['position']) && !$parameters['position'] instanceof AlignPosition) {
+                        $parameters['position'] = AlignPosition::from($parameters['position']);
+                    }
+                    break;
+                case 'pickColor':
+                    if (isset($parameters['colorFormat']) && !$parameters['colorFormat'] instanceof ColorFormat) {
+                        $parameters['colorFormat'] = ColorFormat::from($parameters['colorFormat']);
+                    }
+                    break;
+                case 'resize':
+                case 'width':
+                case 'height':
+                    if (isset($parameters['constraints']) && !$parameters['constraints'] instanceof Constraint) {
+                        $parameters['constraints'] = Constraint::from($parameters['constraints']);
+                    }
+                    break;
+                case 'crop':
+                    if (isset($parameters['position']) && !$parameters['position'] instanceof CropPosition) {
+                        $parameters['position'] = CropPosition::from($parameters['position']);
+                    }
+                    break;
+                case 'fit':
+                    if (isset($parameters['fit']) && !$parameters['fit'] instanceof Fit) {
+                        $parameters['fit'] = Fit::from($parameters['fit']);
+                    }
+                    break;
+                case 'flip':
+                    if (isset($parameters['flip']) && !$parameters['flip'] instanceof FlipDirection) {
+                        $parameters['flip'] = FlipDirection::from($parameters['flip']);
+                    }
+                    break;
+                default:
+                    break;
+            }
             $image->$manipulationName(...$parameters);
         }
     }

--- a/src/Conversions/Manipulations.php
+++ b/src/Conversions/Manipulations.php
@@ -5,7 +5,6 @@ namespace Spatie\MediaLibrary\Conversions;
 use Spatie\Image\Drivers\ImageDriver;
 use Spatie\Image\Enums\AlignPosition;
 use Spatie\Image\Enums\BorderType;
-use Spatie\Image\Enums\ColorFormat;
 use Spatie\Image\Enums\Constraint;
 use Spatie\Image\Enums\CropPosition;
 use Spatie\Image\Enums\Fit;
@@ -59,53 +58,7 @@ class Manipulations
     public function apply(ImageDriver $image): void
     {
         foreach ($this->manipulations as $manipulationName => $parameters) {
-            switch ($manipulationName) {
-                case 'border':
-                    if (isset($parameters['type']) && !$parameters['type'] instanceof BorderType) {
-                        $parameters['type'] = BorderType::from($parameters['type']);
-                    }
-                    break;
-                case 'watermark':
-                    if (isset($parameters['fit']) && !$parameters['fit'] instanceof Fit) {
-                        $parameters['fit'] = Fit::from($parameters['fit']);
-                    }
-                // Fallthrough intended for position
-                case 'resizeCanvas':
-                case 'insert':
-                    if (isset($parameters['position']) && !$parameters['position'] instanceof AlignPosition) {
-                        $parameters['position'] = AlignPosition::from($parameters['position']);
-                    }
-                    break;
-                case 'pickColor':
-                    if (isset($parameters['colorFormat']) && !$parameters['colorFormat'] instanceof ColorFormat) {
-                        $parameters['colorFormat'] = ColorFormat::from($parameters['colorFormat']);
-                    }
-                    break;
-                case 'resize':
-                case 'width':
-                case 'height':
-                    if (isset($parameters['constraints']) && !$parameters['constraints'] instanceof Constraint) {
-                        $parameters['constraints'] = Constraint::from($parameters['constraints']);
-                    }
-                    break;
-                case 'crop':
-                    if (isset($parameters['position']) && !$parameters['position'] instanceof CropPosition) {
-                        $parameters['position'] = CropPosition::from($parameters['position']);
-                    }
-                    break;
-                case 'fit':
-                    if (isset($parameters['fit']) && !$parameters['fit'] instanceof Fit) {
-                        $parameters['fit'] = Fit::from($parameters['fit']);
-                    }
-                    break;
-                case 'flip':
-                    if (isset($parameters['flip']) && !$parameters['flip'] instanceof FlipDirection) {
-                        $parameters['flip'] = FlipDirection::from($parameters['flip']);
-                    }
-                    break;
-                default:
-                    break;
-            }
+            $parameters = $this->transformParameters($manipulationName, $parameters);
             $image->$manipulationName(...$parameters);
         }
     }
@@ -129,5 +82,61 @@ class Manipulations
     public function toArray(): array
     {
         return $this->manipulations;
+    }
+
+    /**
+     * @param  int|string  $manipulationName
+     * @param  mixed  $parameters
+     * @return mixed
+     */
+    public function transformParameters(int|string $manipulationName, mixed $parameters): mixed
+    {
+        switch ($manipulationName) {
+            case 'border':
+                if (isset($parameters['type']) && !$parameters['type'] instanceof BorderType) {
+                    $parameters['type'] = BorderType::from($parameters['type']);
+                }
+                break;
+            case 'watermark':
+                if (isset($parameters['fit']) && !$parameters['fit'] instanceof Fit) {
+                    $parameters['fit'] = Fit::from($parameters['fit']);
+                }
+            // Fallthrough intended for position
+            case 'resizeCanvas':
+            case 'insert':
+                if (isset($parameters['position']) && !$parameters['position'] instanceof AlignPosition) {
+                    $parameters['position'] = AlignPosition::from($parameters['position']);
+                }
+                break;
+            case 'resize':
+            case 'width':
+            case 'height':
+                if (isset($parameters['constraints']) && is_array($parameters['constraints'])) {
+                    foreach ($parameters['constraints'] as &$constraint) {
+                        if (!$constraint instanceof Constraint) {
+                            $constraint = Constraint::from($constraint);
+                        }
+                    }
+                }
+                break;
+            case 'crop':
+                if (isset($parameters['position']) && !$parameters['position'] instanceof CropPosition) {
+                    $parameters['position'] = CropPosition::from($parameters['position']);
+                }
+                break;
+            case 'fit':
+                if (isset($parameters['fit']) && !$parameters['fit'] instanceof Fit) {
+                    $parameters['fit'] = Fit::from($parameters['fit']);
+                }
+                break;
+            case 'flip':
+                if (isset($parameters['flip']) && !$parameters['flip'] instanceof FlipDirection) {
+                    $parameters['flip'] = FlipDirection::from($parameters['flip']);
+                }
+                break;
+            default:
+                break;
+        }
+        return $parameters;
     }
 }

--- a/tests/Conversions/ImageManipulationTest.php
+++ b/tests/Conversions/ImageManipulationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Spatie\Image\Enums\BorderType;
+use Spatie\Image\Enums\Fit;
+use Spatie\Image\Enums\AlignPosition;
+use Spatie\Image\Enums\Constraint;
+use Spatie\Image\Enums\CropPosition;
+use Spatie\Image\Enums\FlipDirection;
+use Spatie\Image\Image;
+use Spatie\MediaLibrary\Conversions\Manipulations;
+
+it('transforms parameters correctly', function () {
+    // Mock the image object
+    $image =  Image::load(pathToImage: $this->getTestJpg());
+
+    // Define manipulations
+    $manipulations = [
+        'border' => ['width' => 10, 'type' => 'expand'],
+        'watermark' => ['fit' => 'contain', 'watermarkImage' => $this->getTestPng()],
+        'resizeCanvas' => ['position' => 'center'],
+        'resize' => ['constraints' => ['preserveAspectRatio'], 'width' => 100, 'height' => 100],
+        'crop' => ['width' => 50, 'height'=> 50, 'position' => 'topLeft'],
+        'fit' => ['fit' => 'contain'],
+        'flip' => ['flip' => 'horizontal'],
+    ];
+
+    $transformedParameters = [];
+
+    // Create an instance of the class containing the logic
+    $manipulator = new Manipulations($manipulations);
+
+    foreach ($manipulations as $manipulationName => $parameters) {
+        $parameters = $manipulator->transformParameters($manipulationName, $parameters);
+
+        // Apply the manipulation
+        $image->$manipulationName(...$parameters);
+
+        // Store the transformed parameters for assertions
+        $transformedParameters[$manipulationName] = $parameters;
+    }
+
+    // Assertions to check if parameters have been correctly transformed
+    expect($transformedParameters['border']['type'])->toBeInstanceOf(BorderType::class)
+        ->and($transformedParameters['watermark']['fit'])->toBeInstanceOf(Fit::class)
+        ->and($transformedParameters['resizeCanvas']['position'])->toBeInstanceOf(AlignPosition::class)
+        ->and($transformedParameters['resize']['constraints'][0])->toBeInstanceOf(Constraint::class)
+        ->and($transformedParameters['crop']['position'])->toBeInstanceOf(CropPosition::class)
+        ->and($transformedParameters['fit']['fit'])->toBeInstanceOf(Fit::class)
+        ->and($transformedParameters['flip']['flip'])->toBeInstanceOf(FlipDirection::class);
+});
+
+it('handles parameters that are already enum instances', function () {
+    // Mock the image object
+    $image =  Image::load(pathToImage: $this->getTestJpg());
+
+    // Define manipulations with parameters already as enum instances
+    $manipulations = [
+        'border' => ['width' => 10, 'type' => BorderType::Expand],
+        'watermark' => ['fit' => Fit::Contain, 'watermarkImage' => $this->getTestPng()],
+        'resizeCanvas' => ['position' => AlignPosition::Center],
+        'resize' => ['constraints' => [Constraint::PreserveAspectRatio], 'width' => 100, 'height' => 100],
+        'crop' => ['width' => 50, 'height'=> 50, 'position' => CropPosition::TopLeft],
+        'fit' => ['fit' => Fit::Contain],
+        'flip' => ['flip' => FlipDirection::Horizontal],
+    ];
+
+    $transformedParameters = [];
+
+    // Create an instance of the class containing the logic
+    $manipulator = new Manipulations($manipulations);
+
+    foreach ($manipulations as $manipulationName => $parameters) {
+        $parameters = $manipulator->transformParameters($manipulationName, $parameters);
+
+        // Apply the manipulation
+        $image->$manipulationName(...$parameters);
+
+        // Store the transformed parameters for assertions
+        $transformedParameters[$manipulationName] = $parameters;
+    }
+
+    // Assertions to check if parameters remain unchanged
+    expect($transformedParameters['border']['type'])->toBeInstanceOf(BorderType::class)
+        ->and($transformedParameters['watermark']['fit'])->toBeInstanceOf(Fit::class)
+        ->and($transformedParameters['resizeCanvas']['position'])->toBeInstanceOf(AlignPosition::class)
+        ->and($transformedParameters['resize']['constraints'][0])->toBeInstanceOf(Constraint::class)
+        ->and($transformedParameters['crop']['position'])->toBeInstanceOf(CropPosition::class)
+        ->and($transformedParameters['fit']['fit'])->toBeInstanceOf(Fit::class)
+        ->and($transformedParameters['flip']['flip'])->toBeInstanceOf(FlipDirection::class);
+});


### PR DESCRIPTION
It seems there is a bug introduced when passing paramaters that are already enum to image manipulations.  https://github.com/spatie/laravel-medialibrary/discussions/3626

The existing code for image manipulations was using a match expression to transform parameters based on the manipulation name. However, the match expression does not perform assignments in the way expected, leading to an error when attempting to convert parameters to enum types. Specifically, the following error was encountered:

```txt
TypeError: Spatie\Image\Enums\Fit::from(): Argument #1 ($value) must be of type string|int, Spatie\Image\Enums\Fit given in /var/www/html/vendor/spatie/laravel-medialibrary/src/Conversions/Manipulations.php:69
```

The root cause was that some parameters were already instances of the enum classes, and attempting to reassign them caused errors.

**Solution Overview**

To address this issue, the match expression was replaced with a switch statement. This allows for more explicit checks and transformations of parameters, ensuring that parameters are only converted if they are not already instances of the corresponding enum classes. The solution involves:

1. Using a switch statement to handle each manipulation case.
2. Checking if the parameter is not already an instance of the enum class before converting it.

For readability reasons I've changed the match to a switch statement.

I've also removed the `pickColor` handling as it is not not to be a valid image manipulation operation.
