### PR TITLE
Added ability to programatically specify custom queue on FileAdder

### DIFF
--- a/src/Conversions/Actions/PerformConversionAction.php
+++ b/src/Conversions/Actions/PerformConversionAction.php
@@ -27,7 +27,7 @@ class PerformConversionAction
 
         event(new ConversionWillStartEvent($media, $conversion, $copiedOriginalFile));
 
-        $manipulationResult = (new PerformManipulationsAction())->execute($media, $conversion, $copiedOriginalFile);
+        $manipulationResult = (new PerformManipulationsAction)->execute($media, $conversion, $copiedOriginalFile);
 
         $newFileName = $conversion->getConversionFile($media);
 

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -39,7 +39,7 @@ class Conversion
     ) {
         $optimizerChain = OptimizerChainFactory::create(config('media-library.image_optimizers'));
 
-        $this->manipulations = new Manipulations();
+        $this->manipulations = new Manipulations;
         $this->manipulations->optimize($optimizerChain)->format('jpg');
 
         $this->fileNamer = app(config('media-library.file_namer'));
@@ -106,7 +106,7 @@ class Conversion
 
     public function withoutManipulations(): self
     {
-        $this->manipulations = new Manipulations();
+        $this->manipulations = new Manipulations;
 
         return $this;
     }

--- a/src/Conversions/ConversionCollection.php
+++ b/src/Conversions/ConversionCollection.php
@@ -20,7 +20,7 @@ class ConversionCollection extends Collection
 
     public static function createForMedia(Media $media): self
     {
-        return (new static())->setMedia($media);
+        return (new static)->setMedia($media);
     }
 
     public function setMedia(Media $media): self
@@ -56,7 +56,7 @@ class ConversionCollection extends Collection
         }
 
         /** @var \Spatie\MediaLibrary\HasMedia $model */
-        $model = new $modelName();
+        $model = new $modelName;
 
         /*
          * In some cases the user might want to get the actual model

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -68,7 +68,7 @@ class FileManipulator
                 return $onlyMissing && Storage::disk($media->disk)->exists($relativePath);
             })
             ->each(function (Conversion $conversion) use ($media, $copiedOriginalFile) {
-                (new PerformConversionAction())->execute($conversion, $media, $copiedOriginalFile);
+                (new PerformConversionAction)->execute($conversion, $media, $copiedOriginalFile);
             });
 
         $temporaryDirectory->delete();

--- a/src/Conversions/ImageGenerators/Svg.php
+++ b/src/Conversions/ImageGenerators/Svg.php
@@ -13,7 +13,7 @@ class Svg extends ImageGenerator
     {
         $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
 
-        $image = new Imagick();
+        $image = new Imagick;
         $image->readImage($file);
         $image->setBackgroundColor(new ImagickPixel('none'));
         $image->setImageFormat('jpg');

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -139,7 +139,7 @@ trait InteractsWithMedia
         }
 
         $downloader = config('media-library.media_downloader', DefaultDownloader::class);
-        $temporaryFile = (new $downloader())->getTempFile($url);
+        $temporaryFile = (new $downloader)->getTempFile($url);
         $this->guardAgainstInvalidMimeType($temporaryFile, $allowedMimeTypes);
 
         $filename = basename(parse_url($url, PHP_URL_PATH));
@@ -383,7 +383,7 @@ trait InteractsWithMedia
         $this->removeMediaItemsNotPresentInArray($newMediaArray, $collectionName);
 
         $mediaClass = $this->getMediaModel();
-        $mediaInstance = new $mediaClass();
+        $mediaInstance = new $mediaClass;
         $keyName = $mediaInstance->getKeyName();
 
         return collect($newMediaArray)

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -241,7 +241,7 @@ class FileAdder
 
         $mediaClass = $this->subject?->getMediaModel() ?? config('media-library.media_model');
         /** @var Media $media */
-        $media = new $mediaClass();
+        $media = new $mediaClass;
 
         $media->name = $this->mediaName;
 
@@ -304,7 +304,7 @@ class FileAdder
 
         $mediaClass = $this->subject?->getMediaModel() ?? config('media-library.media_model');
         /** @var Media $media */
-        $media = new $mediaClass();
+        $media = new $mediaClass;
 
         $media->name = $this->mediaName;
 
@@ -466,7 +466,7 @@ class FileAdder
             }
         }
 
-        if ($this->generateResponsiveImages && (new ImageGenerator())->canConvert($media)) {
+        if ($this->generateResponsiveImages && (new ImageGenerator)->canConvert($media)) {
             $generateResponsiveImagesJobClass = config('media-library.jobs.generate_responsive_images', GenerateResponsiveImagesJob::class);
 
             $job = new $generateResponsiveImagesJobClass($media);

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -50,6 +50,8 @@ class FileAdder
 
     protected string $diskName = '';
 
+    protected ?string $onQueue = null;
+
     protected ?int $fileSize = null;
 
     protected string $conversionsDiskName = '';
@@ -174,6 +176,13 @@ class FileAdder
     public function storingConversionsOnDisk(string $diskName): self
     {
         $this->conversionsDiskName = $diskName;
+
+        return $this;
+    }
+
+    public function onQueue(?string $queue = null): self
+    {
+        $this->onQueue = $queue;
 
         return $this;
     }
@@ -475,7 +484,7 @@ class FileAdder
                 $job->onConnection($customConnection);
             }
 
-            if ($customQueue = config('media-library.queue_name')) {
+            if ($customQueue = ($this->onQueue ?? config('media-library.queue_name'))) {
                 $job->onQueue($customQueue);
             }
 

--- a/src/MediaCollections/HtmlableMedia.php
+++ b/src/MediaCollections/HtmlableMedia.php
@@ -52,7 +52,7 @@ class HtmlableMedia implements \Stringable, Htmlable
 
     public function toHtml(): string
     {
-        $imageGenerator = ImageGeneratorFactory::forMedia($this->media) ?? new Image();
+        $imageGenerator = ImageGeneratorFactory::forMedia($this->media) ?? new Image;
 
         if (! $imageGenerator->canHandleMime($this->media->mime_type)) {
             return '';

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -33,7 +33,7 @@ class MediaLibraryServiceProvider extends PackageServiceProvider
     {
         $mediaClass = config('media-library.media_model', Media::class);
 
-        $mediaClass::observe(new MediaObserver());
+        $mediaClass::observe(new MediaObserver);
     }
 
     public function packageRegistered(): void
@@ -44,7 +44,7 @@ class MediaLibraryServiceProvider extends PackageServiceProvider
         $this->app->scoped(MediaRepository::class, function () {
             $mediaClass = config('media-library.media_model');
 
-            return new MediaRepository(new $mediaClass());
+            return new MediaRepository(new $mediaClass);
         });
     }
 }

--- a/tests/Conversions/Commands/CleanCommandTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest.php
@@ -227,7 +227,7 @@ it('can clean deprecated conversion files in custom path', function () {
 
     $this->urlGenerator = new DefaultUrlGenerator($this->config);
 
-    $this->pathGenerator = new CustomPathGenerator();
+    $this->pathGenerator = new CustomPathGenerator;
 
     $this->urlGenerator->setPathGenerator($this->pathGenerator);
 
@@ -256,7 +256,7 @@ it('can clean deprecated conversion files in same path as original image', funct
 
     $this->urlGenerator = new DefaultUrlGenerator($this->config);
 
-    $this->pathGenerator = new TestPathGeneratorConversionsInOriginalImageDirectory();
+    $this->pathGenerator = new TestPathGeneratorConversionsInOriginalImageDirectory;
 
     $this->urlGenerator->setPathGenerator($this->pathGenerator);
 
@@ -360,7 +360,7 @@ it('will not clean orphaned media items when disabled', function () {
 });
 
 it('will not clean media items on soft deleted models', function () {
-    $testModelClass = new class() extends TestModel
+    $testModelClass = new class extends TestModel
     {
         use SoftDeletes;
     };

--- a/tests/Conversions/ConversionCustomWidthCalculator.php
+++ b/tests/Conversions/ConversionCustomWidthCalculator.php
@@ -5,7 +5,7 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\WidthCalculators\FixedWidthCalculator;
 
 it('can utilize various width calculators for conversions across different models', function () {
-    $testModel3Sizes = (new class() extends TestModel
+    $testModel3Sizes = (new class extends TestModel
     {
         public function registerMediaConversions(?Media $media = null): void
         {
@@ -13,7 +13,7 @@ it('can utilize various width calculators for conversions across different model
         }
     })::create(['name' => 'test.jpg']);
 
-    $testModel5Sizes = (new class() extends TestModel
+    $testModel5Sizes = (new class extends TestModel
     {
         public function registerMediaConversions(?Media $media = null): void
         {

--- a/tests/Conversions/FileManipulatorTest.php
+++ b/tests/Conversions/FileManipulatorTest.php
@@ -12,7 +12,7 @@ it('does not perform manipulations if not necessary', function () {
     $imageFile = $this->getTestJpg();
     $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaCollection();
 
-    $conversionTempFile = (new PerformManipulationsAction())->execute(
+    $conversionTempFile = (new PerformManipulationsAction)->execute(
         $media,
         $this->conversion->withoutManipulations(),
         $imageFile

--- a/tests/Conversions/ImageGenerators/AvifTest.php
+++ b/tests/Conversions/ImageGenerators/AvifTest.php
@@ -3,7 +3,7 @@
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Avif;
 
 it('can convert a avif', function () {
-    $imageGenerator = new Avif();
+    $imageGenerator = new Avif;
 
     if (! $imageGenerator->requirementsAreInstalled()) {
         $this->markTestSkipped('Skipping avif test because requirements to run it are not met');

--- a/tests/Conversions/ImageGenerators/DualTypeCheckingTest.php
+++ b/tests/Conversions/ImageGenerators/DualTypeCheckingTest.php
@@ -4,13 +4,13 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestSupport\TestImageGenerator;
 
 it('can convert an image with a valid extension and mime type', function () {
-    $generator = new TestImageGenerator();
+    $generator = new TestImageGenerator;
     $generator->shouldMatchBothExtensionsAndMimeTypes = true;
 
     $generator->supportedMimetypes->push('supported-mime-type');
     $generator->supportedExtensions->push('supported-extension');
 
-    $media = new Media();
+    $media = new Media;
     $media->mime_type = 'supported-mime-type';
     $media->file_name = 'some-file.supported-extension';
 
@@ -18,13 +18,13 @@ it('can convert an image with a valid extension and mime type', function () {
 });
 
 it('cannot convert an image with an invalid extension and mime type', function () {
-    $generator = new TestImageGenerator();
+    $generator = new TestImageGenerator;
     $generator->shouldMatchBothExtensionsAndMimeTypes = true;
 
     $generator->supportedMimetypes->push('supported-mime-type');
     $generator->supportedExtensions->push('supported-extension');
 
-    $media = new Media();
+    $media = new Media;
     $media->mime_type = 'invalid-mime-type';
     $media->file_name = 'some-file.invalid-extension';
 
@@ -32,13 +32,13 @@ it('cannot convert an image with an invalid extension and mime type', function (
 });
 
 it('cannot convert an image with only a valid mime type', function () {
-    $generator = new TestImageGenerator();
+    $generator = new TestImageGenerator;
     $generator->shouldMatchBothExtensionsAndMimeTypes = true;
 
     $generator->supportedMimetypes->push('supported-mime-type');
     $generator->supportedExtensions->push('supported-extension');
 
-    $media = new Media();
+    $media = new Media;
     $media->mime_type = 'supported-mime-type';
     $media->file_name = 'some-file.invalid-extension';
 
@@ -46,13 +46,13 @@ it('cannot convert an image with only a valid mime type', function () {
 });
 
 it('cannot convert an image with only a valid extension', function () {
-    $generator = new TestImageGenerator();
+    $generator = new TestImageGenerator;
     $generator->shouldMatchBothExtensionsAndMimeTypes = true;
 
     $generator->supportedExtensions->push('supported-extension');
     $generator->supportedMimetypes->push('supported-mime-type');
 
-    $media = new Media();
+    $media = new Media;
     $media->mime_type = 'invalid-mime-type';
     $media->file_name = 'some-file.supported-extension';
 

--- a/tests/Conversions/ImageGenerators/ImageTest.php
+++ b/tests/Conversions/ImageGenerators/ImageTest.php
@@ -3,7 +3,7 @@
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Image;
 
 it('can convert an image', function () {
-    $imageGenerator = new Image();
+    $imageGenerator = new Image;
 
     $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestJpg())->toMediaCollection();
 
@@ -21,7 +21,7 @@ it(
         //TIFF format requires imagick
         config(['media-library.image_driver' => 'imagick']);
 
-        $imageGenerator = new Image();
+        $imageGenerator = new Image;
 
         $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestTiff())->toMediaCollection();
 
@@ -40,7 +40,7 @@ it(
         //heic format requires imagick
         config(['media-library.image_driver' => 'imagick']);
 
-        $imageGenerator = new Image();
+        $imageGenerator = new Image;
 
         $media = $this->testModelWithoutMediaConversions->addMedia($this->getTestHeic())->toMediaCollection();
 

--- a/tests/Conversions/ImageGenerators/PdfTest.php
+++ b/tests/Conversions/ImageGenerators/PdfTest.php
@@ -3,7 +3,7 @@
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf;
 
 it('can convert a pdf', function () {
-    $imageGenerator = new Pdf();
+    $imageGenerator = new Pdf;
 
     if (! $imageGenerator->requirementsAreInstalled()) {
         $this->markTestSkipped('Skipping pdf test because requirements to run it are not met');

--- a/tests/Conversions/ImageGenerators/SvgTest.php
+++ b/tests/Conversions/ImageGenerators/SvgTest.php
@@ -5,7 +5,7 @@ use Spatie\MediaLibrary\Conversions\ImageGenerators\Svg;
 it('can convert a svg', function () {
     config()->set('media-library.image_driver', 'imagick');
 
-    $imageGenerator = new Svg();
+    $imageGenerator = new Svg;
 
     if (! $imageGenerator->requirementsAreInstalled()) {
         $this->markTestSkipped('Skipping svg test because requirements to run it are not met');

--- a/tests/Conversions/ImageGenerators/VideoTest.php
+++ b/tests/Conversions/ImageGenerators/VideoTest.php
@@ -4,7 +4,7 @@ use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Video;
 
 it('can convert a video', function () {
-    $imageGenerator = new Video();
+    $imageGenerator = new Video;
 
     if (! $imageGenerator->requirementsAreInstalled()) {
         $this->markTestSkipped('Skipping video test because requirements to run it are not met');

--- a/tests/Conversions/ImageGenerators/WebpTest.php
+++ b/tests/Conversions/ImageGenerators/WebpTest.php
@@ -3,7 +3,7 @@
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Webp;
 
 it('can convert a webp', function () {
-    $imageGenerator = new Webp();
+    $imageGenerator = new Webp;
 
     if (! $imageGenerator->requirementsAreInstalled()) {
         $this->markTestSkipped('Skipping webp test because requirements to run it are not met');

--- a/tests/Downloader/HttpFacadeDownloaderTest.php
+++ b/tests/Downloader/HttpFacadeDownloaderTest.php
@@ -23,7 +23,7 @@ it('can save a url to a temp location', function () {
         ->with($url)
         ->once();
 
-    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader();
+    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader;
 
     $result = $downloader->getTempFile($url);
 
@@ -38,7 +38,7 @@ it('can be mocked easily for tests', function () {
         'https://example.com' => Http::response('::file::'),
     ]);
 
-    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader();
+    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader;
 
     $result = $downloader->getTempFile($url);
 

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -628,7 +628,7 @@ it('will throw an exception and revert database when file cannot be added', func
 });
 
 it('will throw an exception and revert database when file cannot be added and model uses softdeletes', function () {
-    $testModelClass = new class() extends TestModel
+    $testModelClass = new class extends TestModel
     {
         use SoftDeletes;
     };

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -44,7 +44,7 @@ it('can create a derived version for an image keeping the original format', func
 });
 
 it('will use the name of the conversion for naming the converted file', function () {
-    $modelClass = new class() extends TestModelWithConversion
+    $modelClass = new class extends TestModelWithConversion
     {
         public function registerMediaConversions(?Media $media = null): void
         {
@@ -128,7 +128,7 @@ it('will not create a derived version if manipulations did not change', function
 });
 
 it('will have access the model instance when register media conversions using model instance has been set', function () {
-    $modelClass = new class() extends TestModel
+    $modelClass = new class extends TestModel
     {
         public bool $registerMediaConversionsUsingModelInstance = true;
 
@@ -145,7 +145,7 @@ it('will have access the model instance when register media conversions using mo
         }
     };
 
-    $model = new $modelClass();
+    $model = new $modelClass;
     $model->name = 'testmodel';
     $model->width = 123;
     $model->save();

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -7,7 +7,7 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
 
 it('will use the disk from a media collection', function () {
-    $testModel = new class() extends TestModelWithConversion
+    $testModel = new class extends TestModelWithConversion
     {
         public function registerMediaCollections(): void
         {
@@ -30,7 +30,7 @@ it('will use the disk from a media collection', function () {
 });
 
 it('will not use the disk name of the collection if a diskname is specified while adding', function () {
-    $testModel = new class() extends TestModelWithConversion
+    $testModel = new class extends TestModelWithConversion
     {
         public function registerMediaCollections(): void
         {
@@ -49,7 +49,7 @@ it('will not use the disk name of the collection if a diskname is specified whil
 });
 
 it('can register media conversions when defining media collections', function () {
-    $testModel = new class() extends TestModelWithoutMediaConversions
+    $testModel = new class extends TestModelWithoutMediaConversions
     {
         public function registerMediaCollections(): void
         {
@@ -71,7 +71,7 @@ it('can register media conversions when defining media collections', function ()
 });
 
 it('will not use media conversions from an unrelated collection', function () {
-    $testModel = new class() extends TestModelWithoutMediaConversions
+    $testModel = new class extends TestModelWithoutMediaConversions
     {
         public function registerMediaCollections(): void
         {
@@ -93,7 +93,7 @@ it('will not use media conversions from an unrelated collection', function () {
 });
 
 it('will use conversions defined in conversions and conversions defined in collections', function () {
-    $testModel = new class() extends TestModelWithoutMediaConversions
+    $testModel = new class extends TestModelWithoutMediaConversions
     {
         public function registerMediaConversions(?Media $media = null): void
         {
@@ -124,7 +124,7 @@ it('will use conversions defined in conversions and conversions defined in colle
 });
 
 it('can accept certain files', function () {
-    $testModel = new class() extends TestModelWithConversion
+    $testModel = new class extends TestModelWithConversion
     {
         public function registerMediaCollections(): void
         {
@@ -144,7 +144,7 @@ it('can accept certain files', function () {
 });
 
 it('can guard against invalid mimetypes', function () {
-    $testModel = new class() extends TestModelWithConversion
+    $testModel = new class extends TestModelWithConversion
     {
         public function registerMediaCollections(): void
         {
@@ -164,7 +164,7 @@ it('can guard against invalid mimetypes', function () {
 });
 
 it('can generate responsive images', function () {
-    $testModel = new class() extends TestModelWithConversion
+    $testModel = new class extends TestModelWithConversion
     {
         public function registerMediaCollections(): void
         {
@@ -190,7 +190,7 @@ it('can generate responsive images', function () {
 });
 
 it('can generate responsive images on condition', function () {
-    $testModel = new class() extends TestModelWithConversion
+    $testModel = new class extends TestModelWithConversion
     {
         public function registerMediaCollections(): void
         {
@@ -216,7 +216,7 @@ it('can generate responsive images on condition', function () {
 });
 
 test('if the single file method is specified it will delete all other media and will only keep the new one', function () {
-    $testModel = new class() extends TestModelWithConversion
+    $testModel = new class extends TestModelWithConversion
     {
         public function registerMediaCollections(): void
         {
@@ -236,7 +236,7 @@ test('if the single file method is specified it will delete all other media and 
 });
 
 test('if the only keeps latest method is specified it will delete all other media and will only keep the latest n ones', function () {
-    $testModel = new class() extends TestModelWithConversion
+    $testModel = new class extends TestModelWithConversion
     {
         public function registerMediaCollections(): void
         {

--- a/tests/Feature/Media/DeleteTest.php
+++ b/tests/Feature/Media/DeleteTest.php
@@ -43,7 +43,7 @@ it('will remove the files without extension', function () {
 it('will remove files when deleting a media object with a custom path generator', function () {
     config(['media-library.path_generator' => TestPathGenerator::class]);
 
-    $pathGenerator = new TestPathGenerator();
+    $pathGenerator = new TestPathGenerator;
 
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
     $path = $pathGenerator->getPath($media);
@@ -59,7 +59,7 @@ it('will remove files when deleting a media object with a custom path and direct
     config(['media-library.path_generator' => CustomDirectoryStructurePathGenerator::class]);
     config(['media-library.file_remover_class' => FileBaseFileRemover::class]);
 
-    $pathGenerator = new CustomDirectoryStructurePathGenerator();
+    $pathGenerator = new CustomDirectoryStructurePathGenerator;
 
     $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
     $path = $pathGenerator->getPath($media);
@@ -75,7 +75,7 @@ it('will remove converted files when deleting a media object with a custom path 
     config(['media-library.path_generator' => CustomDirectoryStructurePathGenerator::class]);
     config(['media-library.file_remover_class' => FileBaseFileRemover::class]);
 
-    $pathGenerator = new CustomDirectoryStructurePathGenerator();
+    $pathGenerator = new CustomDirectoryStructurePathGenerator;
 
     $media = $this->testModelWithConversion->addMedia($this->getTestJpg())->toMediaCollection('images');
 
@@ -95,7 +95,7 @@ it('will remove converted files and responsive images when deleting a media obje
     config(['media-library.file_remover_class' => FileBaseFileRemover::class]);
 
     $media = $this->testModelWithConversionsOnOtherDisk->addMedia($this->getTestPng())->toMediaCollection('images');
-    $pathGenerator = new CustomDirectoryStructurePathGenerator();
+    $pathGenerator = new CustomDirectoryStructurePathGenerator;
 
     expect(File::exists($media->getPath()))->toBeTrue();
     expect(Storage::disk($media->disk)->exists($pathGenerator->getPathForResponsiveImages($media).'test___thumb_50_63.jpg'))->toBeTrue();
@@ -141,7 +141,7 @@ it('will NOT remove other files within the same folder when deleting a media obj
 });
 
 it('will not remove the files when should delete preserving media returns true', function () {
-    $testModelClass = new class() extends TestModel
+    $testModelClass = new class extends TestModel
     {
         public function shouldDeletePreservingMedia(): bool
         {
@@ -161,7 +161,7 @@ it('will not remove the files when should delete preserving media returns true',
 });
 
 it('will remove the files when should delete preserving media returns false', function () {
-    $testModelClass = new class() extends TestModel
+    $testModelClass = new class extends TestModel
     {
         public function shouldDeletePreservingMedia(): bool
         {
@@ -181,7 +181,7 @@ it('will remove the files when should delete preserving media returns false', fu
 });
 
 it('will not remove the file when model uses softdelete', function () {
-    $testModelClass = new class() extends TestModel
+    $testModelClass = new class extends TestModel
     {
         use SoftDeletes;
     };
@@ -201,7 +201,7 @@ it('will not remove the file when model uses softdelete', function () {
 });
 
 it('will remove the file when model uses softdelete with force', function () {
-    $testModelClass = new class() extends TestModel
+    $testModelClass = new class extends TestModel
     {
         use SoftDeletes;
     };

--- a/tests/Feature/Media/ToResponseTest.php
+++ b/tests/Feature/Media/ToResponseTest.php
@@ -10,7 +10,7 @@ test('to response sends the content', function () {
     $content = ob_get_contents();
     ob_end_clean();
 
-    $temporaryDirectory = (new TemporaryDirectory())->create();
+    $temporaryDirectory = (new TemporaryDirectory)->create();
     file_put_contents($temporaryDirectory->path('response.pdf'), $content);
 
     $this->assertFileEquals($testPdf, $temporaryDirectory->path('response.pdf'));

--- a/tests/Feature/Media/UpdateManipulationsTest.php
+++ b/tests/Feature/Media/UpdateManipulationsTest.php
@@ -4,7 +4,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
 it('will create derived files when manipulations have changed', function () {
-    $testModelClass = new class() extends TestModel
+    $testModelClass = new class extends TestModel
     {
         public function registerMediaConversions(?Media $media = null): void
         {
@@ -36,7 +36,7 @@ it('will create derived files when manipulations have changed', function () {
 });
 
 it('will not create derived files when manipulations have not changed', function () {
-    $testModelClass = new class() extends TestModel
+    $testModelClass = new class extends TestModel
     {
         public function registerMediaConversions(?Media $media = null): void
         {

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -234,7 +234,7 @@ it('can retrieve a zip with s3 disk', function () {
     $content = ob_get_contents();
     ob_end_clean();
 
-    $temporaryDirectory = (new TemporaryDirectory())->create();
+    $temporaryDirectory = (new TemporaryDirectory)->create();
     file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
     $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');

--- a/tests/MediaCollections/GetRegisteredMediaCollections.php
+++ b/tests/MediaCollections/GetRegisteredMediaCollections.php
@@ -3,7 +3,7 @@
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 
 it('calling getRegisteredMediaCollections multiple times should return the same result', function () {
-    $testModel = new class() extends TestModelWithConversion
+    $testModel = new class extends TestModelWithConversion
     {
         public function registerMediaCollections(): void
         {

--- a/tests/ResponsiveImages/FileSizeOptimizedWidthCalculatorTest.php
+++ b/tests/ResponsiveImages/FileSizeOptimizedWidthCalculatorTest.php
@@ -3,7 +3,7 @@
 use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator;
 
 it('can calculate the optimized widths from a file', function () {
-    $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidthsFromFile($this->getTestJpg());
+    $dimensions = (new FileSizeOptimizedWidthCalculator)->calculateWidthsFromFile($this->getTestJpg());
 
     $this->assertEquals([
         0 => 340,
@@ -11,7 +11,7 @@ it('can calculate the optimized widths from a file', function () {
         2 => 237,
     ], $dimensions->toArray());
 
-    $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidthsFromFile($this->getSmallTestJpg());
+    $dimensions = (new FileSizeOptimizedWidthCalculator)->calculateWidthsFromFile($this->getSmallTestJpg());
 
     $this->assertEquals([
         0 => 150,
@@ -19,7 +19,7 @@ it('can calculate the optimized widths from a file', function () {
 });
 
 it('can calculate the optimized widths for different dimensions', function () {
-    $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidths(300 * 1024, 300, 200);
+    $dimensions = (new FileSizeOptimizedWidthCalculator)->calculateWidths(300 * 1024, 300, 200);
 
     $this->assertEquals([
         0 => 300,
@@ -34,7 +34,7 @@ it('can calculate the optimized widths for different dimensions', function () {
         9 => 60,
     ], $dimensions->toArray());
 
-    $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidths(3000 * 1024, 2400, 1800);
+    $dimensions = (new FileSizeOptimizedWidthCalculator)->calculateWidths(3000 * 1024, 2400, 1800);
 
     $this->assertEquals([
         0 => 2400,
@@ -55,7 +55,7 @@ it('can calculate the optimized widths for different dimensions', function () {
         15 => 165,
     ], $dimensions->toArray());
 
-    $dimensions = (new FileSizeOptimizedWidthCalculator())->calculateWidths(12000 * 1024, 8200, 5500);
+    $dimensions = (new FileSizeOptimizedWidthCalculator)->calculateWidths(12000 * 1024, 8200, 5500);
 
     $this->assertEquals([
         0 => 8200,

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -37,7 +37,7 @@ it('can return a stream of multiple files with the same filename', function () {
     $content = ob_get_contents();
     ob_end_clean();
 
-    $temporaryDirectory = (new TemporaryDirectory())->create();
+    $temporaryDirectory = (new TemporaryDirectory)->create();
     file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
     $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');
@@ -56,7 +56,7 @@ it('will respect the filename set by getDownloadFilename method', function () {
     $content = ob_get_contents();
     ob_end_clean();
 
-    $temporaryDirectory = (new TemporaryDirectory())->create();
+    $temporaryDirectory = (new TemporaryDirectory)->create();
     file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
     $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');
@@ -95,7 +95,7 @@ test('media with zip file folder prefix property saved in correct zip folder', f
     $content = ob_get_contents();
     ob_end_clean();
 
-    $temporaryDirectory = (new TemporaryDirectory())->create();
+    $temporaryDirectory = (new TemporaryDirectory)->create();
     file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
     $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test (2).jpg');
@@ -128,7 +128,7 @@ test('media with zip file folder prefix property saved in correct zip folder and
     $content = ob_get_contents();
     ob_end_clean();
 
-    $temporaryDirectory = (new TemporaryDirectory())->create();
+    $temporaryDirectory = (new TemporaryDirectory)->create();
     file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
     $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'test.jpg');
@@ -154,7 +154,7 @@ test('media with zip file prefix property saved with correct prefix', function (
     @$zipStreamResponse->toResponse(request())->sendContent();
     $content = ob_get_contents();
     ob_end_clean();
-    $temporaryDirectory = (new TemporaryDirectory())->create();
+    $temporaryDirectory = (new TemporaryDirectory)->create();
     file_put_contents($temporaryDirectory->path('response.zip'), $content);
 
     $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'just_a_string_prefix test.jpg');

--- a/tests/Support/PathGenerator/BasePathGeneratorTest.php
+++ b/tests/Support/PathGenerator/BasePathGeneratorTest.php
@@ -11,7 +11,7 @@ beforeEach(function () {
 
     $this->urlGenerator = new DefaultUrlGenerator($this->config);
 
-    $this->pathGenerator = new CustomPathGenerator();
+    $this->pathGenerator = new CustomPathGenerator;
 
     $this->urlGenerator->setPathGenerator($this->pathGenerator);
 });

--- a/tests/Support/UrlGenerator/BaseUrlGeneratorTest.php
+++ b/tests/Support/UrlGenerator/BaseUrlGeneratorTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
     $this->conversionKeepingOriginalImageFormat = ConversionCollection::createForMedia($this->media)->getByName('keep_original_format');
 
     $this->urlGenerator = new DefaultUrlGenerator($this->config);
-    $this->pathGenerator = new DefaultPathGenerator();
+    $this->pathGenerator = new DefaultPathGenerator;
 
     $this->urlGenerator
         ->setMedia($this->media)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,7 +57,7 @@ abstract class TestCase extends Orchestra
         $this->setUpTempTestFiles();
 
         $this->testModel = TestModel::first();
-        $this->testUnsavedModel = new TestModel();
+        $this->testUnsavedModel = new TestModel;
         $this->testModelWithConversion = TestModelWithConversion::first();
         $this->testModelWithMultipleConversions = TestModelWithMultipleConversions::first();
         $this->testModelWithPreviewConversion = TestModelWithPreviewConversion::first();
@@ -145,7 +145,7 @@ abstract class TestCase extends Orchestra
 
         if (MediaLibraryPro::isInstalled()) {
             include_once __DIR__.'/../vendor/spatie/laravel-medialibrary-pro/database/migrations/create_temporary_uploads_table.stub';
-            (new CreateTemporaryUploadsTable())->up();
+            (new CreateTemporaryUploadsTable)->up();
         }
 
         $mediaTableMigration = require __DIR__.'/../database/migrations/create_media_table.php.stub';
@@ -321,7 +321,7 @@ abstract class TestCase extends Orchestra
 
     protected function fileExistsInZip($zipPath, $filename): bool
     {
-        $zip = new ZipArchive();
+        $zip = new ZipArchive;
 
         if ($zip->open($zipPath) === true) {
             return $zip->locateName($filename, ZipArchive::FL_NODIR) !== false;
@@ -332,7 +332,7 @@ abstract class TestCase extends Orchestra
 
     protected function fileExistsInZipRecognizeFolder($zipPath, $filename): bool
     {
-        $zip = new ZipArchive();
+        $zip = new ZipArchive;
 
         if ($zip->open($zipPath) === true) {
             return $zip->locateName($filename) !== false;

--- a/tests/TestSupport/TestImageGenerator.php
+++ b/tests/TestSupport/TestImageGenerator.php
@@ -16,9 +16,9 @@ class TestImageGenerator extends ImageGenerator
 
     public function __construct()
     {
-        $this->supportedExtensions = new Collection();
+        $this->supportedExtensions = new Collection;
 
-        $this->supportedMimetypes = new Collection();
+        $this->supportedMimetypes = new Collection;
     }
 
     public function supportedExtensions(): Collection


### PR DESCRIPTION
We've run into an issue where we have thousands of conversions being generated, it blocks up the queue for conversions that should be considered a higher priority.

This small addition allows us to programatically tap into the FileAdder and set a custom queue depending on the job we're performing.

So we can have two queues, one called `conversions` and one called `high_priority_conversions` for example.