### PR TITLE
Add version to responsive image url

### DIFF
--- a/src/ResponsiveImages/ResponsiveImage.php
+++ b/src/ResponsiveImages/ResponsiveImage.php
@@ -43,7 +43,13 @@ class ResponsiveImage
 
         $urlGenerator = UrlGeneratorFactory::createForMedia($this->media, $conversionName);
 
-        return $urlGenerator->getResponsiveImagesDirectoryUrl().rawurlencode($this->fileName);
+        $url = $urlGenerator->getResponsiveImagesDirectoryUrl().rawurlencode($this->fileName);
+
+        if (config('media-library.version_urls') === true) {
+            $url = "{$url}?v={$this->media->updated_at->timestamp}";
+        }
+
+        return $url;
     }
 
     public function generatedFor(): string


### PR DESCRIPTION
Within the config of this package you can enable versioned urls, this PR adds support for versioned responsive image urls.

This PR is extending the behavior added in PR #1569

I'm aware phpstan is failing, on unchanged files though, I did not have the time today to fix those. Will come back to these later if needed. 