### PR TITLE
Allow overriding the default media observer.

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -42,6 +42,11 @@ return [
     'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
 
     /*
+     * The fully qualified class name of the media observer.
+     */
+    'media_observer' => Spatie\MediaLibrary\MediaCollections\Models\Observers\MediaObserver::class,
+
+    /*
      * When enabled, media collections will be serialised using the default
      * laravel model serialization behaviour.
      *

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -32,9 +32,9 @@ class MediaLibraryServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         $mediaClass = config('media-library.media_model', Media::class);
-        $mediaObserver = config('media-library.media_observer', MediaObserver::class);
+        $mediaObserverClass = config('media-library.media_observer', MediaObserver::class);
 
-        $mediaClass::observe(new $mediaObserver);
+        $mediaClass::observe(new $mediaObserverClass);
     }
 
     public function packageRegistered(): void

--- a/src/MediaLibraryServiceProvider.php
+++ b/src/MediaLibraryServiceProvider.php
@@ -32,8 +32,9 @@ class MediaLibraryServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         $mediaClass = config('media-library.media_model', Media::class);
+        $mediaObserver = config('media-library.media_observer', MediaObserver::class);
 
-        $mediaClass::observe(new MediaObserver);
+        $mediaClass::observe(new $mediaObserver);
     }
 
     public function packageRegistered(): void


### PR DESCRIPTION
Adds a configuration option to register a custom media observer for when you might want to override the default handling for deleting a media etc.

This is fully backwards compatible assuming someone hasn't adding a custom `media_observer` key to their media-library.php config file (unlikely).

I considered adding tests, but there's not really anything package specific to test with this change.