### PR TITLE
Feat: set default expiration minutes when no value passes in args for temp url

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -215,6 +215,12 @@ return [
      */
     'media_downloader_ssl' => env('MEDIA_DOWNLOADER_SSL', true),
 
+    /*
+     * The default lifetime in minutes for temporary urls.
+     * This is used when you call the `getLastTemporaryUrl` or `getLastTemporaryUrl` method on a media item.
+     */
+    'temporary_url_default_lifetime' => env('MEDIA_TEMPORARY_URL_DEFAULT_LIFETIME', 5),
+
     'remote' => [
         /*
          * Any extra headers that should be included when uploading media to

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -380,10 +380,12 @@ trait InteractsWithMedia
      * If no profile is given, return the source's url.
      */
     public function getFirstTemporaryUrl(
-        DateTimeInterface $expiration,
+        ?DateTimeInterface $expiration = null,
         string $collectionName = 'default',
         string $conversionName = ''
     ): string {
+        $expiration = $expiration ?: now()->addMinutes(config('media-library.temporary_url_default_lifetime'));
+
         return $this->getMediaItemTemporaryUrl($expiration, $collectionName, $conversionName, CollectionPosition::First);
     }
 
@@ -394,10 +396,12 @@ trait InteractsWithMedia
      * If no profile is given, return the source's url.
      */
     public function getLastTemporaryUrl(
-        DateTimeInterface $expiration,
+        ?DateTimeInterface $expiration = null,
         string $collectionName = 'default',
         string $conversionName = ''
     ): string {
+        $expiration = $expiration ?: now()->addMinutes(config('media-library.temporary_url_default_lifetime'));
+
         return $this->getMediaItemTemporaryUrl($expiration, $collectionName, $conversionName, CollectionPosition::Last);
     }
 

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -141,6 +141,16 @@ it('can get the temporary url to first media in a collection', function () {
     expect($this->testModel->getFirstTemporaryUrl(Carbon::now()->addMinutes(5), 'images'))->toEqual($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5)));
 });
 
+it('can get the temporary url to first media in a collection when no expiration passed', function () {
+    $firstMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images', 's3_disk');
+    $firstMedia->save();
+
+    $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images', 's3_disk');
+    $secondMedia->save();
+
+    expect($this->testModel->getFirstTemporaryUrl(collectionName: 'images'))->toEqual($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5)));
+});
+
 it('retrieves a temporary media conversion url from s3', function () {
     $media = $this->testModelWithConversion
         ->addMedia($this->getTestJpg())


### PR DESCRIPTION
Most of the time I work with temporary URLs when working with private media. It is very cumbersome to set the expiration time for every `$model->getFirstTemporaryUrl(now()->addMinutes(5))` 

To overcome this, I am submitting this PR, where, if no arg is passed, a default time is set, can be configured from config.

This want I can do

```php
// Before
$model->getFirstTemporaryUrl(now()->addMinutes(5));

// After
$model->getFirstTemporaryUrl();
```