### PR TITLE
Optimize filename suffix generation in MediaStream

### DIFF
--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -11,6 +11,7 @@ use ZipStream\ZipStream;
 class MediaStream implements Responsable
 {
     protected Collection $mediaItems;
+    private array $nameCounters = [];
 
     protected array $zipOptions;
 
@@ -108,28 +109,22 @@ class MediaStream implements Responsable
 
     protected function getFileNameWithSuffix(Collection $mediaItems, int $currentIndex): string
     {
-        $fileNameCount = 0;
-
         $fileName = $mediaItems[$currentIndex]->getDownloadFilename();
 
-        foreach ($mediaItems as $index => $media) {
-            if ($index >= $currentIndex) {
-                break;
-            }
+        $prefix = $this->getZipFileNamePrefix($mediaItems, $currentIndex);
+        $key = $prefix . $fileName;
 
-            if ($this->getZipFileNamePrefix($mediaItems, $index).$media->getDownloadFilename() === $this->getZipFileNamePrefix($mediaItems, $currentIndex).$fileName) {
-                $fileNameCount++;
-            }
-        }
+        $count = ($this->nameCounters[$key] ?? 0);
+        $this->nameCounters[$key] = $count + 1;
 
-        if ($fileNameCount === 0) {
+        if ($count === 0) {
             return $fileName;
         }
 
         $extension = pathinfo($fileName, PATHINFO_EXTENSION);
         $fileNameWithoutExtension = pathinfo($fileName, PATHINFO_FILENAME);
 
-        return "{$fileNameWithoutExtension} ({$fileNameCount}).{$extension}";
+        return "{$fileNameWithoutExtension} ({$count}).{$extension}";
     }
 
     protected function getZipFileNamePrefix(Collection $mediaItems, int $currentIndex): string


### PR DESCRIPTION
Refactored getFileNameWithSuffix to use a nameCounters array for tracking duplicate filenames, improving performance and simplifying logic for generating unique filenames in zip archives.