### PR TITLE
Do not use default url when conversion does not exists

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -321,12 +321,8 @@ trait InteractsWithMedia
             ? $this->getFirstMedia($collectionName)
             : $this->getLastMedia($collectionName);
 
-        if (! $media) {
+        if (! $media || ($conversionName !== '' && ! $media->hasGeneratedConversion($conversionName))) {
             return $this->getFallbackMediaUrl($collectionName, $conversionName) ?: '';
-        }
-
-        if ($conversionName !== '' && ! $media->hasGeneratedConversion($conversionName)) {
-            return $media->getUrl();
         }
 
         return $media->getUrl($conversionName);

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -335,7 +335,7 @@ it('can get the correct path to the converted media in a collection if conversio
     expect($this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'))->toEqual($media->getPath('avatar_thumb'));
 });
 
-it('can get the default url to the first media in a collection if conversion not marked as generated yet', function () {
+it('will return null when first media in a collection the conversion not marked as generated yet', function () {
     $media = $this
         ->testModelWithConversionQueued
         ->addMedia($this->getTestJpg())
@@ -345,7 +345,7 @@ it('can get the default url to the first media in a collection if conversion not
     unlink($avatarThumbConversion);
     $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
 
-    expect($this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'))->toEqual("/media/{$media->id}/test.jpg");
+    expect($this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'))->toBeNull();
 });
 
 it('will return preloaded media sorting on order column', function () {

--- a/tests/Feature/InteractsWithMedia/GetMediaTest.php
+++ b/tests/Feature/InteractsWithMedia/GetMediaTest.php
@@ -335,7 +335,7 @@ it('can get the correct path to the converted media in a collection if conversio
     expect($this->testModelWithConversionQueued->getFirstMediaPath('avatar', 'avatar_thumb'))->toEqual($media->getPath('avatar_thumb'));
 });
 
-it('will return null when first media in a collection the conversion not marked as generated yet', function () {
+it('will return empty url when first media in a collection the conversion not marked as generated yet', function () {
     $media = $this
         ->testModelWithConversionQueued
         ->addMedia($this->getTestJpg())
@@ -345,7 +345,7 @@ it('will return null when first media in a collection the conversion not marked 
     unlink($avatarThumbConversion);
     $this->testModelWithConversionQueued->getFirstMedia('avatar')->markAsConversionNotGenerated('avatar_thumb');
 
-    expect($this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'))->toBeNull();
+    expect($this->testModelWithConversionQueued->getFirstMediaUrl('avatar', 'avatar_thumb'))->toEqual('');
 });
 
 it('will return preloaded media sorting on order column', function () {


### PR DESCRIPTION
I think this actually may also fix a security risk:

```php
$url = $this->getFirstMediaUrl('clips', 'thumbnail'); // thumbnail does not exists (yet)

echo $url; // https://s3.example.com/media/media_original_filename.mp4
```

It shouldn't fallback to the default media asset (`media_original_filename.mp4
`), as in my case this is not exposed to the public.

This results in a 403 (because I have set my s3 permissions correctly), but could result in exposing information and a invalid fallback even if public (it tried to render an image with a mp4 file).

I do understand you can use `hasGeneratedConversion(..)`, but I think most will just return a null if not generated yet. For example:

```
// PostResource.php

public function toArray($request): array
{
    return [
        'id' => $this->getKey(),
        'name' => $this->name,
        'thumbnail' => $this->getFirstMediaUrl('clips', 'thumbnail'),
    ];
}
```

It's perfectly possible to do the `null` check in your frontend, or even implement the fallback in a component (e.g. broken image icon).