### PR TITLE
Fix deletion of files without extension

### DIFF
--- a/src/Support/FileRemover/DefaultFileRemover.php
+++ b/src/Support/FileRemover/DefaultFileRemover.php
@@ -37,7 +37,7 @@ class DefaultFileRemover implements FileRemover
                     $imagePaths = array_filter(
                         $allFilePaths,
                         function (string $path) use ($media) {
-                            return Str::contains($path, pathinfo($media->file_name, PATHINFO_FILENAME).'.');
+                            return Str::afterLast($path, '/') === $media->file_name;
                         }
                     );
                     foreach ($imagePaths as $imagePath) {

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -30,6 +30,16 @@ it('will remove the files when deleting a media instance', function () {
     expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeFalse();
 });
 
+it('will remove the files without extension', function () {
+    $media = $this->testModel->addMedia($this->getTestImageWithoutExtension())->toMediaCollection('images');
+
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeTrue();
+
+    $media->delete();
+
+    expect(File::isDirectory($this->getMediaDirectory($media->id)))->toBeFalse();
+});
+
 it('will remove files when deleting a media object with a custom path generator', function () {
     config(['media-library.path_generator' => TestPathGenerator::class]);
 


### PR DESCRIPTION
Tests are failing in Laravel apps when using fake images generated by  `UploadedFile::fake()->image('image.jpg')` as the file will be generated internally by `tmpfile()` and will be named _(E.g.)_  `phpGoZkJ9`

Currently, it looks if the path contains the filename, including the dot: `phpGoZkJ9.`

I changed it to match the full filename after the forward slash `/`
From my understanding, the `$path` will always have a forward slash (`/`) before the filename. 

If there's a case where doesn't have a forward slash or uses double backslashes `\\` (because Windows),I will happily update my PR to include corresponding scenarios and tests.

Thanks!