### PR TITLE
Fix to broken tests for Responsive Media Conversions.

### DIFF
--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -24,6 +24,18 @@ it('will use the format parameter if it was given', function () {
     expect($this->conversion->getManipulations()->getManipulationArgument('format'))->toEqual(['png']);
 });
 
+it('will set conversions to responsive', function () {
+    $this->conversion->withResponsiveImages();
+
+    expect($this->conversion->shouldGenerateResponsiveImages())->toBeTrue();
+});
+
+it('will set conversions to not be responsive', function () {
+    $this->conversion->withResponsiveImages()->withResponsiveImages(false);
+
+    expect($this->conversion->shouldGenerateResponsiveImages())->toBeFalse();
+});
+
 it('will be performed on the given collection names', function () {
     $this->conversion->performOnCollections('images', 'downloads');
     expect($this->conversion->shouldBePerformedOn('images'))->toBeTrue();

--- a/tests/ResponsiveImages/ResponsiveImageTest.php
+++ b/tests/ResponsiveImages/ResponsiveImageTest.php
@@ -112,18 +112,3 @@ it('can handle file names with underscore', function () {
 
     expect($media->getResponsiveImageUrls('non-existing-conversion'))->toBe([]);
 });
-
-test('a media instance can be set to not generate responsive urls', function () {
-    $this
-        ->testModelWithResponsiveImages
-        ->addMedia($this->getTestJpg())
-        ->withResponsiveImages()
-        ->withResponsiveImages(false)
-        ->toMediaCollection();
-
-    $media = $this->testModelWithResponsiveImages->getFirstMedia();
-
-    expect($media->hasResponsiveImages())->toBeFalse();
-
-    expect($media->hasResponsiveImages('thumb'))->toBeFalse();
-});


### PR DESCRIPTION
Fix for my broken tests from #3742 .

I have double checked that these tests work correctly on my end. There shouldn't be any change in underlying functionality.

I apologise for not properly & thoroughly checking my previous PR w/rt the tests themselves.