### PR TITLE
getMediaItem returns weird result

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -308,7 +308,7 @@ trait InteractsWithMedia
 
     protected function getMediaItem(string $collectionName, $filters, CollectionPosition $position)
     {
-        $media = $this->getMedia($collectionName, $filters);
+        $media = $this->getMedia($collectionName, $filters)->sortBy('id');
 
         return $position === CollectionPosition::First
             ? $media->first()


### PR DESCRIPTION
I have this extremely weird issue.

When using `getFirstMedia()` or `getLastMedia()` I'm receiving a wrong result.

When I do this:
```php
dd(
    $model->getMedia(MyModel::COLLECTION_NAME_CONST)
                ->keyBy('id')
                ->map(fn ($media) => $media->created_at->toDatetimeString()),

    $model->getLastMedia(MyModel::COLLECTION_NAME_CONST)->getKey()
);
```

this gets outputted...

<img width="272" height="459" alt="Scherm­afbeelding 2025-09-03 om 19 15 52" src="https://github.com/user-attachments/assets/d87e376d-144f-48ae-8730-7ffd38d0578f" />

The last media item is the second one (id 2594)...
So it seems `getMedia()` is returning items in random order, causing `getLastMedia()` to behave unexpectedly.

On my local machine it works just fine. When tried on different cloud servers, each server yields a _different_ ordering of the collection...

Additional context: 
- all configs are default; no custom media model
- The model only has one single, simple collection defined.
- the model doesn't have any global scope, or any other ordering

Wild guess: SQL doesn't guarantee a fixed order when no explicit ordering is applied. And I don't find any references of the media query being ordered before doing `first()` or `last()`...?

This is just a heads-up PR which is most probably garbage.

--- 

Note: the issues section is currently broken. See [here](https://github.com/spatie/laravel-medialibrary/discussions/3808) 

