### PR TITLE
Set config directory for larastan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,8 @@ parameters:
         - src
         - config
         - database
+    configDirectories:
+        - config
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true


### PR DESCRIPTION
- https://github.com/larastan/larastan/pull/2217
Avoids 
```
Called 'env' outside of the config directory which returns null when the config is cached, use 'config'.
```