### PR TITLE
Add @return $this annotation to methods

### DIFF
--- a/src/Conversions/ConversionCollection.php
+++ b/src/Conversions/ConversionCollection.php
@@ -23,6 +23,9 @@ class ConversionCollection extends Collection
         return (new static)->setMedia($media);
     }
 
+    /**
+     * @return $this
+     */
     public function setMedia(Media $media): self
     {
         $this->media = $media;

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -78,6 +78,9 @@ class FileManipulator
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     protected function dispatchQueuedConversions(
         Media $media,
         ConversionCollection $conversions,
@@ -104,6 +107,9 @@ class FileManipulator
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     protected function generateResponsiveImages(Media $media, bool $withResponsiveImages): self
     {
         if (! $withResponsiveImages) {

--- a/src/Conversions/Manipulations.php
+++ b/src/Conversions/Manipulations.php
@@ -28,6 +28,9 @@ class Manipulations
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function addManipulation(string $name, array $parameters = []): self
     {
         $this->manipulations[$name] = $parameters;
@@ -64,6 +67,9 @@ class Manipulations
         }
     }
 
+    /**
+     * @return $this
+     */
     public function mergeManipulations(self $manipulations): self
     {
         foreach ($manipulations->toArray() as $name => $parameters) {
@@ -73,6 +79,9 @@ class Manipulations
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function removeManipulation(string $name): self
     {
         unset($this->manipulations[$name]);

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -452,6 +452,9 @@ trait InteractsWithMedia
         }
     }
 
+    /**
+     * @return $this
+     */
     public function clearMediaCollection(string $collectionName = 'default'): HasMedia
     {
         $this
@@ -467,6 +470,9 @@ trait InteractsWithMedia
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function clearMediaCollectionExcept(
         string $collectionName = 'default',
         array|Collection|Media $excludedMedia = []

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -73,6 +73,9 @@ class FileAdder
         $this->fileNameSanitizer = fn ($fileName) => $this->defaultSanitizer($fileName);
     }
 
+    /**
+     * @return $this
+     */
     public function setSubject(Model $subject): self
     {
         /** @var HasMedia $subject */
@@ -81,6 +84,9 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setFile($file): self
     {
         $this->file = $file;
@@ -124,6 +130,9 @@ class FileAdder
         throw UnknownType::create();
     }
 
+    /**
+     * @return $this
+     */
     public function preservingOriginal(bool $preserveOriginal = true): self
     {
         $this->preserveOriginal = $preserveOriginal;
@@ -131,11 +140,17 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function usingName(string $name): self
     {
         return $this->setName($name);
     }
 
+    /**
+     * @return $this
+     */
     public function setName(string $name): self
     {
         $this->mediaName = $name;
@@ -143,6 +158,9 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setOrder(?int $order): self
     {
         $this->order = $order;
@@ -150,11 +168,17 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function usingFileName(string $fileName): self
     {
         return $this->setFileName($fileName);
     }
 
+    /**
+     * @return $this
+     */
     public function setFileName(string $fileName): self
     {
         $this->fileName = $fileName;
@@ -162,6 +186,9 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setFileSize(int $fileSize): self
     {
         $this->fileSize = $fileSize;
@@ -169,6 +196,9 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function withCustomProperties(array $customProperties): self
     {
         $this->customProperties = $customProperties;
@@ -176,6 +206,9 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function storingConversionsOnDisk(string $diskName): self
     {
         $this->conversionsDiskName = $diskName;
@@ -183,6 +216,9 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function onQueue(?string $queue = null): self
     {
         $this->onQueue = $queue;
@@ -190,6 +226,9 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function withManipulations(array $manipulations): self
     {
         $this->manipulations = $manipulations;
@@ -197,6 +236,9 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function withProperties(array $properties): self
     {
         $this->properties = $properties;
@@ -204,11 +246,17 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function withAttributes(array $properties): self
     {
         return $this->withProperties($properties);
     }
 
+    /**
+     * @return $this
+     */
     public function withResponsiveImages(): self
     {
         $this->generateResponsiveImages = true;
@@ -216,6 +264,9 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function withResponsiveImagesIf($condition): self
     {
         $this->generateResponsiveImages = (bool) (is_callable($condition) ? $condition() : $condition);
@@ -223,6 +274,9 @@ class FileAdder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function addCustomHeaders(array $customRemoteHeaders): self
     {
         $this->customHeaders = $customRemoteHeaders;
@@ -430,6 +484,9 @@ class FileAdder
         return $sanitizedFileName;
     }
 
+    /**
+     * @return $this
+     */
     public function sanitizingFileName(callable $fileNameSanitizer): self
     {
         $this->fileNameSanitizer = $fileNameSanitizer;

--- a/src/MediaCollections/HtmlableMedia.php
+++ b/src/MediaCollections/HtmlableMedia.php
@@ -21,6 +21,9 @@ class HtmlableMedia implements \Stringable, Htmlable
         protected Media $media
     ) {}
 
+    /**
+     * @return $this
+     */
     public function attributes(array $attributes): self
     {
         if (is_array($attributes['class'] ?? null)) {
@@ -36,6 +39,9 @@ class HtmlableMedia implements \Stringable, Htmlable
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function conversion(string $conversionName): self
     {
         $this->conversionName = $conversionName;
@@ -43,6 +49,9 @@ class HtmlableMedia implements \Stringable, Htmlable
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function lazy(): self
     {
         $this->loadingAttributeValue = ('lazy');

--- a/src/MediaCollections/MediaCollection.php
+++ b/src/MediaCollections/MediaCollection.php
@@ -47,6 +47,9 @@ class MediaCollection
         return new static($name);
     }
 
+    /**
+     * @return $this
+     */
     public function useDisk(string $diskName): self
     {
         $this->diskName = $diskName;
@@ -54,6 +57,9 @@ class MediaCollection
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function storeConversionsOnDisk(string $conversionsDiskName): self
     {
         $this->conversionsDiskName = $conversionsDiskName;
@@ -61,6 +67,9 @@ class MediaCollection
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function acceptsFile(callable $acceptsFile): self
     {
         $this->acceptsFile = $acceptsFile;
@@ -68,6 +77,9 @@ class MediaCollection
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function acceptsMimeTypes(array $mimeTypes): self
     {
         $this->acceptsMimeTypes = $mimeTypes;
@@ -80,6 +92,9 @@ class MediaCollection
         return $this->onlyKeepLatest(1);
     }
 
+    /**
+     * @return $this
+     */
     public function onlyKeepLatest(int $maximumNumberOfItemsInCollection): self
     {
         if ($maximumNumberOfItemsInCollection < 1) {
@@ -98,6 +113,9 @@ class MediaCollection
         $this->mediaConversionRegistrations = $mediaConversionRegistrations;
     }
 
+    /**
+     * @return $this
+     */
     public function useFallbackUrl(string $url, string $conversionName = ''): self
     {
         if ($conversionName === '') {
@@ -109,6 +127,9 @@ class MediaCollection
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function useFallbackPath(string $path, string $conversionName = ''): self
     {
         if ($conversionName === '') {
@@ -120,6 +141,9 @@ class MediaCollection
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function withResponsiveImages(): self
     {
         $this->generateResponsiveImages = true;
@@ -127,6 +151,9 @@ class MediaCollection
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function withResponsiveImagesIf($condition): self
     {
         $this->generateResponsiveImages = (bool) (is_callable($condition) ? $condition() : $condition);

--- a/src/MediaCollections/Models/Collections/MediaCollection.php
+++ b/src/MediaCollections/Models/Collections/MediaCollection.php
@@ -18,6 +18,9 @@ class MediaCollection extends Collection implements Htmlable
 
     public ?string $formFieldName = null;
 
+    /**
+     * @return $this
+     */
     public function collectionName(string $collectionName): self
     {
         $this->collectionName = $collectionName;
@@ -25,6 +28,9 @@ class MediaCollection extends Collection implements Htmlable
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function formFieldName(string $formFieldName): self
     {
         $this->formFieldName = $formFieldName;

--- a/src/MediaCollections/Models/Concerns/CustomMediaProperties.php
+++ b/src/MediaCollections/Models/Concerns/CustomMediaProperties.php
@@ -4,6 +4,9 @@ namespace Spatie\MediaLibrary\MediaCollections\Models\Concerns;
 
 trait CustomMediaProperties
 {
+    /**
+     * @return $this
+     */
     public function setCustomHeaders(array $customHeaders): self
     {
         $this->setCustomProperty('custom_headers', $customHeaders);

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -259,6 +259,9 @@ class Media extends Model implements Attachable, Htmlable, Responsable
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function forgetCustomProperty(string $name): self
     {
         $customProperties = $this->custom_properties;
@@ -282,6 +285,9 @@ class Media extends Model implements Attachable, Htmlable, Responsable
         return collect($this->generated_conversions ?? []);
     }
 
+    /**
+     * @return $this
+     */
     public function markAsConversionGenerated(string $conversionName): self
     {
         $generatedConversions = $this->generated_conversions;
@@ -295,6 +301,9 @@ class Media extends Model implements Attachable, Htmlable, Responsable
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function markAsConversionNotGenerated(string $conversionName): self
     {
         $generatedConversions = $this->generated_conversions;
@@ -315,6 +324,9 @@ class Media extends Model implements Attachable, Htmlable, Responsable
         return Arr::get($generatedConversions, $conversionName, false);
     }
 
+    /**
+     * @return $this
+     */
     public function setStreamChunkSize(int $chunkSize): self
     {
         $this->streamChunkSize = $chunkSize;

--- a/src/ResponsiveImages/ResponsiveImage.php
+++ b/src/ResponsiveImages/ResponsiveImage.php
@@ -99,6 +99,9 @@ class ResponsiveImage
         return $between;
     }
 
+    /**
+     * @return $this
+     */
     public function delete(): self
     {
         $pathGenerator = PathGeneratorFactory::create($this->media);

--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -26,6 +26,9 @@ class MediaStream implements Responsable
         $this->zipOptions = [];
     }
 
+    /**
+     * @return $this
+     */
     public function useZipOptions(callable $zipOptionsCallable): self
     {
         $zipOptionsCallable($this->zipOptions);
@@ -33,6 +36,9 @@ class MediaStream implements Responsable
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function addMedia(...$mediaItems): self
     {
         collect($mediaItems)

--- a/src/Support/UrlGenerator/BaseUrlGenerator.php
+++ b/src/Support/UrlGenerator/BaseUrlGenerator.php
@@ -19,6 +19,9 @@ abstract class BaseUrlGenerator implements UrlGenerator
 
     public function __construct(protected Config $config) {}
 
+    /**
+     * @return $this
+     */
     public function setMedia(Media $media): UrlGenerator
     {
         $this->media = $media;
@@ -26,6 +29,9 @@ abstract class BaseUrlGenerator implements UrlGenerator
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setConversion(Conversion $conversion): UrlGenerator
     {
         $this->conversion = $conversion;
@@ -33,6 +39,9 @@ abstract class BaseUrlGenerator implements UrlGenerator
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setPathGenerator(PathGenerator $pathGenerator): UrlGenerator
     {
         $this->pathGenerator = $pathGenerator;


### PR DESCRIPTION
 #3777 and #3779 added generics to `InteractsWithMedia` and `FileAdder`, which improves PHPStan recognition of return types. However, PHPStan is still unable to follow through chaining; for instance, it will interpret the return value of:
```
$this->addMedia($file)
    ->usingFileName($filename)
    ->toMediaCollection('collection');
```
as the base `Media` class, even if an extended class has been specified.

This PR fixes that by listing the return type of a bunch of methods as `$this`. These include methods in the `FileAdder` class, needed for the example above; but I have also included several others (mostly with generics, where I believe it's most useful, but not only).