### PR TITLE
Dynamically check instance of temporary upload model

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -123,7 +123,7 @@ class FileAdder
             return $this;
         }
 
-        if ($file instanceof TemporaryUpload) {
+        if ($file instanceof (config('media-library.temporary_upload_model'))) {
             return $this;
         }
 
@@ -363,7 +363,7 @@ class FileAdder
             return $this->toMediaCollectionFromRemote($collectionName, $diskName);
         }
 
-        if ($this->file instanceof TemporaryUpload) {
+        if ($this->file instanceof (config('media-library.temporary_upload_model'))) {
             return $this->toMediaCollectionFromTemporaryUpload($collectionName, $diskName, $this->fileName);
         }
 


### PR DESCRIPTION
This PR makes the `instanceof` check for the temporary upload model dynamic by retrieving the model from the config instead of hardcoding it. This allows using a model that does not extend the base class.