### PR TITLE
Add native `copyObject` API support for R2 disks

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -11,9 +11,7 @@ return [
     /*
      * If using R2 (Cloudflare), set your disk key below to true. Enables optimized copy behavior.
      */
-    'r2_disks' => [
-        'r2' => true, // disk name => true
-    ],
+    'r2_disk' => false,
 
     /*
      * The maximum file size of an item in bytes.

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -11,7 +11,7 @@ return [
     /*
      * If using R2 (Cloudflare), set your disk key below to true. Enables optimized copy behavior.
      */
-    'r2_disk' => false,
+    'r2_disk' => env('R2_FILESYSTEM_DISK', false),
 
     /*
      * The maximum file size of an item in bytes.

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -9,6 +9,13 @@ return [
     'disk_name' => env('MEDIA_DISK', 'public'),
 
     /*
+     * If using R2 (Cloudflare), set your disk key below to true. Enables optimized copy behavior.
+     */
+    'r2_disks' => [
+        'r2' => true, // disk name => true
+    ],
+
+    /*
      * The maximum file size of an item in bytes.
      * Adding a larger file will result in an exception.
      */

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -47,6 +47,11 @@ return [
     'disk_name' => env('MEDIA_DISK', 'public'),
 
     /*
+     * If using R2 (Cloudflare), set your disk key below to true. Enables optimized copy behavior.
+     */
+    'r2_disk' => env('R2_FILESYSTEM_DISK', false),
+    
+    /*
      * The maximum file size of an item in bytes.
      * Adding a larger file will result in an exception.
      */


### PR DESCRIPTION
This PR adds optional support for native copyObject when using R2-compatible S3 disks.

- Introduced `r2_disk` config to define is that R2 disk and use `copyObject`.
- If the disk supports getClient and getBucket, the library will use native S3 copyObject.
- Falls back to default copy method if unavailable.

This improves performance and avoids unnecessary file downloads/uploads.
