### PR TITLE
Add null check for temporary model instance

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -123,7 +123,7 @@ class FileAdder
             return $this;
         }
 
-        if ($file instanceof (config('media-library.temporary_upload_model'))) {
+        if ($this->isInstanceOfTemporaryUploadModel($file)) {
             return $this;
         }
 
@@ -363,7 +363,7 @@ class FileAdder
             return $this->toMediaCollectionFromRemote($collectionName, $diskName);
         }
 
-        if ($this->file instanceof (config('media-library.temporary_upload_model'))) {
+        if ($this->isInstanceOfTemporaryUploadModel($this->file)) {
             return $this->toMediaCollectionFromTemporaryUpload($collectionName, $diskName, $this->fileName);
         }
 
@@ -635,5 +635,16 @@ class FileAdder
         return $extension
             ? $file.'.'.$extension
             : $file;
+    }
+
+    protected function isInstanceOfTemporaryUploadModel(mixed $file): bool
+    {
+        $model = config('media-library.temporary_upload_model');
+
+        if ($model === null) {
+            return false;
+        }
+
+        return $file instanceof $model;
     }
 }


### PR DESCRIPTION
This fixes the change made in https://github.com/spatie/laravel-medialibrary/pull/3795 by adding a null check.

I extracted it to a method since it's used in 2 different places and otherwise seems a bit too verbose too repeat. Didn't add a type hint because `$this->file` doesn't have it either, maybe for backwards compatibility.