### PR TITLE
Use Lazy Collection for artisan commands

### DIFF
--- a/src/Conversions/Commands/RegenerateCommand.php
+++ b/src/Conversions/Commands/RegenerateCommand.php
@@ -6,7 +6,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\Conversions\FileManipulator;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
@@ -80,7 +80,7 @@ class RegenerateCommand extends Command
         $this->info('All done!');
     }
 
-    public function getMediaToBeRegenerated(): Collection
+    public function getMediaToBeRegenerated(): LazyCollection
     {
         // Get this arg first as it can also be passed to the greater-than-id branch
         $modelType = $this->argument('modelType');

--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -5,7 +5,7 @@ namespace Spatie\MediaLibrary\MediaCollections\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Filesystem\Factory;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
@@ -68,8 +68,8 @@ class CleanCommand extends Command
         $this->info('All done!');
     }
 
-    /** @return Collection<int, Media> */
-    public function getMediaItems(): Collection
+    /** @return LazyCollection<int, Media> */
+    public function getMediaItems(): LazyCollection
     {
         $modelType = $this->argument('modelType');
         $collectionName = $this->argument('collectionName');
@@ -111,8 +111,8 @@ class CleanCommand extends Command
         });
     }
 
-    /** @return Collection<int, Media> */
-    protected function getOrphanedMediaItems(): Collection
+    /** @return LazyCollection<int, Media> */
+    protected function getOrphanedMediaItems(): LazyCollection
     {
         $collectionName = $this->argument('collectionName');
 

--- a/src/MediaCollections/Commands/ClearCommand.php
+++ b/src/MediaCollections/Commands/ClearCommand.php
@@ -4,7 +4,7 @@ namespace Spatie\MediaLibrary\MediaCollections\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\LazyCollection;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
@@ -41,8 +41,8 @@ class ClearCommand extends Command
         $this->info('All done!');
     }
 
-    /** @return Collection<int, Media> */
-    public function getMediaItems(): Collection
+    /** @return LazyCollection<int, Media> */
+    public function getMediaItems(): LazyCollection
     {
         $modelType = $this->argument('modelType');
         $collectionName = $this->argument('collectionName');

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -4,9 +4,9 @@ namespace Spatie\MediaLibrary\MediaCollections;
 
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection as DbCollection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
@@ -41,9 +41,9 @@ class MediaRepository
         return $media->filter($filter);
     }
 
-    public function all(): DbCollection
+    public function all(): LazyCollection
     {
-        return $this->query()->get();
+        return $this->query()->cursor();
     }
 
     public function allIds(): Collection
@@ -51,50 +51,50 @@ class MediaRepository
         return $this->query()->pluck($this->model->getKeyName());
     }
 
-    public function getByModelType(string $modelType): DbCollection
+    public function getByModelType(string $modelType): LazyCollection
     {
-        return $this->query()->where('model_type', $modelType)->get();
+        return $this->query()->where('model_type', $modelType)->cursor();
     }
 
-    public function getByIds(array $ids): DbCollection
+    public function getByIds(array $ids): LazyCollection
     {
-        return $this->query()->whereIn($this->model->getKeyName(), $ids)->get();
+        return $this->query()->whereIn($this->model->getKeyName(), $ids)->cursor();
     }
 
-    public function getByIdGreaterThan(int $startingFromId, bool $excludeStartingId = false, string $modelType = ''): DbCollection
+    public function getByIdGreaterThan(int $startingFromId, bool $excludeStartingId = false, string $modelType = ''): LazyCollection
     {
         return $this->query()
             ->where($this->model->getKeyName(), $excludeStartingId ? '>' : '>=', $startingFromId)
             ->when($modelType !== '', fn (Builder $q) => $q->where('model_type', $modelType))
-            ->get();
+            ->cursor();
     }
 
-    public function getByModelTypeAndCollectionName(string $modelType, string $collectionName): DbCollection
+    public function getByModelTypeAndCollectionName(string $modelType, string $collectionName): LazyCollection
     {
         return $this->query()
             ->where('model_type', $modelType)
             ->where('collection_name', $collectionName)
-            ->get();
+            ->cursor();
     }
 
-    public function getByCollectionName(string $collectionName): DbCollection
+    public function getByCollectionName(string $collectionName): LazyCollection
     {
         return $this->query()
             ->where('collection_name', $collectionName)
-            ->get();
+            ->cursor();
     }
 
-    public function getOrphans(): DbCollection
+    public function getOrphans(): LazyCollection
     {
         return $this->orphansQuery()
-            ->get();
+            ->cursor();
     }
 
-    public function getOrphansByCollectionName(string $collectionName): DbCollection
+    public function getOrphansByCollectionName(string $collectionName): LazyCollection
     {
         return $this->orphansQuery()
             ->where('collection_name', $collectionName)
-            ->get();
+            ->cursor();
     }
 
     protected function query(): Builder

--- a/tests/Feature/Media/MediaRepositoryTest.php
+++ b/tests/Feature/Media/MediaRepositoryTest.php
@@ -12,5 +12,5 @@ it('can use a custom media model', function () {
 
     $mediaRepository = app(MediaRepository::class);
 
-    expect($mediaRepository->all()->getQueueableClass())->toEqual(TestCustomMediaModel::class);
+    expect($mediaRepository->getCollection($this->testModel, 'default')->getQueueableClass())->toEqual(TestCustomMediaModel::class);
 });


### PR DESCRIPTION
Following on from #3669...

The artisan commands are the only place that the `getBy*()` and `getOrphans*()` methods are used within the package. 

As `MediaRepository` is not yet configurable the only impacted users for this change would be those that replace it in the container, or those that resolve it and expect Eloquent Collections from the`getBy*()` and `getOrphans*()` methods.

Alternatively, we could introduce an interface to bind to and a `repository_class` configuration option, and ship a `CursorMediaRepository` that returns `LazyCollections` from the `getBy*()` and `getOrphans*()` methods. I initially started down this path however, I can't think of a reason that the artisan commands shouldn't always use `LazyCollection`.

If it's decided that the latter option is better, we should take the opportunity of a major release to create a `MediaCollections\MediaRepositories` namespace.

I'm open to feedback.