### PR TITLE
Update installation-setup.md

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -289,6 +289,8 @@ By default, the media library will store its files on Laravel's `public` disk. I
             'driver' => 'local',
             'root'   => public_path('media'),
             'url'    => env('APP_URL').'/media',
+            'visibility' => 'public',
+            'throw' => false,
         ],
     ...
 ```


### PR DESCRIPTION
We add the two values, **`visibility`** and **`throw`**, in Laravel's filesystem configuration for the following reasons:

1. **`visibility` => 'public'**:   Ensures that files and directories created are accessible to the web server (e.g., Nginx). Files will have permissions like **`644`** and directories **`755`**, making them readable by others while maintaining write permissions for the application.

2. **`throw` => false**:   Prevents Laravel from throwing exceptions when a filesystem operation (like file upload or deletion) fails. Instead, Laravel will silently fail, allowing you to handle errors gracefully without crashing the application.

These settings help ensure compatibility between containers (Nginx and PHP-FPM) and avoid permission-related issues during file access.