### PR TITLE
Add `deferred()` conversion option

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -1,5 +1,31 @@
 <?php
 
+use Spatie\ImageOptimizer\Optimizers\Avifenc;
+use Spatie\ImageOptimizer\Optimizers\Cwebp;
+use Spatie\ImageOptimizer\Optimizers\Gifsicle;
+use Spatie\ImageOptimizer\Optimizers\Jpegoptim;
+use Spatie\ImageOptimizer\Optimizers\Optipng;
+use Spatie\ImageOptimizer\Optimizers\Pngquant;
+use Spatie\ImageOptimizer\Optimizers\Svgo;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Avif;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Image;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Svg;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Video;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Webp;
+use Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob;
+use Spatie\MediaLibrary\Downloaders\DefaultDownloader;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\MediaCollections\Models\Observers\MediaObserver;
+use Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob;
+use Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred;
+use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator;
+use Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer;
+use Spatie\MediaLibrary\Support\FileRemover\DefaultFileRemover;
+use Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator;
+use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
+use Spatie\MediaLibraryPro\Models\TemporaryUpload;
+
 return [
 
     /*
@@ -39,12 +65,12 @@ return [
     /*
      * The fully qualified class name of the media model.
      */
-    'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
+    'media_model' => Media::class,
 
     /*
      * The fully qualified class name of the media observer.
      */
-    'media_observer' => Spatie\MediaLibrary\MediaCollections\Models\Observers\MediaObserver::class,
+    'media_observer' => MediaObserver::class,
 
     /*
      * When enabled, media collections will be serialised using the default
@@ -59,7 +85,7 @@ return [
      *
      * This model is only used in Media Library Pro (https://medialibrary.pro)
      */
-    'temporary_upload_model' => Spatie\MediaLibraryPro\Models\TemporaryUpload::class,
+    'temporary_upload_model' => TemporaryUpload::class,
 
     /*
      * When enabled, Media Library Pro will only process temporary uploads that were uploaded
@@ -76,17 +102,17 @@ return [
     /*
      * This is the class that is responsible for naming generated files.
      */
-    'file_namer' => Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer::class,
+    'file_namer' => DefaultFileNamer::class,
 
     /*
      * The class that contains the strategy for determining a media file's path.
      */
-    'path_generator' => Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class,
+    'path_generator' => DefaultPathGenerator::class,
 
     /*
      * The class that contains the strategy for determining how to remove files.
      */
-    'file_remover_class' => Spatie\MediaLibrary\Support\FileRemover\DefaultFileRemover::class,
+    'file_remover_class' => DefaultFileRemover::class,
 
     /*
      * Here you can specify which path generator should be used for the given class.
@@ -101,7 +127,7 @@ return [
      * When urls to files get generated, this class will be called. Use the default
      * if your files are stored locally above the site root or on s3.
      */
-    'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
+    'url_generator' => DefaultUrlGenerator::class,
 
     /*
      * Moves media on updating to keep path consistent. Enable it only with a custom
@@ -121,34 +147,34 @@ return [
      * the optimizers that will be used by default.
      */
     'image_optimizers' => [
-        Spatie\ImageOptimizer\Optimizers\Jpegoptim::class => [
+        Jpegoptim::class => [
             '-m85', // set maximum quality to 85%
             '--force', // ensure that progressive generation is always done also if a little bigger
             '--strip-all', // this strips out all text information such as comments and EXIF data
             '--all-progressive', // this will make sure the resulting image is a progressive one
         ],
-        Spatie\ImageOptimizer\Optimizers\Pngquant::class => [
+        Pngquant::class => [
             '--force', // required parameter for this package
         ],
-        Spatie\ImageOptimizer\Optimizers\Optipng::class => [
+        Optipng::class => [
             '-i0', // this will result in a non-interlaced, progressive scanned image
             '-o2', // this set the optimization level to two (multiple IDAT compression trials)
             '-quiet', // required parameter for this package
         ],
-        Spatie\ImageOptimizer\Optimizers\Svgo::class => [
+        Svgo::class => [
             '--disable=cleanupIDs', // disabling because it is known to cause troubles
         ],
-        Spatie\ImageOptimizer\Optimizers\Gifsicle::class => [
+        Gifsicle::class => [
             '-b', // required parameter for this package
             '-O3', // this produces the slowest but best results
         ],
-        Spatie\ImageOptimizer\Optimizers\Cwebp::class => [
+        Cwebp::class => [
             '-m 6', // for the slowest compression method in order to get the best compression.
             '-pass 10', // for maximizing the amount of analysis pass.
             '-mt', // multithreading for some speed improvements.
             '-q 90', // quality factor that brings the least noticeable changes.
         ],
-        Spatie\ImageOptimizer\Optimizers\Avifenc::class => [
+        Avifenc::class => [
             '-a cq-level=23', // constant quality level, lower values mean better quality and greater file size (0-63).
             '-j all', // number of jobs (worker threads, "all" uses all available cores).
             '--min 0', // min quantizer for color (0-63).
@@ -164,12 +190,12 @@ return [
      * These generators will be used to create an image of media files.
      */
     'image_generators' => [
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Image::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Webp::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Avif::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Svg::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Video::class,
+        Image::class,
+        Webp::class,
+        Avif::class,
+        Pdf::class,
+        Svg::class,
+        Video::class,
     ],
 
     /*
@@ -209,8 +235,8 @@ return [
      * your custom jobs extend the ones provided by the package.
      */
     'jobs' => [
-        'perform_conversions' => Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
-        'generate_responsive_images' => Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
+        'perform_conversions' => PerformConversionsJob::class,
+        'generate_responsive_images' => GenerateResponsiveImagesJob::class,
     ],
 
     /*
@@ -218,7 +244,7 @@ return [
      * This is particularly useful when the url of the image is behind a firewall and
      * need to add additional flags, possibly using curl.
      */
-    'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
+    'media_downloader' => DefaultDownloader::class,
 
     /*
      * When using the addMediaFromUrl method the SSL is verified by default.
@@ -255,7 +281,7 @@ return [
          *
          * https://docs.spatie.be/laravel-medialibrary/v9/advanced-usage/generating-responsive-images
          */
-        'width_calculator' => Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator::class,
+        'width_calculator' => FileSizeOptimizedWidthCalculator::class,
 
         /*
          * By default rendering media to a responsive image will add some javascript and a tiny placeholder.
@@ -268,7 +294,7 @@ return [
          * This class will generate the tiny placeholder used for progressive image loading. By default
          * the media library will use a tiny blurred jpg image.
          */
-        'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
+        'tiny_placeholder_generator' => Blurred::class,
     ],
 
     /*

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -169,7 +169,7 @@ in the `media-library` config file to `false`.
 
 ## Deferred conversions
 
-Instead of processing a conversion synchronously or dispatching it to a queue, you can use `deferred()` to schedule the conversion to run after the HTTP response has been sent to the browser. This uses Laravel's [`defer()` helper](https://laravel.com/docs/11.x/helpers#deferred-functions) under the hood.
+Instead of processing a conversion synchronously or dispatching it to a queue, you can use `deferred()` to schedule the conversion to run after the HTTP response has been sent to the browser. This uses Laravel's [`defer()` helper](https://laravel.com/docs/13.x/helpers#deferred-functions) under the hood.
 
 Deferred conversions are useful when you need a conversion to happen promptly after upload without blocking the upload request itself — for example, generating an avatar thumbnail that should be available quickly, but doesn't need to delay the response.
 

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -167,6 +167,23 @@ This prevents unexpected behaviour where the model does not yet exist in the dat
 If you need the conversions to run within your transaction, you can set the `queue_conversions_after_database_commit`
 in the `media-library` config file to `false`.
 
+## Deferred conversions
+
+Instead of processing a conversion synchronously or dispatching it to a queue, you can use `deferred()` to schedule the conversion to run after the HTTP response has been sent to the browser. This uses Laravel's [`defer()` helper](https://laravel.com/docs/11.x/helpers#deferred-functions) under the hood.
+
+Deferred conversions are useful when you need a conversion to happen promptly after upload without blocking the upload request itself — for example, generating an avatar thumbnail that should be available quickly, but doesn't need to delay the response.
+
+```php
+// in your model
+public function registerMediaConversions(?Media $media = null): void
+{
+    $this->addMediaConversion('thumb')
+            ->width(368)
+            ->height(232)
+            ->deferred();
+}
+```
+
 ## Using model properties in a conversion
 
 When registering conversions inside the `registerMediaConversions` function you won't have access to your model properties by default. If you want to use a property of your model as input for defining a conversion you must set `registerMediaConversionsUsingModelInstance` to `

--- a/docs/converting-images/defining-conversions.md
+++ b/docs/converting-images/defining-conversions.md
@@ -171,7 +171,7 @@ in the `media-library` config file to `false`.
 
 Instead of processing a conversion synchronously or dispatching it to a queue, you can use `deferred()` to schedule the conversion to run after the HTTP response has been sent to the browser. This uses Laravel's [`defer()` helper](https://laravel.com/docs/13.x/helpers#deferred-functions) under the hood.
 
-Deferred conversions are useful when you need a conversion to happen promptly after upload without blocking the upload request itself — for example, generating an avatar thumbnail that should be available quickly, but doesn't need to delay the response.
+Deferred conversions are useful when you need a conversion to happen promptly after upload without blocking the upload request itself. A common case is generating an avatar thumbnail that should be available quickly, but doesn't need to delay the response.
 
 ```php
 // in your model
@@ -183,6 +183,10 @@ public function registerMediaConversions(?Media $media = null): void
             ->deferred();
 }
 ```
+
+Deferred conversions run inline in the same PHP process after the response is flushed, so they keep the worker busy until they finish. For slow conversions, or models with many conversions, prefer `queued()` so the work runs on a queue worker instead.
+
+Deferred conversions require Laravel 11.23 or higher (the version that introduced the `defer()` helper). On older versions, use `queued()` or `nonQueued()`.
 
 ## Using model properties in a conversion
 

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -24,6 +24,8 @@ class Conversion
 
     protected bool $performOnQueue;
 
+    protected bool $performDeferred = false;
+
     protected bool $keepOriginalImageFormat = false;
 
     protected bool $generateResponsiveImages = false;
@@ -179,6 +181,14 @@ class Conversion
         return $this;
     }
 
+    public function deferred(): self
+    {
+        $this->performDeferred = true;
+        $this->performOnQueue = false;
+
+        return $this;
+    }
+
     public function nonOptimized(): self
     {
         $this->removeManipulation('optimize');
@@ -213,6 +223,11 @@ class Conversion
     public function shouldBeQueued(): bool
     {
         return $this->performOnQueue;
+    }
+
+    public function shouldBeDeferred(): bool
+    {
+        return $this->performDeferred;
     }
 
     public function getResultExtension(string $originalFileExtension = ''): string

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -4,12 +4,13 @@ namespace Spatie\MediaLibrary\Conversions;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Conditionable;
+use Spatie\Image\Drivers\ImageDriver;
 use Spatie\ImageOptimizer\OptimizerChainFactory;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\WidthCalculator;
 use Spatie\MediaLibrary\Support\FileNamer\FileNamer;
 
-/** @mixin \Spatie\Image\Drivers\ImageDriver */
+/** @mixin ImageDriver */
 class Conversion
 {
     use Conditionable;

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -179,6 +179,7 @@ class Conversion
     public function nonQueued(): self
     {
         $this->performOnQueue = false;
+        $this->performDeferred = false;
 
         return $this;
     }

--- a/src/Conversions/Conversion.php
+++ b/src/Conversions/Conversion.php
@@ -170,6 +170,7 @@ class Conversion
 
     public function queued(): self
     {
+        $this->performDeferred = false;
         $this->performOnQueue = true;
 
         return $this;

--- a/src/Conversions/ConversionCollection.php
+++ b/src/Conversions/ConversionCollection.php
@@ -5,6 +5,7 @@ namespace Spatie\MediaLibrary\Conversions;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidConversion;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
@@ -58,7 +59,7 @@ class ConversionCollection extends Collection
             return;
         }
 
-        /** @var \Spatie\MediaLibrary\HasMedia $model */
+        /** @var HasMedia $model */
         $model = new $modelName;
 
         /*
@@ -67,7 +68,7 @@ class ConversionCollection extends Collection
          * properties. This will causes extra queries.
          */
         if ($model->registerMediaConversionsUsingModelInstance && $media->model) {
-            /** @var \Spatie\MediaLibrary\HasMedia $model */
+            /** @var HasMedia $model */
             $model = $media->model;
 
             $model->mediaConversions = [];

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -11,6 +11,7 @@ use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob;
 use Spatie\MediaLibrary\Support\TemporaryDirectory;
+use RuntimeException;
 
 class FileManipulator
 {
@@ -99,6 +100,12 @@ class FileManipulator
     ): self {
         if ($conversions->isEmpty()) {
             return $this;
+        }
+
+        if (! function_exists('defer')) {
+            throw new RuntimeException(
+                'Deferred conversions require Laravel 11.23 or higher. Use queued() or nonQueued() instead.',
+            );
         }
 
         defer(fn () => $this->performConversions($conversions, $media, $onlyMissing));

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -25,7 +25,7 @@ class FileManipulator
             return;
         }
 
-        [$queuedConversions, $conversions] = ConversionCollection::createForMedia($media)
+        $allConversions = ConversionCollection::createForMedia($media)
             ->filter(function (Conversion $conversion) use ($onlyConversionNames) {
                 if (count($onlyConversionNames) === 0) {
                     return true;
@@ -33,11 +33,19 @@ class FileManipulator
 
                 return in_array($conversion->getName(), $onlyConversionNames);
             })
-            ->filter(fn (Conversion $conversion) => $conversion->shouldBePerformedOn($media->collection_name))
-            ->partition(fn (Conversion $conversion) => $queueAll || $conversion->shouldBeQueued());
+            ->filter(fn (Conversion $conversion) => $conversion->shouldBePerformedOn($media->collection_name));
+
+        [$deferredConversions, $remaining] = $allConversions->partition(
+            fn (Conversion $conversion) => ! $queueAll && $conversion->shouldBeDeferred()
+        );
+
+        [$queuedConversions, $conversions] = $remaining->partition(
+            fn (Conversion $conversion) => $queueAll || $conversion->shouldBeQueued()
+        );
 
         $this
             ->performConversions($conversions, $media, $onlyMissing)
+            ->performDeferredConversions($deferredConversions, $media, $onlyMissing)
             ->dispatchQueuedConversions($media, $queuedConversions, $onlyMissing)
             ->generateResponsiveImages($media, $withResponsiveImages);
     }
@@ -80,6 +88,20 @@ class FileManipulator
         $conversions->each(fn (Conversion $conversion) => (new PerformConversionAction)->execute($conversion, $media, $copiedOriginalFile));
 
         $temporaryDirectory->delete();
+
+        return $this;
+    }
+
+    protected function performDeferredConversions(
+        ConversionCollection $conversions,
+        Media $media,
+        bool $onlyMissing = false
+    ): self {
+        if ($conversions->isEmpty()) {
+            return $this;
+        }
+
+        defer(fn () => $this->performConversions($conversions, $media, $onlyMissing));
 
         return $this;
     }

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -4,6 +4,7 @@ namespace Spatie\MediaLibrary\Conversions;
 
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use RuntimeException;
 use Spatie\MediaLibrary\Conversions\Actions\PerformConversionAction;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
 use Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob;
@@ -11,7 +12,6 @@ use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob;
 use Spatie\MediaLibrary\Support\TemporaryDirectory;
-use RuntimeException;
 
 class FileManipulator
 {

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -36,12 +36,20 @@ class FileManipulator
             })
             ->filter(fn (Conversion $conversion) => $conversion->shouldBePerformedOn($media->collection_name));
 
+        if ($queueAll) {
+            $this
+                ->dispatchQueuedConversions($media, $allConversions, $onlyMissing)
+                ->generateResponsiveImages($media, $withResponsiveImages);
+
+            return;
+        }
+
         [$deferredConversions, $remaining] = $allConversions->partition(
-            fn (Conversion $conversion) => ! $queueAll && $conversion->shouldBeDeferred()
+            fn (Conversion $conversion) => $conversion->shouldBeDeferred()
         );
 
         [$queuedConversions, $conversions] = $remaining->partition(
-            fn (Conversion $conversion) => $queueAll || $conversion->shouldBeQueued()
+            fn (Conversion $conversion) => $conversion->shouldBeQueued()
         );
 
         $this

--- a/src/Conversions/Manipulations.php
+++ b/src/Conversions/Manipulations.php
@@ -11,7 +11,7 @@ use Spatie\Image\Enums\Fit;
 use Spatie\Image\Enums\FlipDirection;
 use Spatie\Image\Enums\Orientation;
 
-/** @mixin \Spatie\Image\Drivers\ImageDriver */
+/** @mixin ImageDriver */
 class Manipulations
 {
     protected array $manipulations = [];

--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\MediaLibrary;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\Conversions\Conversion;
@@ -11,12 +12,12 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
- * @mixin \Illuminate\Database\Eloquent\Model
+ * @mixin Model
  *
  * @method void prepareToAttachMedia(Media $media, FileAdder $fileAdder)
  *
  * @property bool $registerMediaConversionsUsingModelInstance
- * @property ?\Spatie\MediaLibrary\MediaCollections\MediaCollection $mediaCollections
+ * @property ?MediaCollection $mediaCollections
  */
 interface HasMedia
 {

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -14,6 +14,7 @@ use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Downloaders\DefaultDownloader;
 use Spatie\MediaLibrary\Enums\CollectionPosition;
 use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenClearedEvent;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidBase64Data;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidUrl;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeDeleted;
@@ -146,7 +147,7 @@ trait InteractsWithMedia
      *
      * @return FileAdder<TMedia>
      *
-     * @throws \Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded
+     * @throws FileCannotBeAdded
      */
     public function addMediaFromUrl(string $url, array|string ...$allowedMimeTypes): FileAdder
     {
@@ -200,7 +201,7 @@ trait InteractsWithMedia
      *
      * @return FileAdder<TMedia>
      *
-     * @throws \Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded
+     * @throws FileCannotBeAdded
      * @throws InvalidBase64Data
      */
     public function addMediaFromBase64(string $base64data, array|string ...$allowedMimeTypes): FileAdder
@@ -583,7 +584,7 @@ trait InteractsWithMedia
      * Delete the associated media with the given id.
      * You may also pass a media object.
      *
-     * @throws \Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeDeleted
+     * @throws MediaCannotBeDeleted
      */
     public function deleteMedia(int|string|Media $mediaId): void
     {

--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\Conversions\FileManipulator;
+use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -192,7 +193,7 @@ class CleanCommand extends Command
             return true;
         }
 
-        /** @var \Spatie\MediaLibrary\HasMedia $model */
+        /** @var HasMedia $model */
         $model = new $modelName;
 
         $collection = $model->getMediaCollection($media->collection_name);

--- a/src/MediaCollections/Models/Concerns/HasUuid.php
+++ b/src/MediaCollections/Models/Concerns/HasUuid.php
@@ -4,13 +4,14 @@ namespace Spatie\MediaLibrary\MediaCollections\Models\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 trait HasUuid
 {
     public static function bootHasUuid(): void
     {
         static::creating(function (Model $model) {
-            /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $model */
+            /** @var Media $model */
             if (empty($model->uuid)) {
                 $model->uuid = (string) Str::uuid();
             }

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Mail\Attachment;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -60,8 +61,8 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  * @property array $custom_properties
  * @property array $generated_conversions
  * @property array $responsive_images
- * @property-read ?\Illuminate\Support\Carbon $created_at
- * @property-read ?\Illuminate\Support\Carbon $updated_at
+ * @property-read ?Carbon $created_at
+ * @property-read ?Carbon $updated_at
  */
 class Media extends Model implements Attachable, Htmlable, Responsable
 {

--- a/tests/Conversions/Commands/CleanCommandTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest.php
@@ -59,7 +59,7 @@ it('can clean deprecated conversion files with none arguments given', function (
 });
 
 test('generated conversion are cleared after cleanup', function () {
-    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    /** @var Media $media */
     $media = $this->media['model2']['collection1'];
 
     Media::where('id', '<>', $media->id)->delete();

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -90,6 +90,10 @@ it('will not be queued when deferred', function () {
     expect($this->conversion->deferred()->shouldBeQueued())->toBeFalse();
 });
 
+it('will not be deferred when queued', function () {
+    expect($this->conversion->deferred()->queued()->shouldBeDeferred())->toBeFalse();
+});
+
 it('can determine the extension of the result', function () {
     $this->conversion->width(50);
 

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -72,7 +72,7 @@ it('will be non queued by default', function () {
 });
 
 it('can be set to queued', function () {
-    config()->set('media-library.queue_conversions_by_default', false);    
+    config()->set('media-library.queue_conversions_by_default', false);
     $this->conversion->queued();
     expect($this->conversion->shouldBeQueued())->toBeTrue();
     expect($this->conversion->shouldBeDeferred())->toBeFalse();

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -72,26 +72,23 @@ it('will be non queued by default', function () {
 });
 
 it('can be set to queued', function () {
-    config()->set('media-library.queue_conversions_by_default', false);
-    expect($this->conversion->queued()->shouldBeQueued())->toBeTrue();
+    config()->set('media-library.queue_conversions_by_default', false);    
+    $this->conversion->queued();
+    expect($this->conversion->shouldBeQueued())->toBeTrue();
+    expect($this->conversion->shouldBeDeferred())->toBeFalse();
 });
 
 it('can be set to non queued', function () {
     config()->set('media-library.queue_conversions_by_default', true);
-    expect($this->conversion->nonQueued()->shouldBeQueued())->toBeFalse();
+    $this->conversion->nonQueued();
+    expect($this->conversion->shouldBeQueued())->toBeFalse();
+    expect($this->conversion->shouldBeDeferred())->toBeFalse();
 });
 
 it('can be set to deferred', function () {
-    expect($this->conversion->deferred()->shouldBeDeferred())->toBeTrue();
-});
-
-it('will not be queued when deferred', function () {
-    config()->set('media-library.queue_conversions_by_default', true);
-    expect($this->conversion->deferred()->shouldBeQueued())->toBeFalse();
-});
-
-it('will not be deferred when queued', function () {
-    expect($this->conversion->deferred()->queued()->shouldBeDeferred())->toBeFalse();
+    $this->conversion->deferred();
+    expect($this->conversion->shouldBeDeferred())->toBeTrue();
+    expect($this->conversion->shouldBeQueued())->toBeFalse();
 });
 
 it('can determine the extension of the result', function () {

--- a/tests/Conversions/ConversionTest.php
+++ b/tests/Conversions/ConversionTest.php
@@ -81,6 +81,15 @@ it('can be set to non queued', function () {
     expect($this->conversion->nonQueued()->shouldBeQueued())->toBeFalse();
 });
 
+it('can be set to deferred', function () {
+    expect($this->conversion->deferred()->shouldBeDeferred())->toBeTrue();
+});
+
+it('will not be queued when deferred', function () {
+    config()->set('media-library.queue_conversions_by_default', true);
+    expect($this->conversion->deferred()->shouldBeQueued())->toBeFalse();
+});
+
 it('can determine the extension of the result', function () {
     $this->conversion->width(50);
 

--- a/tests/Downloader/HttpFacadeDownloaderTest.php
+++ b/tests/Downloader/HttpFacadeDownloaderTest.php
@@ -1,12 +1,14 @@
 <?php
 
 use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
+use Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader;
 
 it('can save a url to a temp location', function () {
     $url = 'https://example.com';
 
-    \Illuminate\Support\Facades\Http::shouldReceive('withUserAgent')
+    Http::shouldReceive('withUserAgent')
         ->with('Spatie MediaLibrary')
         ->once()
         ->andReturnSelf()
@@ -23,7 +25,7 @@ it('can save a url to a temp location', function () {
         ->with($url)
         ->once();
 
-    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader;
+    $downloader = new HttpFacadeDownloader;
 
     $result = $downloader->getTempFile($url);
 
@@ -38,7 +40,7 @@ it('can be mocked easily for tests', function () {
         'https://example.com' => Http::response('::file::'),
     ]);
 
-    $downloader = new \Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader;
+    $downloader = new HttpFacadeDownloader;
 
     $result = $downloader->getTempFile($url);
 
@@ -46,7 +48,7 @@ it('can be mocked easily for tests', function () {
         ->toBeString()
         ->and($result)
         ->toBeFile()
-        ->and(\Illuminate\Support\Facades\File::get($result))
+        ->and(File::get($result))
         ->toBe('::file::');
 
     Http::assertSent(function (Request $request) {

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -179,7 +179,7 @@ it('can create a deferred derived version of an image', function () {
     $this->app->make(DeferredCallbackCollection::class)->invoke();
 
     $this->assertFileExists($thumbPath);
-});
+})->skip(! function_exists('defer'), 'Deferred conversions require Laravel 11.23 or higher.');
 
 it('can set filesize', function () {
     $media = $this->testModelWithoutMediaConversions

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -7,7 +7,6 @@ use Spatie\MediaLibrary\Conversions\Manipulations;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
-use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionDeferred;
 
 it('can add an file to the default collection', function () {
     $media = $this->testModelWithoutMediaConversions

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -7,6 +7,7 @@ use Spatie\MediaLibrary\Conversions\Manipulations;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionDeferred;
 
 it('can add an file to the default collection', function () {
     $media = $this->testModelWithoutMediaConversions
@@ -168,19 +169,9 @@ it('will have access the model instance when register media conversions using mo
 });
 
 it('can create a deferred derived version of an image', function () {
-    $modelClass = new class extends TestModelWithConversion
-    {
-        public function registerMediaConversions(?Media $media = null): void
-        {
-            $this->addMediaConversion('thumb')
-                ->width(50)
-                ->deferred();
-        }
-    };
-
-    $model = $modelClass::first();
-
-    $media = $model->addMedia($this->getTestJpg())->toMediaCollection('images');
+    $media = $this->testModelWithConversionDeferred
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('images');
 
     $thumbPath = $this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg');
 

--- a/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/AddMediaTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Carbon\Carbon;
+use Illuminate\Support\Defer\DeferredCallbackCollection;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\Conversions\Manipulations;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -164,6 +165,30 @@ it('will have access the model instance when register media conversions using mo
         ->toArray();
 
     expect($conversionManipulations['width'])->toEqual([123]);
+});
+
+it('can create a deferred derived version of an image', function () {
+    $modelClass = new class extends TestModelWithConversion
+    {
+        public function registerMediaConversions(?Media $media = null): void
+        {
+            $this->addMediaConversion('thumb')
+                ->width(50)
+                ->deferred();
+        }
+    };
+
+    $model = $modelClass::first();
+
+    $media = $model->addMedia($this->getTestJpg())->toMediaCollection('images');
+
+    $thumbPath = $this->getMediaDirectory($media->id.'/conversions/test-thumb.jpg');
+
+    $this->assertFileDoesNotExist($thumbPath);
+
+    $this->app->make(DeferredCallbackCollection::class)->invoke();
+
+    $this->assertFileExists($thumbPath);
 });
 
 it('can set filesize', function () {

--- a/tests/Feature/Media/CopyTest.php
+++ b/tests/Feature/Media/CopyTest.php
@@ -1,13 +1,14 @@
 <?php
 
 use Spatie\MediaLibrary\MediaCollections\FileAdder;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 
 it('can copy media from one model to another', function () {
     /** @var TestModel $model */
     $model = TestModel::create(['name' => 'test']);
 
-    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    /** @var Media $media */
     $media = $model
         ->addMedia($this->getTestJpg())
         ->usingName('custom-name')
@@ -42,7 +43,7 @@ it('can copy file without extension', function () {
     /** @var TestModel $model */
     $model = TestModel::create(['name' => 'test']);
 
-    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    /** @var Media $media */
     $media = $model
         ->addMedia($this->getTestImageWithoutExtension())
         ->usingName('custom-name')
@@ -73,7 +74,7 @@ it('can copy media from one model to another on a specific disk', function () {
     /** @var TestModel $model */
     $model = TestModel::create(['name' => 'test']);
 
-    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    /** @var Media $media */
     $media = $model
         ->addMedia($this->getTestJpg())
         ->usingName('custom-name')
@@ -104,7 +105,7 @@ it('can handle file adder callback', function () {
     /** @var TestModel $model */
     $model = TestModel::create(['name' => 'test']);
 
-    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    /** @var Media $media */
     $media = $model
         ->addMedia($this->getTestJpg())
         ->usingName('custom-name')
@@ -134,7 +135,7 @@ it('can copy file with accent', function () {
     /** @var TestModel $model */
     $model = TestModel::create(['name' => 'test']);
 
-    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    /** @var Media $media */
     $media = $model
         ->addMedia($this->getAntaresThumbJpgWithAccent())
         ->usingName('custom-name')

--- a/tests/Feature/Media/UpdateManipulationsTest.php
+++ b/tests/Feature/Media/UpdateManipulationsTest.php
@@ -14,7 +14,7 @@ it('will create derived files when manipulations have changed', function () {
 
     $testModel = $testModelClass::find($this->testModel->id);
 
-    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    /** @var Media $media */
     $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
     touch($media->getPath('update_test'), time() - 1);
@@ -46,7 +46,7 @@ it('will not create derived files when manipulations have not changed', function
 
     $testModel = $testModelClass::find($this->testModel->id);
 
-    /** @var \Spatie\MediaLibrary\MediaCollections\Models\Media $media */
+    /** @var Media $media */
     $media = $testModel->addMedia($this->getTestJpg())->toMediaCollection('images');
 
     $media->manipulations = [

--- a/tests/MediaCollections/FileSystem/FileSystemTest.php
+++ b/tests/MediaCollections/FileSystem/FileSystemTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\MediaLibrary\MediaCollections\Filesystem;
+use Spatie\MediaLibrary\Tests\TestSupport\TestPrefixPathGenerator;
 
 beforeEach(function () {
     $this->filesystem = app()->make(Filesystem::class);
@@ -79,7 +80,7 @@ it('does not let media custom headers override ContentType for conversions', fun
 });
 
 it('can get stream with custom path generator that uses prefix instead of directory', function () {
-    config()->set('media-library.path_generator', \Spatie\MediaLibrary\Tests\TestSupport\TestPrefixPathGenerator::class);
+    config()->set('media-library.path_generator', TestPrefixPathGenerator::class);
 
     $media = $this->testModel
         ->addMedia($this->getTestJpg())

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,7 @@ use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 use Spatie\MediaLibrary\Support\MediaLibraryPro;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionDeferred;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionQueued;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionsOnOtherDisk;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionUsingModelInstance;
@@ -38,6 +39,8 @@ abstract class TestCase extends Orchestra
     protected TestModelWithPreviewConversion $testModelWithPreviewConversion;
 
     protected TestModelWithoutMediaConversions $testModelWithoutMediaConversions;
+
+    protected TestModelWithConversionDeferred $testModelWithConversionDeferred;
 
     protected TestModelWithConversionQueued $testModelWithConversionQueued;
 
@@ -66,6 +69,7 @@ abstract class TestCase extends Orchestra
         $this->testModelWithConversion = TestModelWithConversion::first();
         $this->testModelWithMultipleConversions = TestModelWithMultipleConversions::first();
         $this->testModelWithPreviewConversion = TestModelWithPreviewConversion::first();
+        $this->testModelWithConversionDeferred = TestModelWithConversionDeferred::first();
         $this->testModelWithConversionQueued = TestModelWithConversionQueued::first();
         $this->testModelWithoutMediaConversions = TestModelWithoutMediaConversions::first();
         $this->testModelWithMorphMap = TestModelWithMorphMap::first();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Dotgetenv\Dotgetenv;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Schema;
@@ -91,7 +92,7 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      * @return array
      */
     protected function getPackageProviders($app)
@@ -104,7 +105,7 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      */
     public function getEnvironmentSetUp($app)
     {
@@ -140,7 +141,7 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      */
     protected function setUpDatabase($app)
     {

--- a/tests/TestSupport/TestModels/TestModelWithConversionDeferred.php
+++ b/tests/TestSupport/TestModels/TestModelWithConversionDeferred.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class TestModelWithConversionDeferred extends TestModel
+{
+    public function registerMediaConversions(?Media $media = null): void
+    {
+        $this
+            ->addMediaConversion('thumb')
+            ->width(50)
+            ->deferred();
+    }
+}


### PR DESCRIPTION
This adds a `deferred()` media conversion option. This is handy if for example you wanted to do a quick conversion such as an avatar thumbnail which is used on the next page after upload.

```php
$this->addMediaConversion('thumb')
    ->width(400)
    ->deferred();
```

I did think about using a single enum property, rather than toggling two boolean ones, but I didn’t want to break compatibility.

Note: There's a "Fix styling" CI commit that's changed a lot of files here that are unrelated to this PR.