### PR TITLE
Add onlyKeepFirst() method to MediaCollection

### DIFF
--- a/src/MediaCollections/Exceptions/FileCannotBeAddedToFullCollection.php
+++ b/src/MediaCollections/Exceptions/FileCannotBeAddedToFullCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\MediaLibrary\MediaCollections\Exceptions;
+
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\MediaCollections\File;
+use Spatie\MediaLibrary\MediaCollections\MediaCollection;
+
+class FileCannotBeAddedToFullCollection extends FileCannotBeAdded
+{
+    public static function create(File $file, MediaCollection $mediaCollection, HasMedia $hasMedia): self
+    {
+        $modelType = $hasMedia::class;
+
+        $limit = $mediaCollection->collectionSizeLimit;
+
+        return new static("The file with properties `{$file}` could not be added to the collection named `{$mediaCollection->name}` of model `{$modelType}` with id `{$hasMedia->getKey()}` because the collection is full (limit: {$limit}).");
+    }
+}

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -15,6 +15,7 @@ use Spatie\MediaLibrary\MediaCollections\Exceptions\FileDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileIsTooBig;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileNameNotAllowed;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileUnacceptableForCollection;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAddedToFullCollection;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\UnknownType;
 use Spatie\MediaLibrary\MediaCollections\File as PendingFile;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -596,6 +597,17 @@ class FileAdder
 
         if (! empty($collection->acceptsMimeTypes) && ! in_array($file->mimeType, $collection->acceptsMimeTypes)) {
             throw FileUnacceptableForCollection::create($file, $collection, $this->subject);
+        }
+
+        if ($collection->collectionSizeLimit && $collection->keepFirst) {
+            /** @var HasMedia */
+            $subject = $this->subject->fresh();
+
+            $collectionMedia = $subject->getMedia($collection->name);
+
+            if ($collectionMedia->count() >= $collection->collectionSizeLimit) {
+                throw FileCannotBeAddedToFullCollection::create($file, $collection, $this->subject);
+            }
         }
     }
 

--- a/src/MediaCollections/MediaCollection.php
+++ b/src/MediaCollections/MediaCollection.php
@@ -28,6 +28,8 @@ class MediaCollection
 
     public bool $singleFile = false;
 
+    public bool $keepFirst = false;
+
     /** @var array<string, string> */
     public array $fallbackUrls = [];
 
@@ -104,6 +106,26 @@ class MediaCollection
         $this->singleFile = ($maximumNumberOfItemsInCollection === 1);
 
         $this->collectionSizeLimit = $maximumNumberOfItemsInCollection;
+
+        $this->keepFirst = false;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function onlyKeepFirst(int $maximumNumberOfItemsInCollection): self
+    {
+        if ($maximumNumberOfItemsInCollection < 1) {
+            throw new InvalidArgumentException("You should pass a value higher than 0. `{$maximumNumberOfItemsInCollection}` given.");
+        }
+
+        $this->singleFile = ($maximumNumberOfItemsInCollection === 1);
+
+        $this->collectionSizeLimit = $maximumNumberOfItemsInCollection;
+
+        $this->keepFirst = true;
 
         return $this;
     }

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileUnacceptableForCollection;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAddedToFullCollection;
 use Spatie\MediaLibrary\MediaCollections\File;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
@@ -254,5 +255,30 @@ test('if the only keeps latest method is specified it will delete all other medi
     $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
 
     $this->assertFalse($model->getMedia('images')->contains(fn ($model) => $model->is($firstFile)));
+    expect($model->getMedia('images'))->toHaveCount(3);
+});
+
+test('if the only keeps first method is specified it will reject adding new media and will only keep the first n ones', function () {
+    $testModel = new class extends TestModelWithConversion
+    {
+        public function registerMediaCollections(): void
+        {
+            $this
+                ->addMediaCollection('images')
+                ->onlyKeepFirst(3);
+        }
+    };
+
+    $model = $testModel::create(['name' => 'testmodel']);
+
+    $firstFile = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+    $this->expectException(FileCannotBeAddedToFullCollection::class);
+
+    $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images');
+
+    $this->assertTrue($model->getMedia('images')->contains(fn ($model) => $model->is($firstFile)));
     expect($model->getMedia('images'))->toHaveCount(3);
 });


### PR DESCRIPTION
- Add onlyKeepFirst() method to MediaCollection to allow rejecting new additions once the collection size limit is reached, while keeping the first N items in the collection.
- Update the onlyKeepLatest() method to set the keepFirst property to false, ensuring that existing behavior is maintained unless onlyKeepFirst() is explicitly called.
- Update FileAdder to check for the keepFirst property when adding files to a collection with a size limit.
- Add a new exception FileCannotBeAddedToFullCollection to handle cases where a file cannot be added to a collection that has reached its size limit with keepFirst enabled.
- Update tests to cover the new functionality of onlyKeepFirst() in MediaCollection and the corresponding behavior in FileAdder.