### PR TITLE
Fix SVG files loosing transparency during conversion

### DIFF
--- a/src/Conversions/ImageGenerators/Svg.php
+++ b/src/Conversions/ImageGenerators/Svg.php
@@ -11,12 +11,13 @@ class Svg extends ImageGenerator
 {
     public function convert(string $file, ?Conversion $conversion = null): string
     {
-        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.jpg';
+        $imageFile = pathinfo($file, PATHINFO_DIRNAME).'/'.pathinfo($file, PATHINFO_FILENAME).'.png';
 
-        $image = new Imagick;
-        $image->readImage($file);
+        $image = new Imagick();
         $image->setBackgroundColor(new ImagickPixel('none'));
-        $image->setImageFormat('jpg');
+        $image->readImage($file);
+
+        $image->setImageFormat('png32');
 
         file_put_contents($imageFile, $image);
 

--- a/tests/Conversions/ImageGenerators/SvgTest.php
+++ b/tests/Conversions/ImageGenerators/SvgTest.php
@@ -20,4 +20,4 @@ it('can convert a svg', function () {
     expect(mime_content_type($imageFile))->toEqual('image/png');
 
     expect((new Imagick($imageFile))->getImageAlphaChannel())->toBeTrue();
-})->skipWhenRunningLocally();
+});

--- a/tests/Conversions/ImageGenerators/SvgTest.php
+++ b/tests/Conversions/ImageGenerators/SvgTest.php
@@ -17,5 +17,5 @@ it('can convert a svg', function () {
 
     $imageFile = $imageGenerator->convert($media->getPath());
 
-    expect(mime_content_type($imageFile))->toEqual('image/jpeg');
+    expect(mime_content_type($imageFile))->toEqual('image/png');
 })->skipWhenRunningLocally();

--- a/tests/Conversions/ImageGenerators/SvgTest.php
+++ b/tests/Conversions/ImageGenerators/SvgTest.php
@@ -18,4 +18,6 @@ it('can convert a svg', function () {
     $imageFile = $imageGenerator->convert($media->getPath());
 
     expect(mime_content_type($imageFile))->toEqual('image/png');
+
+    expect((new Imagick($imageFile))->getImageAlphaChannel())->toBeTrue();
 })->skipWhenRunningLocally();


### PR DESCRIPTION
Hello,

When running a media conversion against an SVG file to another file format that support transparency such as PNG or WEBP, conversions will lose any transparency and force a white background.

Two modifications were needed to make it work:

- Convert SVG files to PNG32 instead of JPEG to avoid loosing transparency
- Set the image background color **before** reading the image

I tested this change on PHP 8.3 / Imagick 1809 / ImageMagick 7.1.1-41 on Fedora Linux.

The PNG format of `png32` was the one previously used before [this commit](https://github.com/spatie/laravel-medialibrary/commit/955d6f28dcca637b38f239ffebe66c396ecda973), I guess 32 is good enough for most SVG use-cases.