### PR TITLE
Add opt-in conversions_disk_name config for default conversions disk

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -35,6 +35,17 @@ return [
     'disk_name' => env('MEDIA_DISK', 'public'),
 
     /*
+     * The disk on which to store conversions (thumbnails, etc.) and responsive images
+     * when no disk is specified explicitly on the media collection or via
+     * `storingConversionsOnDisk()`. When left null, conversions are stored on the
+     * same disk as the original media — preserving previous behavior.
+     *
+     * This is useful when the originals live on a remote disk (e.g. S3) but the
+     * generated derivatives should stay local for faster access and lower egress.
+     */
+    'conversions_disk_name' => env('MEDIA_CONVERSIONS_DISK', null),
+
+    /*
      * The maximum file size of an item in bytes.
      * Adding a larger file will result in an exception.
      */

--- a/docs/advanced-usage/working-with-multiple-filesystems.md
+++ b/docs/advanced-usage/working-with-multiple-filesystems.md
@@ -27,6 +27,23 @@ $media = $yourModel
    ->toMediaCollection('images', 'local');
 ```
 
+### Configuring a default conversions disk
+
+If you want every conversion to land on a particular disk without repeating `storingConversionsOnDisk(...)` for every upload, set the `conversions_disk_name` config value:
+
+```php
+// config/media-library.php
+
+return [
+    'disk_name' => 's3',
+    'conversions_disk_name' => 'public',
+
+    // ...
+];
+```
+
+With this in place, conversions and responsive images are saved on the `public` disk by default, while the originals still live on `s3`. Anything you set explicitly — either via `->storingConversionsOnDisk(...)` on a `FileAdder` or via `->storeConversionsOnDisk(...)` on a media collection — takes precedence. When the value is `null` (the default), conversions stay on the originals' disk, preserving the historical behavior.
+
 ## Are you a visual learner?
 
 Here's a video that shows how to work with multiple filesystems.

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -317,6 +317,21 @@ return [
 
 Want to use S3? Then follow Laravel's instructions on [how to add the S3 Flysystem driver](https://laravel.com/docs/filesystem#configuration). If possible, we recommend [using a remote filesystem like S3](https://twitter.com/taylorotwell/status/1153326292412129280) instead of your local filesystem to prevent security issues.
 
+If you keep your originals on a remote disk like S3 but want to store the generated conversions (thumbnails, responsive images) on a different disk — for example, locally so the application can serve them without an extra remote round-trip — you can set the `conversions_disk_name` config value:
+
+```php
+// config/media-library.php
+
+return [
+    'disk_name' => 's3',
+    'conversions_disk_name' => 'public',
+
+    // ...
+];
+```
+
+When `conversions_disk_name` is left `null` (the default), conversions are stored on the same disk as the original media. The setting is overridden by any explicit `->storingConversionsOnDisk(...)` call or by a `storeConversionsOnDisk(...)` setting on a media collection.
+
 ## Setting up a queue
 
 If you are planning on working with image manipulations it's recommended to configure a queue on your server and specify it in the config file.

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -457,6 +457,12 @@ class FileAdder
             }
         }
 
+        $configuredConversionsDiskName = config('media-library.conversions_disk_name');
+
+        if (! empty($configuredConversionsDiskName)) {
+            return $configuredConversionsDiskName;
+        }
+
         return $originalsDiskName;
     }
 

--- a/tests/Feature/FileAdder/ConversionsDiskTest.php
+++ b/tests/Feature/FileAdder/ConversionsDiskTest.php
@@ -65,3 +65,53 @@ it('will store the conversion on the disk specified in on the media collection',
     );
     expect($conversionsFilePath)->toBeFile();
 });
+
+it('uses the globally configured conversions disk when no other disk is specified', function () {
+    config()->set('media-library.conversions_disk_name', 'secondMediaDisk');
+
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
+
+    expect($media->disk)->toEqual('public');
+    expect($media->conversions_disk)->toEqual('secondMediaDisk');
+
+    expect($media->getPath('thumb'))->toBeFile();
+    $this->assertEquals(
+        $this->getTestsPath('TestSupport/temp/media2/1/conversions/test-thumb.jpg'),
+        $media->getPath('thumb')
+    );
+});
+
+it('falls back to the originals disk when the global conversions disk is empty', function () {
+    config()->set('media-library.conversions_disk_name', null);
+
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection();
+
+    expect($media->conversions_disk)->toEqual($media->disk);
+});
+
+it('lets a per-call storingConversionsOnDisk override the global config', function () {
+    config()->set('media-library.conversions_disk_name', 'public');
+
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->storingConversionsOnDisk('secondMediaDisk')
+        ->toMediaCollection();
+
+    expect($media->conversions_disk)->toEqual('secondMediaDisk');
+});
+
+it('lets a per-collection conversions disk override the global config', function () {
+    config()->set('media-library.conversions_disk_name', 'public');
+
+    $media = $this->testModelWithConversionsOnOtherDisk
+        ->addMedia($this->getTestJpg())
+        ->toMediaCollection('thumb');
+
+    // The collection registers 'secondMediaDisk' via storeConversionsOnDisk(),
+    // which must win over the global config value.
+    expect($media->conversions_disk)->toEqual('secondMediaDisk');
+});


### PR DESCRIPTION
## What

Adds a new optional `conversions_disk_name` setting to `config/media-library.php`. When set, conversions and responsive images are stored on that disk by default — without requiring `->storingConversionsOnDisk(...)` at every upload site or a `storeConversionsOnDisk(...)` declaration on every media collection.

```php
// config/media-library.php
'conversions_disk_name' => env('MEDIA_CONVERSIONS_DISK', null),
```

## Why

When originals live on a remote disk (S3, Hetzner Object Storage, …) it is almost always a mistake to also keep the thumbnails/responsive images there: every page that renders a list of thumbnails then turns into a fan-out of remote `GET`s, which is both slow and (for paid object storage) expensive. The recommended setup is "originals remote, derivatives local," but the framework currently has no central way to express that — every code path that adds media must remember to opt in via `storingConversionsOnDisk(...)`, and any path that uses `->addMedia(...)->toMediaCollection(...)` without that call silently inherits the originals' disk.

Apps that wire in third-party media (Nextcloud importers, mail attachments, IMAP sync, etc.) tend to skip the helper and write directly via `addMedia`, so the divergence is easy to miss until many thousands of conversions have ended up on the wrong disk.

## Behavior

The lookup order in `FileAdder::determineConversionsDiskName()` becomes:

1. Per-call `->storingConversionsOnDisk(...)` (unchanged, highest priority)
2. Per-collection `storeConversionsOnDisk(...)` (unchanged)
3. **New:** `config('media-library.conversions_disk_name')` when not empty
4. Fall back to the originals' disk (unchanged, current default)

## Backward compatibility

- Default value is `null`, which falls through to the original behavior — no change for existing installs.
- All higher-precedence mechanisms (per-call and per-collection overrides) keep winning.
- No migrations, no signature changes, no deprecations.

## Tests

The existing `tests/Feature/FileAdder/ConversionsDiskTest.php` is extended with four new cases covering: opt-in via config, the `null` fallback, per-call override precedence, and per-collection override precedence. The existing four cases keep passing unchanged.

```
Tests:    8 passed (21 assertions)
```

## Docs

Updated `docs/installation-setup.md` and `docs/advanced-usage/working-with-multiple-filesystems.md` with the new setting and a short rationale.