### PR TITLE
Add Support to `ULID` column type

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -15,7 +15,7 @@ return [
     'max_file_size' => 1024 * 1024 * 10, // 10MB
 
     /*
-     * Determiner if the media table should use ULID instead of UUID.
+     * Determine if the media table should use ULID instead of UUID.
      */
     'use_ulid_column' => env('MEDIA_USE_ULID_COLUMN', false),
 

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -15,6 +15,11 @@ return [
     'max_file_size' => 1024 * 1024 * 10, // 10MB
 
     /*
+     * Determiner if the media table should use ULID instead of UUID.
+     */
+    'ulid' => env('MEDIA_ULID', true),
+
+    /*
      * This queue connection will be used to generate derived and responsive images.
      * Leave empty to use the default queue connection.
      */

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -17,7 +17,7 @@ return [
     /*
      * Determiner if the media table should use ULID instead of UUID.
      */
-    'ulid' => env('MEDIA_ULID', false),
+    'use_ulid_column' => env('MEDIA_USE_ULID_COLUMN', false),
 
     /*
      * This queue connection will be used to generate derived and responsive images.

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -17,7 +17,7 @@ return [
     /*
      * Determiner if the media table should use ULID instead of UUID.
      */
-    'ulid' => env('MEDIA_ULID', true),
+    'ulid' => env('MEDIA_ULID', false),
 
     /*
      * This queue connection will be used to generate derived and responsive images.

--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -13,7 +13,7 @@ return new class extends Migration
 
             $table->morphs('model');
 
-            if (config('media-library.ulid')) {
+            if (config('media-library.use_ulid_column') === true) {
                 $table->ulid()->nullable()->unique();
             } else {
                 $table->uuid()->nullable()->unique();

--- a/database/migrations/create_media_table.php.stub
+++ b/database/migrations/create_media_table.php.stub
@@ -12,7 +12,13 @@ return new class extends Migration
             $table->id();
 
             $table->morphs('model');
-            $table->uuid()->nullable()->unique();
+
+            if (config('media-library.ulid')) {
+                $table->ulid()->nullable()->unique();
+            } else {
+                $table->uuid()->nullable()->unique();
+            }
+
             $table->string('collection_name');
             $table->string('name');
             $table->string('file_name');

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -51,6 +51,11 @@ return [
      * Adding a larger file will result in an exception.
      */
     'max_file_size' => 1024 * 1024 * 10,
+
+    /*
+     * Determiner if the media table should use ULID instead of UUID.
+     */
+    'use_ulid_column' => env('MEDIA_USE_ULID_COLUMN', false),
     
     /*
      * This queue connection will be used to generate derived and responsive images.

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -53,7 +53,7 @@ return [
     'max_file_size' => 1024 * 1024 * 10,
 
     /*
-     * Determiner if the media table should use ULID instead of UUID.
+     * Determine if the media table should use ULID instead of UUID.
      */
     'use_ulid_column' => env('MEDIA_USE_ULID_COLUMN', false),
     

--- a/src/MediaCollections/Models/Concerns/DetermineUniqueColumn.php
+++ b/src/MediaCollections/Models/Concerns/DetermineUniqueColumn.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\MediaLibrary\MediaCollections\Models\Concerns;
+
+trait DetermineUniqueColumn
+{
+    public static function determineUniqueIdentifierColumn(): string
+    {
+        return config('media-library.ulid') ? 'ulid' : 'uuid';
+    }
+}

--- a/src/MediaCollections/Models/Concerns/DetermineUniqueIdentifierColumn.php
+++ b/src/MediaCollections/Models/Concerns/DetermineUniqueIdentifierColumn.php
@@ -6,6 +6,6 @@ trait DetermineUniqueIdentifierColumn
 {
     public static function determineUniqueIdentifierColumn(): string
     {
-        return config('media-library.ulid') ? 'ulid' : 'uuid';
+        return config('media-library.use_ulid_column') === true ? 'ulid' : 'uuid';
     }
 }

--- a/src/MediaCollections/Models/Concerns/DetermineUniqueIdentifierColumn.php
+++ b/src/MediaCollections/Models/Concerns/DetermineUniqueIdentifierColumn.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\MediaLibrary\MediaCollections\Models\Concerns;
 
-trait DetermineUniqueColumn
+trait DetermineUniqueIdentifierColumn
 {
     public static function determineUniqueIdentifierColumn(): string
     {

--- a/src/MediaCollections/Models/Concerns/HasUuid.php
+++ b/src/MediaCollections/Models/Concerns/HasUuid.php
@@ -10,9 +10,11 @@ trait HasUuid
     public static function bootHasUuid(): void
     {
         static::creating(function (Model $model) {
+            $column = self::determineUniqueIdentifierColumn();
+
             /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $model */
-            if (empty($model->uuid)) {
-                $model->uuid = (string) Str::uuid();
+            if (empty($model->{$column})) {
+                $model->{$column} = $column === 'ulid' ? (string) Str::ulid() : (string) Str::uuid();
             }
         });
     }
@@ -20,5 +22,15 @@ trait HasUuid
     public static function findByUuid(string $uuid): ?Model
     {
         return static::where('uuid', $uuid)->first();
+    }
+
+    public static function findByUlid(string $ulid): ?Model
+    {
+        return static::where('ulid', $ulid)->first();
+    }
+
+    public static function findBy(string $unique): ?Model
+    {
+        return static::where(self::determineUniqueIdentifierColumn(), $unique)->first();
     }
 }

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -26,6 +26,7 @@ use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\MediaCollections\HtmlableMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Collections\MediaCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Concerns\CustomMediaProperties;
+use Spatie\MediaLibrary\MediaCollections\Models\Concerns\DetermineUniqueColumn;
 use Spatie\MediaLibrary\MediaCollections\Models\Concerns\HasUuid;
 use Spatie\MediaLibrary\MediaCollections\Models\Concerns\IsSorted;
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
@@ -39,6 +40,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
  * @property string $uuid
+ * @property string $ulid
  * @property string $model_type
  * @property string|int $model_id
  * @property string $collection_name
@@ -66,6 +68,7 @@ class Media extends Model implements Attachable, Htmlable, Responsable
     use CustomMediaProperties;
     use HasUuid;
     use IsSorted;
+    use DetermineUniqueColumn;
 
     protected $table = 'media';
 

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -66,9 +66,9 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class Media extends Model implements Attachable, Htmlable, Responsable
 {
     use CustomMediaProperties;
+    use DetermineUniqueIdentifierColumn;
     use HasUuid;
     use IsSorted;
-    use DetermineUniqueIdentifierColumn;
 
     protected $table = 'media';
 

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -26,7 +26,7 @@ use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\MediaCollections\HtmlableMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Collections\MediaCollection;
 use Spatie\MediaLibrary\MediaCollections\Models\Concerns\CustomMediaProperties;
-use Spatie\MediaLibrary\MediaCollections\Models\Concerns\DetermineUniqueColumn;
+use Spatie\MediaLibrary\MediaCollections\Models\Concerns\DetermineUniqueIdentifierColumn;
 use Spatie\MediaLibrary\MediaCollections\Models\Concerns\HasUuid;
 use Spatie\MediaLibrary\MediaCollections\Models\Concerns\IsSorted;
 use Spatie\MediaLibrary\ResponsiveImages\RegisteredResponsiveImages;
@@ -68,7 +68,7 @@ class Media extends Model implements Attachable, Htmlable, Responsable
     use CustomMediaProperties;
     use HasUuid;
     use IsSorted;
-    use DetermineUniqueColumn;
+    use DetermineUniqueIdentifierColumn;
 
     protected $table = 'media';
 


### PR DESCRIPTION
Based on several studies and personal tests, we can prove the effectiveness of `ulid` columns instead of `uuid` when talking about a large volume of data.

A package like this tends to persist a thousand of data in the database since all the media of an entire application is persisted in a table. Some public studies point to abstracts where ULID is advantageous in these cases.

> "ULID is often considered superior to UUID when ordering and efficiency are important. It is lexicographically orderable, which makes it easier to organize data in chronological order, something that UUIDs cannot do efficiently. In addition, ULID is more compact, at 26 characters, compared to UUID's 36 characters, making it easier to read and transmit. Embedding a timestamp in ULID means that IDs generated at close points in time will be ordered in a natural way, which can improve database performance by minimizing index fragmentation. While UUIDs are widely used and supported, ULID offers specific advantages in terms of temporal ordering and storage efficiency, making it a preferred choice in many systems that prioritize these characteristics."

A good read is here: https://medium.com/@sammaingi5/uuid-vs-ulid-how-ulid-improves-write-speeds-d16b23505458

---

This PR is an attempt to implement a configuration that allows ULID to be used instead of UUID.