### PR TITLE
chore: exclude speaking-page.png from export archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 /tests              export-ignore
 /.editorconfig      export-ignore
 /docs               export-ignore
+/speaking-page.png  export-ignore
 /UPGRADING.md       export-ignore
 /CHANGELOG.md       export-ignore
 /CONTRIBUTING.md    export-ignore


### PR DESCRIPTION
## Description
This PR adds `/speaking-page.png` to `.gitattributes` with `export-ignore` to prevent this 3MB file from being included in the Composer distribution package.

## Current Problem
The file currently lives in the repository root and is not excluded by any `.gitattributes` rule (only `/docs` is excluded). This causes every `composer require` to download an unnecessary 3MB image.

## Solution
Added `/speaking-page.png   export-ignore` to `.gitattributes`

## Related Issue
N/A - discovered during local installation

## Checklist
- [x] My PR is for one feature/fix
- [x] My commit history is clean
- [x] No tests required (configuration change)
- [x] No documentation required
