### PR TITLE
Correctly search media conversion by name

### DIFF
--- a/src/Conversions/ConversionCollection.php
+++ b/src/Conversions/ConversionCollection.php
@@ -38,9 +38,11 @@ class ConversionCollection extends Collection
 
     public function getByName(string $name): Conversion
     {
-        $conversion = $this->first(fn (Conversion $conversion) => $conversion->getName() === $name);
+        $conversion = $this
+            ->getConversions($this->media->collection_name)
+            ->first(fn (Conversion $conversion) => $conversion->getName() === $name);
 
-        if (! $conversion) {
+        if (!$conversion) {
             throw InvalidConversion::unknownName($name);
         }
 
@@ -51,7 +53,7 @@ class ConversionCollection extends Collection
     {
         $modelName = Arr::get(Relation::morphMap(), $media->model_type, $media->model_type);
 
-        if (! class_exists($modelName)) {
+        if (!class_exists($modelName)) {
             return;
         }
 
@@ -89,14 +91,16 @@ class ConversionCollection extends Collection
             return $this;
         }
 
-        return $this->filter(fn (Conversion $conversion) => $conversion->shouldBePerformedOn($collectionName));
+        return $this
+            ->filter(fn (Conversion $conversion) => $conversion->shouldBePerformedOn($collectionName))
+            ->values();
     }
 
     protected function addManipulationToConversion(Manipulations $manipulations, string $conversionName): void
     {
         /** @var Conversion|null $conversion */
         $conversion = $this->first(function (Conversion $conversion) use ($conversionName) {
-            if (! $conversion->shouldBePerformedOn($this->media->collection_name)) {
+            if (!$conversion->shouldBePerformedOn($this->media->collection_name)) {
                 return false;
             }
 
@@ -113,7 +117,7 @@ class ConversionCollection extends Collection
 
         if ($conversionName === '*') {
             $this->each(
-                fn (Conversion $conversion) => $conversion->addAsFirstManipulations(clone $manipulations)
+                fn (Conversion $conversion) => $conversion->addAsFirstManipulations(clone $manipulations),
             );
         }
     }
@@ -124,4 +128,5 @@ class ConversionCollection extends Collection
             ->getConversions($collectionName)
             ->map(fn (Conversion $conversion) => $conversion->getConversionFile($this->media));
     }
+
 }

--- a/tests/Conversions/ConversionCollectionConversionsTest.php
+++ b/tests/Conversions/ConversionCollectionConversionsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Spatie\Image\Enums\Fit;
+use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\Conversions\ConversionCollection;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
+
+beforeEach(function () {
+    $this->model = (new class extends TestModel
+    {
+        public function registerMediaConversions(?Media $media = null): void
+        {
+            $this
+                ->addMediaConversion('preview')
+                ->fit(Fit::Crop, 50, 50)
+                ->performOnCollections('avatar')
+                ->format('png')
+                ->nonQueued();
+
+            $this
+                ->addMediaConversion('preview')
+                ->fit(Fit::Crop, 300, 100)
+                ->performOnCollections('signature')
+                ->format('jpeg')
+                ->nonQueued();
+
+            $this
+                ->addMediaConversion('web')
+                ->format('webp')
+                ->nonQueued();
+        }
+
+        public function registerMediaCollections(): void
+        {
+            $this->addMediaCollection('avatar')->acceptsMimeTypes(['image/png'])->singleFile();
+            $this->addMediaCollection('signature')->acceptsMimeTypes(['image/jpeg'])->singleFile();
+        }
+    })::create(['name' => 'testmodel']);
+
+    $avatarMedia = $this->model
+        ->addMedia($this->getTestPng())
+        ->preservingOriginal()
+        ->toMediaCollection('avatar');
+    $avatarMedia->save();
+
+    $signatureMedia = $this->model
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('signature');
+    $signatureMedia->save();
+
+    $this->avatarMedia = $avatarMedia->refresh();
+    $this->signatureMedia = $signatureMedia->refresh();
+});
+
+it('will apply correct conversions for media in different collections', function () {
+    $conversionCollection = ConversionCollection::createForMedia($this->avatarMedia);
+    /** @var ConversionCollection<int, Conversion> $conversions */
+    $conversions = $conversionCollection->getConversions('avatar');
+
+    expect($conversions->count())->toBe(2)
+        ->and($conversions->first()->getName())->toBe('preview')
+        ->and($conversions->first()->getResultExtension())->toBe('png')
+        ->and($conversions->first()->getManipulations()->toArray())->toMatchArray([
+            'fit'    => [Fit::Crop, 50, 50],
+            'format' => ['png'],
+        ])
+        ->and($conversions->last()->getName())->toBe('web')
+        ->and($conversions->last()->getResultExtension())->toBe('webp')
+        ->and($conversions->last()->getManipulations()->toArray())->toMatchArray([
+            'format' => ['webp'],
+        ]);
+
+    $conversionCollection = ConversionCollection::createForMedia($this->signatureMedia);
+    /** @var ConversionCollection<int, Conversion> $conversions */
+    $conversions = $conversionCollection->getConversions('signature');
+
+    expect($conversions->count())->toBe(2)
+        ->and($conversions->first()->getName())->toBe('preview')
+        ->and($conversions->first()->getResultExtension())->toBe('jpeg')
+        ->and($conversions->first()->getManipulations()->toArray())->toMatchArray([
+            'fit'    => [Fit::Crop, 300, 100],
+            'format' => ['jpeg'],
+        ])
+        ->and($conversions->last()->getName())->toBe('web')
+        ->and($conversions->last()->getResultExtension())->toBe('webp')
+        ->and($conversions->last()->getManipulations()->toArray())->toMatchArray([
+            'format' => ['webp'],
+        ]);
+});
+
+it('will generate correct filenames for media in different collections but with identically named conversions', function () {
+    expect($this->model->getFirstMediaUrl('avatar', 'preview'))->toEndWith('.png');
+    expect($this->model->getFirstMediaUrl('avatar', 'web'))->toEndWith('.webp');
+
+    expect($this->model->getFirstMediaUrl('signature', 'preview'))->toEndWith('.jpeg');
+    expect($this->model->getFirstMediaUrl('signature', 'web'))->toEndWith('.webp');
+});


### PR DESCRIPTION
This PR fixes `ConversionCollection`'s behavior in finding conversion by name.

If a subject model has multiple collections, and multiple conversions with the same name, but applied to different collections, then `ConversionCollection` incorrectly determines the conversion which should be applied to the media.

Example:
```php
public function registerMediaCollections(): void
{
    $this->addMediaCollection('avatar')->acceptsMimeTypes(['image/png'])->singleFile();
    $this->addMediaCollection('signature')->acceptsMimeTypes(['image/jpeg'])->singleFile();
}

public function registerMediaConversions(?Media $media = null): void
{
    $this
        ->addMediaConversion('preview')
        ->fit(Fit::Crop, 50, 50)
        ->performOnCollections('avatar')
        ->format('png');

    $this
        ->addMediaConversion('preview')
        ->fit(Fit::Crop, 300, 100)
        ->performOnCollections('signature')
        ->format('jpeg');
}

```

Now, whereas conversion files are generated correctly, their URLs and paths are wrong, because `ConversionCollection` doesn't honor media collection, getting just the first conversion which name matches:

```php
$media = $model->getFirstMedia('signature');

ConversionCollection::createForMedia($media)
    ->getByName('preview') // <-- issue occurs here, first conversion with this name is fetched
    ->getManipulations()
    ->toArray();
```

Result:
```
[
  "format" => [
    "png",
  ],
  "fit" => [
    Spatie\Image\Enums\Fit {#4033
      +name: "Crop",
      +value: "crop",
    },
    50,
    50,
  ],
]
```

Generated URL is wrong too, because internally the fetched conversion is used to determine file extension:
```php
$media->getFirstMediaUrl('signature', 'preview');
```
Result:
```
https://.../media/2/c/test-preview.png <-- should be .jpeg
```

This PR fixes this behavior. Specifically, `ConversionCollection::getByName()` function first filters conversions by media's collection, and only then searches by conversion name.

Tests included.