### PR TITLE
Allow withResponsiveImages to be conditionally set

### DIFF
--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -186,9 +186,9 @@ class Conversion
         return $this;
     }
 
-    public function withResponsiveImages(): self
+    public function withResponsiveImages(bool $withResponsiveImages = true): self
     {
-        $this->generateResponsiveImages = true;
+        $this->generateResponsiveImages = $withResponsiveImages;
 
         return $this;
     }

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -112,3 +112,18 @@ it('can handle file names with underscore', function () {
 
     expect($media->getResponsiveImageUrls('non-existing-conversion'))->toBe([]);
 });
+
+test('a media instance can be set to not generate responsive urls', function () {
+    $this
+        ->testModelWithResponsiveImages
+        ->addMedia($this->getTestJpg())
+        ->withResponsiveImages()
+        ->withResponsiveImages(false)
+        ->toMediaCollection();
+
+    $media = $this->testModelWithResponsiveImages->getFirstMedia();
+
+    expect($media->hasResponsiveImages())->toBeFalse();
+    
+    expect($media->hasResponsiveImages('thumb'))->toBeFalse();
+});


### PR DESCRIPTION
Partial recreation of #2160, this was closed 4 years ago for inactivity.

Allow `withResponsiveImages()` to accept false values, while still maintaining backwards compatibility with current usage of the function.

A test has been included to make sure that the value is working as expected.

This is mostly for cases where `withResponsiveImages` was set by an external package (for example, some Media Library plugins) and you want to set it back to false.