### PR TITLE
fix: media manipulations should be applied before media conversions

### DIFF
--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -3,6 +3,7 @@
 namespace Spatie\MediaLibrary\Conversions;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Traits\Conditionable;
 use Spatie\ImageOptimizer\OptimizerChainFactory;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -137,7 +138,7 @@ class Conversion
 
         $currentManipulations = $this->manipulations->toArray();
 
-        $allManipulations = array_merge($currentManipulations, $newManipulations);
+        $allManipulations = array_merge($newManipulations, Arr::except($currentManipulations, array_keys($newManipulations)));
 
         $this->manipulations = new Manipulations($allManipulations);
 

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -3,7 +3,6 @@
 namespace Spatie\MediaLibrary\Conversions;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Traits\Conditionable;
 use Spatie\ImageOptimizer\OptimizerChainFactory;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;

--- a/src/Conversions/ConversionCollection.php
+++ b/src/Conversions/ConversionCollection.php
@@ -79,11 +79,17 @@ class ConversionCollection extends Collection
 
     protected function addManipulationsFromDb(Media $media): void
     {
-        collect($media->manipulations)->each(function ($manipulation, $conversionName) {
+        collect(Arr::except($media->manipulations, '*'))->each(function ($manipulation, $conversionName) {
             $manipulations = new Manipulations($manipulation);
 
             $this->addManipulationToConversion($manipulations, $conversionName);
         });
+
+        if (array_key_exists('*', $media->manipulations)) {
+            $globalManipulations = new Manipulations($media->manipulations['*']);
+
+            $this->addManipulationToConversion($globalManipulations, '*');
+        }
     }
 
     public function getConversions(string $collectionName = ''): self

--- a/tests/Conversions/ConversionCollectionTest.php
+++ b/tests/Conversions/ConversionCollectionTest.php
@@ -32,10 +32,10 @@ beforeEach(function () {
     $this->avatarMedia = $avatarMedia->fresh();
 });
 
-it('will prepend the manipulation saved on the model and the wildmark manipulations', function () {
+it('will prepend the manipulation saved on the model with the wildmark manipulations which will take precedence', function () {
     $this->media->manipulations = [
-        '*' => ['brightness' => ['-80']],
         'thumb' => ['greyscale' => [], 'height' => [10]],
+        '*' => ['brightness' => ['-80']],
     ];
 
     $conversionCollection = ConversionCollection::createForMedia($this->media);
@@ -53,6 +53,14 @@ it('will prepend the manipulation saved on the model and the wildmark manipulati
     unset($manipulations['optimize']);
 
     $this->assertEquals([
+        'brightness',
+        'greyscale',
+        'height',
+        'format',
+        'width',
+    ], array_keys($manipulations));
+
+    $this->assertEquals([
         'greyscale' => [],
         'height' => [10],
         'brightness' => ['-80'],
@@ -60,6 +68,7 @@ it('will prepend the manipulation saved on the model and the wildmark manipulati
         'width' => [50],
     ], $manipulations);
 });
+
 
 it('will prepend the manipulation saved on the model', function () {
     $conversionCollection = ConversionCollection::createForMedia($this->media);
@@ -75,6 +84,13 @@ it('will prepend the manipulation saved on the model', function () {
     $this->assertArrayHasKey('optimize', $manipulations);
 
     unset($manipulations['optimize']);
+
+    $this->assertEquals([
+        'greyscale',
+        'height',
+        'format',
+        'width',
+    ], array_keys($manipulations));
 
     $this->assertEquals([
         'greyscale' => [],

--- a/tests/Conversions/ConversionCollectionTest.php
+++ b/tests/Conversions/ConversionCollectionTest.php
@@ -69,7 +69,6 @@ it('will prepend the manipulation saved on the model with the wildmark manipulat
     ], $manipulations);
 });
 
-
 it('will prepend the manipulation saved on the model', function () {
     $conversionCollection = ConversionCollection::createForMedia($this->media);
 


### PR DESCRIPTION
This issue was originally opened here #3665 .

This PR fixes it.

It was not originally caught because test assertions `assertEquals` doesn't check ordering for associative arrays. 

I added tests to assert ordering of array keys. 

Also added logic to make `*` manipulations to be applied before anything else. Otherwise 

```
    $this->media->manipulations = [
        'thumb' => ['greyscale' => [], 'height' => [10]],
        '*' => ['manualCrop' => [600, 400, 0, 0]],
    ];

```

would apply `greyscale` and `height` before anything else. The `manualCrop` defined in `*` should be applied before `*`.