### PR TITLE
fix: skip URL encoding for S3 disk to prevent double encoding

### DIFF
--- a/src/Support/UrlGenerator/BaseUrlGenerator.php
+++ b/src/Support/UrlGenerator/BaseUrlGenerator.php
@@ -73,6 +73,12 @@ abstract class BaseUrlGenerator implements UrlGenerator
 
     protected function getUrlEncodedPathRelativeToRoot(): string
     {
+        $driver = config("filesystems.disks.{$this->getDiskName()}.driver");
+        
+        if ($driver === 's3') {
+            return $this->getPathRelativeToRoot();
+        }
+        
         $segments = explode('/', $this->getPathRelativeToRoot());
 
         return implode('/', array_map(rawurlencode(...), $segments));

--- a/src/Support/UrlGenerator/BaseUrlGenerator.php
+++ b/src/Support/UrlGenerator/BaseUrlGenerator.php
@@ -75,7 +75,7 @@ abstract class BaseUrlGenerator implements UrlGenerator
     {
         $driver = config("filesystems.disks.{$this->getDiskName()}.driver");
         
-        if ($driver === 's3') {
+        if ($driver !== 'local') {
             return $this->getPathRelativeToRoot();
         }
         

--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -261,3 +261,12 @@ it('can retrieve a zip with s3 disk', function () {
 
     $this->assertFileExistsInZip($temporaryDirectory->path('response.zip'), 'test.jpg');
 });
+
+it('does not double encode percent signs in filenames on S3', function () {
+    $media = $this->testModel->addMedia($this->getTestFilesDirectory('test_.jpg'))
+        ->usingFileName('IMG_5405%20copy.jpg')
+        ->toMediaCollection('default', 's3_disk');
+
+    expect($media->getUrl())->toContain('IMG_5405%2520copy.jpg');
+    expect($media->getUrl())->not->toContain('IMG_5405%252520copy.jpg');
+});


### PR DESCRIPTION
Fixes #3933 