### PR TITLE
Add support for callables in hasMedia() filters

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -242,7 +242,7 @@ trait InteractsWithMedia
     /*
      * Determine if there is media in the given collection.
      */
-    public function hasMedia(string $collectionName = 'default', array $filters = []): bool
+    public function hasMedia(string $collectionName = 'default', array|callable $filters = []): bool
     {
         return count($this->getMedia($collectionName, $filters)) ? true : false;
     }

--- a/tests/Feature/InteractsWithMedia/HasMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/HasMediaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
 it('returns false for an empty collection', function () {
     expect($this->testModel->hasMedia())->toBeFalse();
 });
@@ -42,4 +44,33 @@ it('returns true for a filtered collection', function () {
     expect($this->testModel->hasMedia('default'))->toBeTrue();
     expect($this->testModel->hasMedia('default', ['test' => true]))->toBeTrue();
     expect($this->testModel->hasMedia('default', ['test' => false]))->toBeFalse();
+});
+
+it('returns true using a filter callback', function () {
+    $media1 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter1' => 'value1'])
+        ->toMediaCollection();
+
+    $media2 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter1' => 'value2'])
+        ->toMediaCollection('images');
+
+    $media3 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter2' => 'value1'])
+        ->toMediaCollection('images');
+
+    $media4 = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties(['filter2' => 'value2'])
+        ->toMediaCollection('images');
+
+    expect($this->testModel->hasMedia('images', fn (Media $media) => isset($media->custom_properties['filter1'])))->toBeTrue();
+    expect($this->testModel->hasMedia('images', fn (Media $media) => isset($media->custom_properties['filter3'])))->toBeFalse();
 });


### PR DESCRIPTION
**Description of Changes**
I encountered a scenario where I expected `$model->hasMedia('my-collection', $filters)` to accept a closure for `$filters`, but it's typehinted to only support an array.
![2024-08-20_11-26](https://github.com/user-attachments/assets/a1d577a5-e10e-41ec-8cd3-5e9b9c14127b)


This PR updates the typehint to match `getMedia()`

In the meantime I worked around this via:
```php
$model->getMedia('my-collection', fn (Media $media) => isset($media->custom_properties['something'])))->isNotEmpty()
```

**Changes Made**
* Update `hasMedia()` to support both `array` and `callable` filters, as per `getMedia()`
* Update test coverage

Resolves #3526 

(NOTE: This is my first contribution to this repository, I believe I've met the requirements but feel free to let me know if there's anything I'm missing and I'll update my PR. Thanks!)