### PR TITLE
Fix renaming files with custom model

### DIFF
--- a/src/MediaCollections/Filesystem.php
+++ b/src/MediaCollections/Filesystem.php
@@ -298,7 +298,7 @@ class Filesystem
 
     protected function renameConversionFiles(Media $media): void
     {
-        $mediaWithOldFileName = config('media-library.media_model')::find($media->id);
+        $mediaWithOldFileName = config('media-library.media_model')::find($media->getKey());
         $mediaWithOldFileName->file_name = $mediaWithOldFileName->getOriginal('file_name');
 
         $conversionDirectory = $this->getConversionDirectory($media);

--- a/tests/Feature/Media/RenameTest.php
+++ b/tests/Feature/Media/RenameTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Spatie\MediaLibrary\MediaLibraryServiceProvider;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestCustomMediaWithCustomKeyName;
+
 it('will rename the file if it is changed on the media object', function () {
     $testFile = $this->getTestFilesDirectory('test.jpg');
 
@@ -12,6 +15,26 @@ it('will rename the file if it is changed on the media object', function () {
 
     $this->assertFileDoesNotExist($this->getMediaDirectory($media->id.'/test.jpg'));
     $this->assertFileExists($this->getMediaDirectory($media->id.'/test-new-name.jpg'));
+});
+
+it('will rename the file with a custom model with custom key name', function () {
+    config()->set('media-library.media_model', TestCustomMediaWithCustomKeyName::class);
+
+    (new MediaLibraryServiceProvider(app()))->register()->boot();
+
+    $this->setUpDatabaseCustomKeyName();
+
+    $testFile = $this->getTestFilesDirectory('test.jpg');
+
+    $media = $this->testModel->addMedia($testFile)->toMediaCollection();
+
+    $this->assertFileExists($this->getMediaDirectory($media->getKey().'/test.jpg'));
+
+    $media->file_name = 'test-new-name.jpg';
+    $media->save();
+
+    $this->assertFileDoesNotExist($this->getMediaDirectory($media->getKey().'/test.jpg'));
+    $this->assertFileExists($this->getMediaDirectory($media->getKey().'/test-new-name.jpg'));
 });
 
 it('will rename conversions', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,9 +5,11 @@ namespace Spatie\MediaLibrary\Tests;
 use CreateTemporaryUploadsTable;
 use Dotgetenv\Dotgetenv;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Schema;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 use Spatie\MediaLibrary\Support\MediaLibraryPro;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
@@ -151,6 +153,21 @@ abstract class TestCase extends Orchestra
         $mediaTableMigration = require __DIR__.'/../database/migrations/create_media_table.php.stub';
 
         $mediaTableMigration->up();
+    }
+
+    protected function setUpDatabaseCustomKeyName()
+    {
+        $customKeyNameMigration = new class extends Migration
+        {
+            public function up()
+            {
+                Schema::table('media', function (Blueprint $table) {
+                    $table->renameColumn('id', 'custom_key_id');
+                });
+            }
+        };
+
+        $customKeyNameMigration->up();
     }
 
     protected function setUpTempTestFiles()

--- a/tests/TestSupport/TestModels/TestCustomMediaWithCustomKeyName.php
+++ b/tests/TestSupport/TestModels/TestCustomMediaWithCustomKeyName.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class TestCustomMediaWithCustomKeyName extends Media
+{
+    protected $table = 'media';
+
+    protected $primaryKey = 'custom_key_id';
+}


### PR DESCRIPTION
This PR attempts to fix file renaming when using a custom model with a primary key name other than 'id'.

We use a custom model that changes the primary key name from `id` to `media_id`:
```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Concerns\HasUuids;
use Spatie\MediaLibrary\MediaCollections\Models\Media as BaseMedia;

class Media extends BaseMedia
{
    use HasUuids;

    protected $primaryKey = 'media_id';
}
```

We want to rename a file as described in the docs ([Retrieving media](https://spatie.be/docs/laravel-medialibrary/v11/basic-usage/retrieving-media)):

```php
$mediaItems[0]->file_name = 'newFileName.jpg';
$mediaItems[0]->save();
```

When renaming file `src/MediaCollections/Filesystem.php` tries to find a media model using the `id` attribute instead of the actual primary key. This PR fixes this bug by using `->getKey()` in this specific place, which works in both cases.