### PR TITLE
Add support for LastMedia functions

### DIFF
--- a/docs/basic-usage/retrieving-media.md
+++ b/docs/basic-usage/retrieving-media.md
@@ -35,6 +35,13 @@ $media = $yourModel->getFirstMedia();
 $url = $yourModel->getFirstMediaUrl();
 ```
 
+You can also retrieve the last media by using similar convenience-methods:
+
+```php
+$media = $yourModel->getLastMedia();
+$url = $yourModel->getLastMediaUrl();
+```
+
 An instance of `Media` also has a name, by default its filename:
 
 ```php

--- a/src/Enums/CollectionPosition.php
+++ b/src/Enums/CollectionPosition.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\MediaLibrary\Enums;
+
+enum CollectionPosition {
+    case FIRST;
+    case LAST;
+}

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -431,14 +431,9 @@ trait InteractsWithMedia
         return $fallbackPaths[$conversionName] ?? $fallbackPaths['default'] ?? '';
     }
 
-    /*
-     * Get the url of the image for the given conversionName
-     * for first media for the given collectionName.
-     * If no profile is given, return the source's url.
-     */
-    public function getFirstMediaPath(string $collectionName = 'default', string $conversionName = ''): string
+    private function getMediaItemPath(string $collectionName, string $conversionName, string $firstOrLast): string
     {
-        $media = $this->getFirstMedia($collectionName);
+        $media = $firstOrLast === 'first' ? $this->getFirstMedia($collectionName) : $this->getLastMedia($collectionName);
 
         if (! $media) {
             return $this->getFallbackMediaPath($collectionName, $conversionName) ?: '';
@@ -449,6 +444,22 @@ trait InteractsWithMedia
         }
 
         return $media->getPath($conversionName);
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for first media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getFirstMediaPath(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        return $this->getMediaItemPath($collectionName, $conversionName, 'first');
+    }
+    
+
+    public function getLastMediaPath(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        return $this->getMediaItemPath($collectionName, $conversionName, 'last');
     }
 
     /*

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -289,24 +289,32 @@ trait InteractsWithMedia
         return config('media-library.media_model');
     }
 
+    private function getMediaItem(string $collectionName, $filters, string $firstOrLast)
+    {
+        $media = $this->getMedia($collectionName, $filters);
+
+        return $firstOrLast === 'first' ? $media->first() : $media->last();
+    }
+
     /**
      * @return TMedia|null
      */
     public function getFirstMedia(string $collectionName = 'default', $filters = []): ?Media
     {
-        $media = $this->getMedia($collectionName, $filters);
-
-        return $media->first();
+        return $this->getMediaItem($collectionName, $filters, 'first');        
     }
 
-    /*
-     * Get the url of the image for the given conversionName
-     * for first media for the given collectionName.
-     * If no profile is given, return the source's url.
+    /**
+     * @return TMedia|null
      */
-    public function getFirstMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
+    public function getLastMedia(string $collectionName = 'default', $filters = []): ?Media
     {
-        $media = $this->getFirstMedia($collectionName);
+        return $this->getMediaItem($collectionName, $filters, 'last');        
+    }
+
+    private function getMediaItemUrl(string $collectionName, string $conversionName, string $firstOrLast): string
+    {
+        $media = $firstOrLast === 'first' ? $this->getFirstMedia($collectionName) : $this->getLastMedia($collectionName);
 
         if (! $media) {
             return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
@@ -322,15 +330,30 @@ trait InteractsWithMedia
     /*
      * Get the url of the image for the given conversionName
      * for first media for the given collectionName.
-     *
      * If no profile is given, return the source's url.
      */
-    public function getFirstTemporaryUrl(
+    public function getFirstMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        return $this->getMediaItemUrl($collectionName, $conversionName, 'first');
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for last media for the given collectionName.
+     * If no profile is given, return the source's url.
+     */
+    public function getLastMediaUrl(string $collectionName = 'default', string $conversionName = ''): string
+    {
+        return $this->getMediaItemUrl($collectionName, $conversionName, 'last');
+    }
+
+    private function getMediaItemTemporaryUrl(
         DateTimeInterface $expiration,
-        string $collectionName = 'default',
-        string $conversionName = ''
+        string $collectionName,
+        string $conversionName,
+        string $firstOrLast
     ): string {
-        $media = $this->getFirstMedia($collectionName);
+        $media = $firstOrLast === 'first' ? $this->getFirstMedia($collectionName) : $this->getLastMedia($collectionName);
 
         if (! $media) {
             return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
@@ -341,6 +364,34 @@ trait InteractsWithMedia
         }
 
         return $media->getTemporaryUrl($expiration, $conversionName);
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for first media for the given collectionName.
+     *
+     * If no profile is given, return the source's url.
+     */
+    public function getFirstTemporaryUrl(
+        DateTimeInterface $expiration,
+        string $collectionName = 'default',
+        string $conversionName = ''
+    ): string {
+        return $this->getMediaItemTemporaryUrl($expiration, $collectionName, $conversionName, 'first');
+    }
+
+    /*
+     * Get the url of the image for the given conversionName
+     * for last media for the given collectionName.
+     *
+     * If no profile is given, return the source's url.
+     */
+    public function getLastTemporaryUrl(
+        DateTimeInterface $expiration,
+        string $collectionName = 'default',
+        string $conversionName = ''
+    ): string {
+        return $this->getMediaItemTemporaryUrl($expiration, $collectionName, $conversionName, 'last');
     }
 
     public function getRegisteredMediaCollections(): Collection

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -203,6 +203,94 @@ it('can get the path to first media in a collection', function () {
     expect($this->testModel->getFirstMediaPath('images'))->toEqual($firstMedia->getPath());
 });
 
+it('can get the last media from a collection', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $media->name = 'first';
+    $media->save();
+
+    $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $media->name = 'last';
+    $media->save();
+
+    expect($this->testModel->getLastMedia('images')->name)->toEqual('last');
+});
+
+it('can get the last media from a collection using a filter', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withCustomProperties(['extra_property' => 'yes'])
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+    $media->name = 'first_with_extra_property';
+    $media->save();
+
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withCustomProperties(['extra_property' => 'yes'])
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+    $media->name = 'last_with_extra_property';
+    $media->save();
+
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+    $media->name = 'last';
+    $media->save();
+
+    expect($this->testModel->getLastMedia('images', ['extra_property' => 'yes'])->name)->toEqual('last_with_extra_property');
+});
+
+it('can get the last media from a collection using a filter callback', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withCustomProperties(['extra_property' => 'yes'])
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+    $media->name = 'first_with_extra_property';
+    $media->save();
+
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->withCustomProperties(['extra_property' => 'yes'])
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+    $media->name = 'last_with_extra_property';
+    $media->save();
+
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection('images');
+    $media->name = 'last';
+    $media->save();
+
+    $media = $this->testModel->getLastMedia('images', fn (Media $media) => isset($media->custom_properties['extra_property']));
+
+    expect($media->name)->toEqual('last_with_extra_property');
+});
+
+it('can get the url to last media in a collection', function () {
+    $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $firstMedia->save();
+
+    $lastMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $lastMedia->save();
+
+    expect($this->testModel->getLastMediaUrl('images'))->toEqual($lastMedia->getUrl());
+});
+
+it('can get the path to last media in a collection', function () {
+    $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $firstMedia->save();
+
+    $lastMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $lastMedia->save();
+
+    expect($this->testModel->getLastMediaPath('images'))->toEqual($lastMedia->getPath());
+});
+
 it('can get the default path to the first media in a collection', function ($conversionName, $expectedPath) {
     expect($this->testModel->getFirstMediaPath('avatar', $conversionName))->toEqual($expectedPath);
 })->with([


### PR DESCRIPTION
Getting the last media item, which is also the most recent media item, is also useful when a collection is used for storing multiple versions of a single file.