### PR TITLE
Add `getAvailablePathRelativeToRoot()` method

### DIFF
--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -175,6 +175,19 @@ class Media extends Model implements Attachable, Htmlable, Responsable
         return $this->getPath();
     }
 
+    public function getAvailablePathRelativeToRoot(array $conversionNames): string
+    {
+        foreach ($conversionNames as $conversionName) {
+            if (! $this->hasGeneratedConversion($conversionName)) {
+                continue;
+            }
+
+            return $this->getPathRelativeToRoot($conversionName);
+        }
+
+        return $this->getPathRelativeToRoot();
+    }
+
     protected function type(): Attribute
     {
         return Attribute::get(

--- a/tests/Feature/Media/GetAvailableUrlTest.php
+++ b/tests/Feature/Media/GetAvailableUrlTest.php
@@ -10,18 +10,21 @@ it('can get a url of first available conversion', function () {
     expect($media->getAvailableUrl(['small', 'medium', 'large']))->toEqual("/media/{$media->id}/conversions/test-large.jpg");
     expect($media->getAvailableFullUrl(['small', 'medium', 'large']))->toEqual("http://localhost/media/{$media->id}/conversions/test-large.jpg");
     expect($media->getAvailablePath(['small', 'medium', 'large']))->toEqual($this->makePathOsSafe($this->getMediaDirectory()."/{$media->id}/conversions/test-large.jpg"));
+    expect($media->getAvailablePathRelativeToRoot(['small', 'medium', 'large']))->toEqual("{$media->id}/conversions/test-large.jpg");
 
     $media->markAsConversionGenerated('medium');
 
     expect($media->getAvailableUrl(['small', 'medium', 'large']))->toEqual("/media/{$media->id}/conversions/test-medium.jpg");
     expect($media->getAvailableFullUrl(['small', 'medium', 'large']))->toEqual("http://localhost/media/{$media->id}/conversions/test-medium.jpg");
     expect($media->getAvailablePath(['small', 'medium', 'large']))->toEqual($this->makePathOsSafe($this->getMediaDirectory()."/{$media->id}/conversions/test-medium.jpg"));
+    expect($media->getAvailablePathRelativeToRoot(['small', 'medium', 'large']))->toEqual("{$media->id}/conversions/test-medium.jpg");
 
     $media->markAsConversionGenerated('small');
 
     expect($media->getAvailableUrl(['small', 'medium', 'large']))->toEqual("/media/{$media->id}/conversions/test-small.jpg");
     expect($media->getAvailableFullUrl(['small', 'medium', 'large']))->toEqual("http://localhost/media/{$media->id}/conversions/test-small.jpg");
     expect($media->getAvailablePath(['small', 'medium', 'large']))->toEqual($this->makePathOsSafe($this->getMediaDirectory()."/{$media->id}/conversions/test-small.jpg"));
+    expect($media->getAvailablePathRelativeToRoot(['small', 'medium', 'large']))->toEqual("{$media->id}/conversions/test-small.jpg");
 });
 
 it('uses original url if no conversion has been generated yet', function () {
@@ -33,4 +36,5 @@ it('uses original url if no conversion has been generated yet', function () {
     expect($media->getAvailableUrl(['small', 'medium', 'large']))->toEqual("/media/{$media->id}/test.jpg");
     expect($media->getAvailableFullUrl(['small', 'medium', 'large']))->toEqual("http://localhost/media/{$media->id}/test.jpg");
     expect($media->getAvailablePath(['small', 'medium', 'large']))->toEqual($this->makePathOsSafe($this->getMediaDirectory()."/{$media->id}/test.jpg"));
+    expect($media->getAvailablePathRelativeToRoot(['small', 'medium', 'large']))->toEqual("{$media->id}/test.jpg");
 });


### PR DESCRIPTION
Adds a method similar to `getAvailablePath()` that calls `getPathRelativeToRoot()` instead of `getPath()`.

This allows code like the following, in cases where you use the `local` filesystem driver in your development environment and the `s3` driver in production, as `getPath()` returns the absolute path which you cannot pass to `Storage::get()`.

```php
Storage::disk($media->disk)->get(
    $media->getAvailablePathRelativeToRoot(['conversion'])
)
```