### PR TITLE
Fix imagedestroy deprecation

### DIFF
--- a/src/Conversions/ImageGenerators/Avif.php
+++ b/src/Conversions/ImageGenerators/Avif.php
@@ -15,8 +15,6 @@ class Avif extends ImageGenerator
 
         imagepng($image, $pathToImageFile, 9);
 
-        imagedestroy($image);
-
         return $pathToImageFile;
     }
 
@@ -27,10 +25,6 @@ class Avif extends ImageGenerator
         }
 
         if (! function_exists('imagepng')) {
-            return false;
-        }
-
-        if (! function_exists('imagedestroy')) {
             return false;
         }
 

--- a/src/Conversions/ImageGenerators/Webp.php
+++ b/src/Conversions/ImageGenerators/Webp.php
@@ -15,8 +15,6 @@ class Webp extends ImageGenerator
 
         imagepng($image, $pathToImageFile, 9);
 
-        imagedestroy($image);
-
         return $pathToImageFile;
     }
 
@@ -27,10 +25,6 @@ class Webp extends ImageGenerator
         }
 
         if (! function_exists('imagepng')) {
-            return false;
-        }
-
-        if (! function_exists('imagedestroy')) {
             return false;
         }
 


### PR DESCRIPTION
https://www.php.net/manual/en/function.imagedestroy.php
> **Warning** This function has been _DEPRECATED_ as of PHP 8.5.0. Relying on this function is highly discouraged.
>
> **Note:** This function has no effect. Prior to PHP 8.0.0