### PR TITLE
Adjust sanitization of PHP file extensions in `FileAdder.php`

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -405,7 +405,7 @@ class FileAdder
         $sanitizedFileName = str_replace(['#', '/', '\\', ' '], '-', $sanitizedFileName);
 
         $phpExtensions = [
-            'php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar',
+            '.php', '.php3', '.php4', '.php5', '.php7', '.php8', '.phtml', '.phar',
         ];
 
         if (Str::endsWith(strtolower($sanitizedFileName), $phpExtensions)) {

--- a/tests/MediaCollections/FileAdderTest.php
+++ b/tests/MediaCollections/FileAdderTest.php
@@ -30,3 +30,9 @@ it('will throw an exception if the sanitized file name is a php file name', func
 
     $adder->defaultSanitizer('filename.php‎');
 })->throws(FileNameNotAllowed::class);
+
+it('will not throw an exception if the sanitized file name ends with php but is not a php file', function () {
+    $adder = app(FileAdder::class);
+
+    $adder->defaultSanitizer('media-libraryJQwPHp');
+})->throwsNoExceptions();


### PR DESCRIPTION
I recently noticed sporadically failing tests in my application after the [addition of PHP extensions ](https://github.com/spatie/laravel-medialibrary/commit/e663609647536ec799f3f5477cd232d83f1685fa)to the `defaultSanitizer()` function of [FileAdder.php](https://github.com/spatie/laravel-medialibrary/blob/main/src/MediaCollections/FileAdder.php). 

Digging into the issue, it turns out the `tempnam()` call in `addMediaFromBase64()` of [InteractsWithMedia.php](https://github.com/spatie/laravel-medialibrary/blob/main/src/InteractsWithMedia.php) was occasionally ending the file name string with `PHp` which was blocked by the PHP extension check.

This PR proposes to add the `.` to all `$phpExtensions` in the list to resolve the issue.