### PR TITLE
Make hasMedia method signature compatible with getMedia in InteractsWithMedia

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -242,7 +242,7 @@ trait InteractsWithMedia
     /*
      * Determine if there is media in the given collection.
      */
-    public function hasMedia(string $collectionName = 'default', array $filters = []): bool
+    public function hasMedia(string $collectionName = 'default', array|callable $filters = []): bool
     {
         return count($this->getMedia($collectionName, $filters)) ? true : false;
     }


### PR DESCRIPTION
The $filters arg of hasMedia does not allow the callable type, while it just calls getMedia which does allow it.

```php
public function hasMedia(string $collectionName = 'default', array $filters = []): bool
    {
        return count($this->getMedia($collectionName, $filters)) ? true : false;
    }

    /**
     * Get media collection by its collectionName.
     */
    public function getMedia(string $collectionName = 'default', array|callable $filters = []): MediaCollections\Models\Collections\MediaCollection
    { 
//omitted 
    }
```