### PR TITLE
Fix PHPDoc property name to use snake_case

### DIFF
--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -49,7 +49,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  * @property string $conversions_disk
  * @property string $type
  * @property string $extension
- * @property-read string $humanReadableSize
+ * @property-read string $human_readable_size
  * @property-read string $preview_url
  * @property-read string $original_url
  * @property int $size

--- a/tests/Feature/Media/GetHumanReadableSizeTest.php
+++ b/tests/Feature/Media/GetHumanReadableSizeTest.php
@@ -1,0 +1,14 @@
+<?php
+
+test('the human_readable_size attribute can be accessed', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+
+    expect($media->human_readable_size)->toBeString();
+    expect($media->human_readable_size)->toContain('KB');
+});
+
+test('the human_readable_size returns correct format', function () {
+    $media = $this->testModel->addMedia($this->getTestJpg())->toMediaCollection();
+
+    expect($media->human_readable_size)->toMatch('/^\d+(\.\d+)?\s(B|KB|MB|GB|TB|PB|EB|ZB|YB)$/');
+});


### PR DESCRIPTION
Updated the @property-read annotation for human readable size from $humanReadableSize to $human_readable_size to align with Laravel's attribute naming conventions. Added tests to verify the attribute is accessible and returns the correct format.