### PR TITLE
Fix awkward phrasing: 'want to not move, but copy' -> clearer wording

### DIFF
--- a/docs/basic-usage/associating-files.md
+++ b/docs/basic-usage/associating-files.md
@@ -14,7 +14,7 @@ $yourModel
 
 The file will now be associated with the `YourModel` instance and will be moved to the disk you've configured.
 
-If you want to not move, but copy, the original file you can call `preservingOriginal`:
+If you want to copy the original file rather than move it, you can call `preservingOriginal`:
 
 ```php
 $yourModel


### PR DESCRIPTION
The sentence 'If you want to not move, but copy, the original file you can call' was awkward and grammatically poor. Rewritten as 'If you want to copy the original file rather than move it, you can call' for clarity.