### PR TITLE
Add support for SSL config for HttpFacadeDownloader

### DIFF
--- a/src/Downloaders/HttpFacadeDownloader.php
+++ b/src/Downloaders/HttpFacadeDownloader.php
@@ -15,7 +15,7 @@ class HttpFacadeDownloader implements Downloader
             ->throw(fn() => throw new UnreachableUrl($url))
             ->sink($temporaryFile);
 
-        if (! config('media-library.media_downloader_ssl', true)) {
+        if (!config('media-library.media_downloader_ssl')) {
             $http->withoutVerifying();
         }
 

--- a/src/Downloaders/HttpFacadeDownloader.php
+++ b/src/Downloaders/HttpFacadeDownloader.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\MediaLibrary\Downloaders;
 
-use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
 

--- a/src/Downloaders/HttpFacadeDownloader.php
+++ b/src/Downloaders/HttpFacadeDownloader.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary\Downloaders;
 
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\UnreachableUrl;
 
@@ -11,10 +12,15 @@ class HttpFacadeDownloader implements Downloader
     {
         $temporaryFile = tempnam(sys_get_temp_dir(), 'media-library');
 
-        Http::withUserAgent('Spatie MediaLibrary')
-            ->throw(fn () => throw new UnreachableUrl($url))
-            ->sink($temporaryFile)
-            ->get($url);
+        $http = Http::withUserAgent('Spatie MediaLibrary')
+            ->throw(fn() => throw new UnreachableUrl($url))
+            ->sink($temporaryFile);
+
+        if (! config('media-library.media_downloader_ssl', true)) {
+            $http->withoutVerifying();
+        }
+
+        $http->get($url);
 
         return $temporaryFile;
     }

--- a/tests/Downloader/HttpFacadeDownloaderTest.php
+++ b/tests/Downloader/HttpFacadeDownloaderTest.php
@@ -58,31 +58,6 @@ it('can be mocked easily for tests', function () {
 it('respects ssl verification settings from config', function () {
     $url = 'https://example.com';
 
-    Config::set('media-library.media_downloader_ssl', true);
-
-    \Illuminate\Support\Facades\Http::shouldReceive('withUserAgent')
-        ->with('Spatie MediaLibrary')
-        ->once()
-        ->andReturnSelf()
-        ->getMock()
-        ->shouldReceive('throw')
-        ->once()
-        ->andReturnSelf()
-        ->getMock()
-        ->shouldReceive('sink')
-        ->once()
-        ->andReturnSelf()
-        ->getMock()
-        ->shouldReceive('withoutVerifying')
-        ->never()
-        ->getMock()
-        ->shouldReceive('get')
-        ->with($url)
-        ->once();
-
-    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader;
-    $downloader->getTempFile($url);
-
     Config::set('media-library.media_downloader_ssl', false);
 
     \Illuminate\Support\Facades\Http::shouldReceive('withUserAgent')
@@ -100,7 +75,6 @@ it('respects ssl verification settings from config', function () {
         ->getMock()
         ->shouldReceive('withoutVerifying')
         ->once()
-        ->andReturnSelf()
         ->getMock()
         ->shouldReceive('get')
         ->with($url)

--- a/tests/Downloader/HttpFacadeDownloaderTest.php
+++ b/tests/Downloader/HttpFacadeDownloaderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 
 it('can save a url to a temp location', function () {
@@ -52,4 +53,59 @@ it('can be mocked easily for tests', function () {
     Http::assertSent(function (Request $request) {
         return $request->url() == 'https://example.com';
     });
+});
+
+it('respects ssl verification settings from config', function () {
+    $url = 'https://example.com';
+
+    Config::set('media-library.media_downloader_ssl', true);
+
+    \Illuminate\Support\Facades\Http::shouldReceive('withUserAgent')
+        ->with('Spatie MediaLibrary')
+        ->once()
+        ->andReturnSelf()
+        ->getMock()
+        ->shouldReceive('throw')
+        ->once()
+        ->andReturnSelf()
+        ->getMock()
+        ->shouldReceive('sink')
+        ->once()
+        ->andReturnSelf()
+        ->getMock()
+        ->shouldReceive('withoutVerifying')
+        ->never()
+        ->getMock()
+        ->shouldReceive('get')
+        ->with($url)
+        ->once();
+
+    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader;
+    $downloader->getTempFile($url);
+
+    Config::set('media-library.media_downloader_ssl', false);
+
+    \Illuminate\Support\Facades\Http::shouldReceive('withUserAgent')
+        ->with('Spatie MediaLibrary')
+        ->once()
+        ->andReturnSelf()
+        ->getMock()
+        ->shouldReceive('throw')
+        ->once()
+        ->andReturnSelf()
+        ->getMock()
+        ->shouldReceive('sink')
+        ->once()
+        ->andReturnSelf()
+        ->getMock()
+        ->shouldReceive('withoutVerifying')
+        ->once()
+        ->andReturnSelf()
+        ->getMock()
+        ->shouldReceive('get')
+        ->with($url)
+        ->once();
+
+    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader;
+    $downloader->getTempFile($url);
 });


### PR DESCRIPTION
This option add support the config `media-library.media_downloader_ssl` for the `HttpFacadeDownloader`. As currently, it's only implemented in the `DefaultDownloader` class