### PR TITLE
Dispatch conversion jobs after database transactions have been committed

### DIFF
--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -95,7 +95,7 @@ class FileManipulator
             ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue(config('media-library.queue_name'));
 
-        dispatch($job);
+        dispatch($job)->afterCommit();
 
         return $this;
     }
@@ -120,7 +120,7 @@ class FileManipulator
             ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue(config('media-library.queue_name'));
 
-        dispatch($job);
+        dispatch($job)->afterCommit();
 
         return $this;
     }


### PR DESCRIPTION
I have been running into an issue (#3677) and it has been raised previously (#3674) that media conversions sometimes immediately fail.

Having done some debugging I've found the cause to be media that is added within a database transaction. In my case this was apparent in Laravel Nova when creating a post with large media.

This means when the queue worker tries to generate the conversions, they immediately fail because the record has not yet been persisted to the database.

The fix is to ensure that these jobs are only dispatched after the data has been committed to the database. This can easily be enforced by calling `->afterCommit()` on the dispatched job. If there is no active transaction the job will be dispatched in the usual way.