### PR TITLE
Allow ZipStream to be 'unfinished'

### DIFF
--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -79,7 +79,7 @@ class MediaStream implements Responsable
         return new StreamedResponse(fn () => $this->getZipStream(), 200, $headers);
     }
 
-    public function getZipStream(): ZipStream
+    public function getZipStream(bool $finish = true): ZipStream
     {
         $this->zipOptions['outputName'] = $this->zipName;
         $zip = new ZipStream(...$this->zipOptions);
@@ -94,7 +94,9 @@ class MediaStream implements Responsable
             }
         });
 
-        $zip->finish();
+        if ($finish) {
+            $zip->finish();
+        }
 
         return $zip;
     }


### PR DESCRIPTION
This is a very simple PR that allows us to set a flag to not finish the stream. This would be useful in instances where we need to add more files to the end of the stream manually.

For example, I've got a project where I'm downloading all of the media associated with the post, and then a dynamically generated PDF of the post. The PDF itself isn't a media item so it can't be added during the process, but can be added retrospectively. To achieve this, I could do...


```php
$filename = $post->slug.'-media.zip';
        $media = $post->getMedia('*');

        // add all of our media
        $stream = MediaStream::create($filename)
            ->addMedia($media)
            ->getZipStream(finish: false);

        // and now add an additional file
        $stream->addFile('blah.pdf', 'contents');
        $stream->finish();

        // and download it
        return new StreamedResponse($stream, 200, [
            'Content-Disposition' => "attachment; filename=\"$filename\"",
            'Content-Type' => 'application/octet-stream',
        ]);
```

It just adds to the packages flexibility / extensibility with very little effort. Thanks!

