### PR TITLE
Correctly remove media folders after removing all media files

### DIFF
--- a/src/Support/FileRemover/DefaultFileRemover.php
+++ b/src/Support/FileRemover/DefaultFileRemover.php
@@ -16,14 +16,14 @@ class DefaultFileRemover implements FileRemover
     {
 
         if ($media->conversions_disk && $media->disk !== $media->conversions_disk) {
-            $this->removeFromMediaDirectory($media, $media->conversions_disk);
             $this->removeFromConversionsDirectory($media, $media->conversions_disk);
             $this->removeFromResponsiveImagesDirectory($media, $media->conversions_disk);
+            $this->removeFromMediaDirectory($media, $media->conversions_disk);
         }
 
-        $this->removeFromMediaDirectory($media, $media->disk);
         $this->removeFromConversionsDirectory($media, $media->disk);
         $this->removeFromResponsiveImagesDirectory($media, $media->disk);
+        $this->removeFromMediaDirectory($media, $media->disk);
     }
 
     public function removeFromMediaDirectory(Media $media, string $disk): void

--- a/tests/Feature/FileAdder/MediaConversions/DeleteMediaFolderTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/DeleteMediaFolderTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\File;
-use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
 
 beforeEach(function () {
     foreach (range(1, 3) as $index) {

--- a/tests/Feature/FileAdder/MediaConversions/DeleteMediaFolderTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/DeleteMediaFolderTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithoutMediaConversions;
+
+beforeEach(function () {
+    foreach (range(1, 3) as $index) {
+        $this->testModelWithoutMediaConversions
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection();
+
+        $this->testModelWithMultipleConversions
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection();
+
+        $this->testModelWithResponsiveImages
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->toMediaCollection();
+    }
+});
+
+it('will remove the media folder when deleting a media model without conversions', function () {
+    $ids = $this->testModelWithoutMediaConversions->getMedia()->pluck('id');
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
+    });
+
+    $this->testModelWithoutMediaConversions->clearMediaCollection();
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
+    });
+});
+
+it('will remove the media folder when deleting a subject without media conversions', function () {
+    $ids = $this->testModelWithoutMediaConversions->getMedia()->pluck('id');
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
+    });
+
+    $this->testModelWithoutMediaConversions->delete();
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
+    });
+});
+
+it('will remove the media folder when deleting a media model with conversions', function () {
+    $ids = $this->testModelWithMultipleConversions->getMedia()->pluck('id');
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
+    });
+
+    $this->testModelWithMultipleConversions->clearMediaCollection();
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
+    });
+});
+
+it('will remove the media folder when deleting a subject with media conversions', function () {
+    $ids = $this->testModelWithMultipleConversions->getMedia()->pluck('id');
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
+    });
+
+    $this->testModelWithMultipleConversions->delete();
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
+    });
+});
+
+it('will remove the media folder when deleting a media model with conversions and responsive images', function () {
+    $ids = $this->testModelWithResponsiveImages->getMedia()->pluck('id');
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
+    });
+
+    $this->testModelWithResponsiveImages->clearMediaCollection();
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
+    });
+});
+
+it('will remove the media folder when deleting a subject with media conversions and responsive images', function () {
+    $ids = $this->testModelWithResponsiveImages->getMedia()->pluck('id');
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeTrue();
+    });
+
+    $this->testModelWithResponsiveImages->delete();
+
+    $ids->map(function ($id) {
+        expect(File::isDirectory($this->getMediaDirectory($id)))->toBeFalse();
+    });
+});
+

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -30,7 +30,7 @@ abstract class TestCase extends Orchestra
 
     protected TestModelWithConversion $testModelWithConversion;
 
-    protected TestModelWithMultipleConversion $testModelWithMultipleConversion;
+    protected TestModelWithMultipleConversions $testModelWithMultipleConversions;
 
     protected TestModelWithPreviewConversion $testModelWithPreviewConversion;
 


### PR DESCRIPTION
If the media model has conversions and/or responsive images, then `DefaultFileRemover` will not remove the media folder upon removing all files.

The reason of this issue lies in order of removing folders. It tries to remove media folder first, then conversions folder, and then responsive images folder (removing empty directories if there are no files left). Although, conversions/responsive images folders reside inside media folder, thus preventing it from being removed.

This PR fixes this issue by changing the order of removing these folders, moving removing media folder to the last, after all other folders have been removed.

Existing tests weren't catching this issue because they used models without conversions/responsive images. New tests have been added to solve this.