### PR TITLE
feat: faster clean command via hash lookup

### DIFF
--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -195,7 +195,7 @@ class CleanCommand extends Command
 
         $mediaIdSet = $this->mediaRepository->allIds()->flip();
 
-        /** @var array<int, string> */
+        /** @var array<int, string> $directories */
         $directories = $this->fileSystem->disk($diskName)->directories($prefix);
 
         collect($directories)


### PR DESCRIPTION
Hi!
I've noticed that the 'media-library:clean' command is very slow. I investigated why that is, and it turned out to be an inefficient O(N*M) search algorithm. However, we could use a simple hash set to make it O(N+M). In layman's terms, we search by key rather than value.

Cheers!