### PR TITLE
Add posibility to change the name from the parent attributes

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -318,7 +318,7 @@ class FileAdder
         $media->name = $this->mediaName;
 
         $sanitizedFileName = ($this->fileNameSanitizer)($this->fileName);
-        $fileName = app(config('media-library.file_namer'))->originalFileName($sanitizedFileName);
+        $fileName = app(config('media-library.file_namer'))->originalFileName($sanitizedFileName, $this->subject);
         $this->fileName = $this->appendExtension($fileName, pathinfo($sanitizedFileName, PATHINFO_EXTENSION));
 
         $media->file_name = $this->fileName;
@@ -356,7 +356,7 @@ class FileAdder
     public function toMediaCollection(string $collectionName = 'default', string $diskName = ''): Media
     {
         $sanitizedFileName = ($this->fileNameSanitizer)($this->fileName);
-        $fileName = app(config('media-library.file_namer'))->originalFileName($sanitizedFileName);
+        $fileName = app(config('media-library.file_namer'))->originalFileName($sanitizedFileName, $this->subject);
         $this->fileName = $this->appendExtension($fileName, pathinfo($sanitizedFileName, PATHINFO_EXTENSION));
 
         if ($this->file instanceof RemoteFile) {

--- a/src/Support/FileNamer/FileNamer.php
+++ b/src/Support/FileNamer/FileNamer.php
@@ -4,10 +4,11 @@ namespace Spatie\MediaLibrary\Support\FileNamer;
 
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\HasMedia;
 
 abstract class FileNamer
 {
-    public function originalFileName(string $fileName): string
+    public function originalFileName(string $fileName, ?HasMedia $model = null): string
     {
         $extLength = strlen(pathinfo($fileName, PATHINFO_EXTENSION));
 


### PR DESCRIPTION
This pull request updates how file names are generated for media uploads by allowing the file namer to access the associated model. The main change is that the `originalFileName` method now receives the media subject/model as an argument, enabling more context-aware file naming.

**File naming improvements:**

* The `originalFileName` method in the `FileNamer` base class now accepts an optional `HasMedia` model parameter, allowing file namers to customize file names based on the associated model. (`src/Support/FileNamer/FileNamer.php`)
* Calls to `originalFileName` in `FileAdder` now pass the `$this->subject` model, providing the file namer with more context for generating file names. (`src/MediaCollections/FileAdder.php`) [[1]](diffhunk://#diff-72951cbdd4bf3d0f820532db8b1a7e9f395c5e55e4fa900e5da51ee4e9f52f63L321-R321) [[2]](diffhunk://#diff-72951cbdd4bf3d0f820532db8b1a7e9f395c5e55e4fa900e5da51ee4e9f52f63L359-R359)