### PR TITLE
Added config variable to disable dispatching jobs after commit

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -32,6 +32,11 @@ return [
     'queue_conversions_by_default' => env('QUEUE_CONVERSIONS_BY_DEFAULT', true),
 
     /*
+     * Should database transactions be run after database commits?
+     */
+    'queue_conversions_after_database_commit' => env('QUEUE_CONVERSIONS_AFTER_DB_COMMIT', true),
+
+    /*
      * The fully qualified class name of the media model.
      */
     'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -149,6 +149,11 @@ public function registerMediaConversions(?Media $media = null): void
 }
 ```
 
+The default behaviour is that queued conversions will run **after all database transactions have been committed**. \
+This prevents unexpected behaviour where the model does not yet exist in the database and the conversion is disregarded.
+If you need the conversions to run within your transaction, you can set the `queue_conversions_after_database_commit`
+in the `media-library` config file to `false`.
+
 ## Using model properties in a conversion
 
 When registering conversions inside the `registerMediaConversions` function you won't have access to your model properties by default. If you want to use a property of your model as input for defining a conversion you must set `registerMediaConversionsUsingModelInstance` to `

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -95,7 +95,9 @@ class FileManipulator
             ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue(config('media-library.queue_name'));
 
-        dispatch($job)->afterCommit();
+        config('media-library.queue_conversions_after_database_commit')
+            ? dispatch($job)->afterCommit()
+            : dispatch($job);
 
         return $this;
     }
@@ -120,7 +122,9 @@ class FileManipulator
             ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue(config('media-library.queue_name'));
 
-        dispatch($job)->afterCommit();
+        config('media-library.queue_conversions_after_database_commit')
+            ? dispatch($job)->afterCommit()
+            : dispatch($job);
 
         return $this;
     }

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -95,7 +95,7 @@ class FileManipulator
             ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue(config('media-library.queue_name'));
 
-        dispatch($job);
+        dispatch($job)->afterCommit();
 
         return $this;
     }
@@ -120,7 +120,7 @@ class FileManipulator
             ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue(config('media-library.queue_name'));
 
-        dispatch($job);
+        dispatch($job)->afterCommit();
 
         return $this;
     }


### PR DESCRIPTION
There are some use cases where the PR #3687 that ensures jobs are dispatched after database transactions may cause undesirable behaviour, particularly in tests which are run within a database transaction for example.

This PR introduces a new configuration variable, which allows disabling this behaviour.