### PR TITLE
Improve return types when using a custom Media model

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -27,6 +27,9 @@ use Spatie\MediaLibrary\Support\MediaLibraryPro;
 use Spatie\MediaLibraryPro\PendingMediaLibraryRequestHandler;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+/**
+ * @template TMedia of \Spatie\MediaLibrary\MediaCollections\Models\Media
+ */
 trait InteractsWithMedia
 {
     /** @var Conversion[] */
@@ -57,7 +60,7 @@ trait InteractsWithMedia
     }
 
     /**
-     * @return MorphMany<Media, $this>
+     * @return MorphMany<TMedia, $this>
      */
     public function media(): MorphMany
     {
@@ -66,12 +69,17 @@ trait InteractsWithMedia
 
     /**
      * Add a file to the media library.
+     *
+     * @return FileAdder<TMedia>
      */
     public function addMedia(string|UploadedFile $file): FileAdder
     {
         return app(FileAdderFactory::class)->create($this, $file);
     }
 
+    /**
+     * @return FileAdder<TMedia>
+     */
     public function addMediaFromRequest(string $key): FileAdder
     {
         return app(FileAdderFactory::class)->createFromRequest($this, $key);
@@ -79,6 +87,8 @@ trait InteractsWithMedia
 
     /**
      * Add a file from the given disk.
+     *
+     * @return FileAdder<TMedia>
      */
     public function addMediaFromDisk(string $key, ?string $disk = null): FileAdder
     {
@@ -111,7 +121,7 @@ trait InteractsWithMedia
      * Add multiple files from a request by keys.
      *
      * @param  string[]  $keys
-     * @return \Spatie\MediaLibrary\MediaCollections\FileAdder[]
+     * @return Collection<int, FileAdder<TMedia>>
      */
     public function addMultipleMediaFromRequest(array $keys): Collection
     {
@@ -121,7 +131,7 @@ trait InteractsWithMedia
     /**
      * Add all files from a request.
      *
-     * @return \Spatie\MediaLibrary\MediaCollections\FileAdder[]
+     * @return Collection<int, FileAdder<TMedia>>
      */
     public function addAllMediaFromRequest(): Collection
     {
@@ -131,9 +141,9 @@ trait InteractsWithMedia
     /**
      * Add a remote file to the media library.
      *
-     *
-     *
      * @throws \Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded
+     *
+     * @return FileAdder<TMedia>
      */
     public function addMediaFromUrl(string $url, array|string ...$allowedMimeTypes): FileAdder
     {
@@ -167,6 +177,8 @@ trait InteractsWithMedia
      * Add a file to the media library that contains the given string.
      *
      * @param string string
+     *
+     * @return FileAdder<TMedia>
      */
     public function addMediaFromString(string $text): FileAdder
     {
@@ -186,6 +198,8 @@ trait InteractsWithMedia
      *
      * @throws \Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded
      * @throws InvalidBase64Data
+     *
+     * @return FileAdder<TMedia>
      */
     public function addMediaFromBase64(string $base64data, array|string ...$allowedMimeTypes): FileAdder
     {
@@ -220,6 +234,8 @@ trait InteractsWithMedia
 
     /**
      * Add a file to the media library from a stream.
+     *
+     * @return FileAdder<TMedia>
      */
     public function addMediaFromStream($stream): FileAdder
     {
@@ -236,6 +252,8 @@ trait InteractsWithMedia
 
     /**
      * Copy a file to the media library.
+     *
+     * @return FileAdder<TMedia>
      */
     public function copyMedia(string|UploadedFile $file): FileAdder
     {
@@ -252,6 +270,8 @@ trait InteractsWithMedia
 
     /**
      * Get media collection by its collectionName.
+     *
+     * @return MediaCollections\Models\Collections\MediaCollection<int, TMedia>
      */
     public function getMedia(string $collectionName = 'default', array|callable $filters = []): MediaCollections\Models\Collections\MediaCollection
     {
@@ -270,6 +290,9 @@ trait InteractsWithMedia
         return config('media-library.media_model');
     }
 
+    /**
+     * @return TMedia|null
+     */
     public function getFirstMedia(string $collectionName = 'default', $filters = []): ?Media
     {
         $media = $this->getMedia($collectionName, $filters);

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -141,9 +141,9 @@ trait InteractsWithMedia
     /**
      * Add a remote file to the media library.
      *
-     * @throws \Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded
-     *
      * @return FileAdder<TMedia>
+     *
+     * @throws \Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded
      */
     public function addMediaFromUrl(string $url, array|string ...$allowedMimeTypes): FileAdder
     {
@@ -177,7 +177,6 @@ trait InteractsWithMedia
      * Add a file to the media library that contains the given string.
      *
      * @param string string
-     *
      * @return FileAdder<TMedia>
      */
     public function addMediaFromString(string $text): FileAdder
@@ -196,10 +195,10 @@ trait InteractsWithMedia
     /**
      * Add a base64 encoded file to the media library.
      *
+     * @return FileAdder<TMedia>
+     *
      * @throws \Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded
      * @throws InvalidBase64Data
-     *
-     * @return FileAdder<TMedia>
      */
     public function addMediaFromBase64(string $base64data, array|string ...$allowedMimeTypes): FileAdder
     {

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -25,6 +25,9 @@ use Spatie\MediaLibraryPro\Models\TemporaryUpload;
 use Symfony\Component\HttpFoundation\File\File as SymfonyFile;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+/**
+ * @template TMedia of \Spatie\MediaLibrary\MediaCollections\Models\Media
+ */
 class FileAdder
 {
     use Macroable;
@@ -229,11 +232,17 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return TMedia
+     */
     public function toMediaCollectionOnCloudDisk(string $collectionName = 'default'): Media
     {
         return $this->toMediaCollection($collectionName, config('filesystems.cloud'));
     }
 
+    /**
+     * @return TMedia
+     */
     public function toMediaCollectionFromRemote(string $collectionName = 'default', string $diskName = ''): Media
     {
         $storage = Storage::disk($this->file->getDisk());
@@ -287,6 +296,9 @@ class FileAdder
         return $media;
     }
 
+    /**
+     * @return TMedia
+     */
     public function toMediaCollection(string $collectionName = 'default', string $diskName = ''): Media
     {
         $sanitizedFileName = ($this->fileNameSanitizer)($this->fileName);
@@ -352,6 +364,9 @@ class FileAdder
         return $media;
     }
 
+    /**
+     * @return TMedia
+     */
     public function toMediaLibrary(string $collectionName = 'default', string $diskName = ''): Media
     {
         return $this->toMediaCollection($collectionName, $diskName);


### PR DESCRIPTION
This PR improves several return types when the Media model is extended (using the media_model config). With these generic types PHPStan can correctly resolve the custom Media model type.