### PR TITLE
docs: add installation instructions for image optimizers on Alpine Linux

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -340,6 +340,13 @@ sudo apt install jpegoptim optipng pngquant gifsicle libavif-bin
 sudo snap install svgo
 ```
 
+Here's how to install all the optimizers on Alpine Linux:
+
+```bash
+apk add jpegoptim optipng pngquant gifsicle libavif-apps
+npm install -g svgo
+```
+
 Here's how to install the binaries on MacOS (using [Homebrew](https://brew.sh/)):
 
 ```bash


### PR DESCRIPTION
Visual proof:
<img width="725" height="942" alt="Screenshot 2025-08-28 130943" src="https://github.com/user-attachments/assets/0ddec4ac-14e3-4f84-94ca-b923c9efa141" />
