### PR TITLE
Add timeout and threads configuration for FFMpeg

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -193,6 +193,18 @@ return [
     'ffprobe_path' => env('FFPROBE_PATH', '/usr/bin/ffprobe'),
 
     /*
+     * The timeout (in seconds) that will be used when generating video
+     * thumbnails via FFMPEG.
+     */
+    'ffmpeg_timeout' => env('FFMPEG_TIMEOUT', 900),
+
+    /*
+     * The number of threads that FFMPEG should use. 0 means that FFMPEG
+     * may decide itself.
+     */
+    'ffmpeg_threads' => env('FFMPEG_THREADS', 0),
+
+    /*
      * Here you can override the class names of the jobs used by this package. Make sure
      * your custom jobs extend the ones provided by the package.
      */

--- a/src/Conversions/ImageGenerators/Video.php
+++ b/src/Conversions/ImageGenerators/Video.php
@@ -15,7 +15,7 @@ class Video extends ImageGenerator
         $ffmpeg = FFMpeg::create([
             'ffmpeg.binaries' => config('media-library.ffmpeg_path'),
             'ffprobe.binaries' => config('media-library.ffprobe_path'),
-            'timeout' => config('media-library.ffmpeg_timeout', 3600),
+            'timeout' => config('media-library.ffmpeg_timeout', 900),
             'ffmpeg.threads' => config('media-library.ffmpeg_threads', 0),
         ]);
 


### PR DESCRIPTION
Configuration enhancements:

* Added support for a configurable FFmpeg timeout using the `media-library.ffmpeg_timeout` setting, with a default value of 900 seconds.
* Added support for configurable FFmpeg thread count using the `media-library.ffmpeg_threads` setting, with a default value of 0 (auto).

I receive a lot of `ffmpeg 300 timeout process` errors, because my system sometimes cannot handle the amount of work, and needs more time. See https://github.com/PHP-FFMpeg/PHP-FFMpeg#ffmpeg how these options are defined.