### PR TITLE
Add default types for template

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -28,7 +28,7 @@ use Spatie\MediaLibraryPro\PendingMediaLibraryRequestHandler;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
- * @template TMedia of \Spatie\MediaLibrary\MediaCollections\Models\Media
+ * @template TMedia of \Spatie\MediaLibrary\MediaCollections\Models\Media = \Spatie\MediaLibrary\MediaCollections\Models\Media
  */
 trait InteractsWithMedia
 {

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\File\File as SymfonyFile;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
- * @template TMedia of \Spatie\MediaLibrary\MediaCollections\Models\Media
+ * @template TMedia of \Spatie\MediaLibrary\MediaCollections\Models\Media = \Spatie\MediaLibrary\MediaCollections\Models\Media
  */
 class FileAdder
 {


### PR DESCRIPTION
This is an improvement of https://github.com/spatie/laravel-medialibrary/pull/3777, so it is no longer required to set the generic value.