### PR TITLE
Adding support for `.m4v` video format

### DIFF
--- a/src/Conversions/ImageGenerators/Video.php
+++ b/src/Conversions/ImageGenerators/Video.php
@@ -43,11 +43,11 @@ class Video extends ImageGenerator
 
     public function supportedExtensions(): Collection
     {
-        return collect(['webm', 'mov', 'mp4']);
+        return collect(['webm', 'mov', 'mp4', 'm4v']);
     }
 
     public function supportedMimeTypes(): Collection
     {
-        return collect(['video/webm', 'video/mpeg', 'video/mp4', 'video/quicktime']);
+        return collect(['video/webm', 'video/mpeg', 'video/mp4', 'video/quicktime', 'video/x-m4v']);
     }
 }


### PR DESCRIPTION
I have a use case where I am downloading `.m4v` files from a remote server and need to then generate thumbnails of them.

ffmpeg and ffprobe (which are used directly by this package) both already support this video format so it's just a matter of adding their extension and MIME-type to the package to allow it to see them as acceptable video files. 