### PR TITLE
Allow regenerate to queue all conversions

### DIFF
--- a/src/Conversions/Commands/RegenerateCommand.php
+++ b/src/Conversions/Commands/RegenerateCommand.php
@@ -23,7 +23,7 @@ class RegenerateCommand extends Command
     {--only-missing : Regenerate only missing conversions}
     {--with-responsive-images : Regenerate responsive images}
     {--force : Force the operation to run when in production}
-    {--queue-all : Queue all conversions}';
+    {--queue-all : Queue all conversions, even non-queued ones}';
 
     protected $description = 'Regenerate the derived images of media';
 

--- a/src/Conversions/Commands/RegenerateCommand.php
+++ b/src/Conversions/Commands/RegenerateCommand.php
@@ -23,7 +23,7 @@ class RegenerateCommand extends Command
     {--only-missing : Regenerate only missing conversions}
     {--with-responsive-images : Regenerate responsive images}
     {--force : Force the operation to run when in production}
-    {--queue : Queue all conversions}';
+    {--queue-all : Queue all conversions}';
 
     protected $description = 'Regenerate the derived images of media';
 
@@ -58,7 +58,7 @@ class RegenerateCommand extends Command
                     Arr::wrap($this->option('only')),
                     $this->option('only-missing'),
                     $this->option('with-responsive-images'),
-                    $this->option('queue'),
+                    $this->option('queue-all'),
                 );
             } catch (Exception $exception) {
                 $this->errorMessages[$media->getKey()] = $exception->getMessage();

--- a/src/Conversions/Commands/RegenerateCommand.php
+++ b/src/Conversions/Commands/RegenerateCommand.php
@@ -22,7 +22,8 @@ class RegenerateCommand extends Command
     {--X|exclude-starting-id : Exclude the provided id when regenerating from a specific id}
     {--only-missing : Regenerate only missing conversions}
     {--with-responsive-images : Regenerate responsive images}
-    {--force : Force the operation to run when in production}';
+    {--force : Force the operation to run when in production}
+    {--queue : Queue all conversions}';
 
     protected $description = 'Regenerate the derived images of media';
 
@@ -56,7 +57,8 @@ class RegenerateCommand extends Command
                     $media,
                     Arr::wrap($this->option('only')),
                     $this->option('only-missing'),
-                    $this->option('with-responsive-images')
+                    $this->option('with-responsive-images'),
+                    $this->option('queue'),
                 );
             } catch (Exception $exception) {
                 $this->errorMessages[$media->getKey()] = $exception->getMessage();

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -19,7 +19,7 @@ class FileManipulator
         array $onlyConversionNames = [],
         bool $onlyMissing = false,
         bool $withResponsiveImages = false,
-        bool $forceQueued = false,
+        bool $queueAll = false,
     ): void {
         if (! $this->canConvertMedia($media)) {
             return;
@@ -34,7 +34,7 @@ class FileManipulator
                 return in_array($conversion->getName(), $onlyConversionNames);
             })
             ->filter(fn (Conversion $conversion) => $conversion->shouldBePerformedOn($media->collection_name))
-            ->partition(fn (Conversion $conversion) => $forceQueued || $conversion->shouldBeQueued());
+            ->partition(fn (Conversion $conversion) => $queueAll || $conversion->shouldBeQueued());
 
         $this
             ->performConversions($conversions, $media, $onlyMissing)

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -18,7 +18,8 @@ class FileManipulator
         Media $media,
         array $onlyConversionNames = [],
         bool $onlyMissing = false,
-        bool $withResponsiveImages = false
+        bool $withResponsiveImages = false,
+        bool $forceQueued = false,
     ): void {
         if (! $this->canConvertMedia($media)) {
             return;
@@ -33,7 +34,7 @@ class FileManipulator
                 return in_array($conversion->getName(), $onlyConversionNames);
             })
             ->filter(fn (Conversion $conversion) => $conversion->shouldBePerformedOn($media->collection_name))
-            ->partition(fn (Conversion $conversion) => $conversion->shouldBeQueued());
+            ->partition(fn (Conversion $conversion) => $forceQueued || $conversion->shouldBeQueued());
 
         $this
             ->performConversions($conversions, $media, $onlyMissing)

--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -369,7 +369,6 @@ it('can set updated_at column when regenerating', function () {
 
 it('can force queue non-queued conversions', function () {
     Queue::fake();
-    config()->set('media-library.queue_connection_name', 'array');
 
     $media = $this->testModelWithConversion
         ->addMedia($this->getTestFilesDirectory('test.jpg'))
@@ -377,7 +376,7 @@ it('can force queue non-queued conversions', function () {
 
     unlink($thumbConversion = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg"));
 
-    $this->artisan('media-library:regenerate', ['--queue' => true]);
+    $this->artisan('media-library:regenerate', ['--queue-all' => true]);
 
     $this->assertFileDoesNotExist($this->getMediaDirectory($thumbConversion));
 


### PR DESCRIPTION
This PR adds a `--queue-all` option to the `media-library:regenerate` artisan command that queues non-queued conversions.

This is particularly helpful when regenerating conversions on historic images after adding a new non-queued conversion to the codebase. I can now run `php artisan media-library:regenerate --only-missing --queue-all` and let the queue take care of it.