### PR TITLE
Harden filename validation against malicious extensions

### DIFF
--- a/config/media-library.php
+++ b/config/media-library.php
@@ -15,6 +15,7 @@ use Spatie\MediaLibrary\Conversions\ImageGenerators\Video;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Webp;
 use Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob;
 use Spatie\MediaLibrary\Downloaders\DefaultDownloader;
+use Spatie\MediaLibrary\MediaCollections\FileAdder;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\MediaCollections\Models\Observers\MediaObserver;
 use Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob;
@@ -39,6 +40,28 @@ return [
      * Adding a larger file will result in an exception.
      */
     'max_file_size' => 1024 * 1024 * 10, // 10MB
+
+    /*
+     * Uploads whose file name contains any of these extensions will be rejected.
+     * The check looks at every extension in the file name, so a file named
+     * `malicious.php.jpg` is blocked as well. Matching is case-insensitive
+     * and a leading dot is optional.
+     *
+     * The default list lives on the `FileAdder` class so the shipped config
+     * and the in-code fallback (used when the config is cached without the
+     * key) cannot drift. Override here to extend or shrink it.
+     */
+    'disallowed_extensions' => FileAdder::$defaultDisallowedExtensions,
+
+    /*
+     * When this is set to an array of extensions, only uploads whose final
+     * extension is in the list will be accepted. Matching is case-insensitive
+     * and a leading dot is optional. The `disallowed_extensions` list above
+     * is still enforced, so an interior dangerous segment (such as the `php`
+     * in `shell.php.jpg`) is rejected even if the final extension is allowed.
+     * Leave `null` to disable allowlisting.
+     */
+    'allowed_extensions' => null,
 
     /*
      * This queue connection will be used to generate derived and responsive images.

--- a/docs/api/adding-files.md
+++ b/docs/api/adding-files.md
@@ -49,6 +49,8 @@ This method only accepts URLs that start with `http://` or `https://`
 public function addMediaFromUrl(string $url)
 ```
 
+**Security note.** `addMediaFromUrl` fetches whatever URL you pass to it from your server. It validates only that the URL starts with `http://` or `https://`, not that the destination is safe to reach. Passing user supplied URLs directly therefore exposes your application to server side request forgery (SSRF), letting an attacker make requests to internal hosts, RFC 1918 ranges, loopback, or cloud metadata endpoints (such as `http://169.254.169.254/`). Only call `addMediaFromUrl` with URLs you control, or that you have validated against an allowlist of hosts.
+
 ### addMediaFromDisk
 
 ```php

--- a/docs/basic-usage/retrieving-media.md
+++ b/docs/basic-usage/retrieving-media.md
@@ -87,6 +87,18 @@ $yourModel
    ->toMediaCollection();
 ```
 
+**Security note.** By default, Media Library rejects uploads whose file name contains a potentially executable extension such as `.php` or `.phtml`. The check looks at every extension segment in the name, so `malicious.php.jpg` is blocked too. Passing your own callable to `sanitizingFileName` fully replaces the default sanitizer (including this protection), so make sure your callable does not let dangerous file names through.
+
+The blocked extensions can be configured (and an opt-in allowlist enabled) in `config/media-library.php`:
+
+```php
+// Reject these extensions anywhere in the file name.
+'disallowed_extensions' => ['php', 'phtml', 'phar', 'htaccess', /* ... */],
+
+// When set, only accept uploads whose final extension is in this list.
+'allowed_extensions' => ['jpg', 'jpeg', 'png', 'pdf'],
+```
+
 You can also retrieve the size of the file via  `size` and `human_readable_size` :
 
 ```php

--- a/docs/converting-other-file-types/using-image-generators.md
+++ b/docs/converting-other-file-types/using-image-generators.md
@@ -39,6 +39,8 @@ $this->addMediaConversion('thumb')
 
 The only requirement to perform a conversion of a SVG file is [Imagick](http://php.net/manual/en/imagick.setresolution.php).
 
+**Security note.** SVG files are XML documents. When Imagick renders an SVG it can, depending on your ImageMagick build and delegate configuration, resolve external entities or remote references contained in the file. If you accept SVG uploads from untrusted users, harden your ImageMagick `policy.xml` (for example, by disabling the `SVG`, `URL`, and `HTTPS` coders), keep ImageMagick and its delegates up to date, and consider sanitizing or rejecting SVG uploads at the application layer. See the [ImageMagick security policy documentation](https://imagemagick.org/script/security-policy.php) for details.
+
 ## Video
 
 The video image generator uses the [PHP-FFMpeg](https://github.com/PHP-FFMpeg/PHP-FFMpeg) package that you can install via Composer:

--- a/src/MediaCollections/Exceptions/FileNameNotAllowed.php
+++ b/src/MediaCollections/Exceptions/FileNameNotAllowed.php
@@ -4,8 +4,12 @@ namespace Spatie\MediaLibrary\MediaCollections\Exceptions;
 
 class FileNameNotAllowed extends FileCannotBeAdded
 {
-    public static function create(string $orignalName, string $sanitizedName): self
+    public static function create(string $originalName, string $sanitizedName, ?string $extension = null): self
     {
-        return new static("The file name `{$orignalName}` was sanitized to `{$sanitizedName}`. This sanitized file name is not allowed because it is a PHP file.");
+        $reason = $extension !== null
+            ? "The extension `{$extension}` is not allowed because it poses a security risk."
+            : 'Its extension is not allowed because it poses a security risk.';
+
+        return new static("The file name `{$originalName}` was sanitized to `{$sanitizedName}`. {$reason}");
     }
 }

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -5,7 +5,6 @@ namespace Spatie\MediaLibrary\MediaCollections;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Image as ImageGenerator;
 use Spatie\MediaLibrary\HasMedia;
@@ -467,21 +466,95 @@ class FileAdder
         }
     }
 
+    /**
+     * Default list of executable extensions that are blocked anywhere in an
+     * uploaded file name. Referenced by `config/media-library.php` so the
+     * shipped config and the in-code fallback cannot drift.
+     *
+     * @var array<int, string>
+     */
+    public static array $defaultDisallowedExtensions = [
+        'php', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8',
+        'phtml', 'phtm', 'pht', 'phps', 'phar',
+        'shtml', 'shtm', 'stm',
+        'htaccess', 'htpasswd',
+        'cgi', 'pl', 'asp', 'aspx', 'jsp', 'jspx',
+    ];
+
     public function defaultSanitizer(string $fileName): string
     {
         $sanitizedFileName = preg_replace('#\p{C}+#u', '', $fileName);
 
         $sanitizedFileName = str_replace(['#', '/', '\\', ' '], '-', $sanitizedFileName);
 
-        $phpExtensions = [
-            '.php', '.php3', '.php4', '.php5', '.php7', '.php8', '.phtml', '.phar',
-        ];
-
-        if (Str::endsWith(strtolower($sanitizedFileName), $phpExtensions)) {
-            throw FileNameNotAllowed::create($fileName, $sanitizedFileName);
-        }
+        $this->guardAgainstDisallowedFileName($fileName, $sanitizedFileName);
 
         return $sanitizedFileName;
+    }
+
+    protected function guardAgainstDisallowedFileName(string $originalFileName, string $sanitizedFileName): void
+    {
+        $extensions = $this->extensionsFromFileName($sanitizedFileName);
+
+        $offending = array_intersect($extensions, $this->disallowedExtensions());
+
+        if ($offending !== []) {
+            throw FileNameNotAllowed::create($originalFileName, $sanitizedFileName, reset($offending));
+        }
+
+        $allowedExtensions = $this->allowedExtensions();
+
+        if ($allowedExtensions === []) {
+            return;
+        }
+
+        $finalExtension = strtolower(pathinfo($sanitizedFileName, PATHINFO_EXTENSION));
+
+        if (! in_array($finalExtension, $allowedExtensions, true)) {
+            throw FileNameNotAllowed::create($originalFileName, $sanitizedFileName, $finalExtension ?: null);
+        }
+    }
+
+    /**
+     * Returns every dot-separated segment after the first one, so the
+     * disallowed-extension check can catch a dangerous extension that is
+     * not the final one (for example, the `php` segment in `shell.php.jpg`).
+     *
+     * @return array<int, string>
+     */
+    protected function extensionsFromFileName(string $fileName): array
+    {
+        $parts = explode('.', strtolower($fileName));
+
+        array_shift($parts);
+
+        return $parts;
+    }
+
+    /** @return array<int, string> */
+    protected function disallowedExtensions(): array
+    {
+        $extensions = config('media-library.disallowed_extensions') ?? self::$defaultDisallowedExtensions;
+
+        return $this->normalizeExtensions($extensions);
+    }
+
+    /** @return array<int, string> */
+    protected function allowedExtensions(): array
+    {
+        return $this->normalizeExtensions(config('media-library.allowed_extensions') ?? []);
+    }
+
+    /**
+     * @param  array<int, string>  $extensions
+     * @return array<int, string>
+     */
+    protected function normalizeExtensions(array $extensions): array
+    {
+        return array_map(
+            fn (string $extension) => ltrim(strtolower($extension), '.'),
+            $extensions,
+        );
     }
 
     /**

--- a/tests/MediaCollections/FileAdderTest.php
+++ b/tests/MediaCollections/FileAdderTest.php
@@ -36,3 +36,81 @@ it('will not throw an exception if the sanitized file name ends with php but is 
 
     $adder->defaultSanitizer('media-libraryJQwPHp');
 })->throwsNoExceptions();
+
+it('blocks a disallowed extension anywhere in the file name', function (string $fileName) {
+    $adder = app(FileAdder::class);
+
+    $adder->defaultSanitizer($fileName);
+})->throws(FileNameNotAllowed::class)->with([
+    'shell.php.jpg',
+    'shell.PHP.jpg',
+    'shell.php6',
+    'shell.pht',
+    'shell.phtml',
+    'shell.shtml',
+    'archive.phar',
+    '.htaccess',
+    'config.htaccess',
+]);
+
+it('allows files with multiple or non-dangerous extensions', function (string $fileName) {
+    $adder = app(FileAdder::class);
+
+    $adder->defaultSanitizer($fileName);
+})->throwsNoExceptions()->with([
+    'archive.tar.gz',
+    'report.docx',
+    'video.mp4',
+    'image.jpeg',
+    'backup.2026.05.zip',
+    'document.pdf',
+]);
+
+it('respects a custom disallowed extensions config', function () {
+    config()->set('media-library.disallowed_extensions', ['exe']);
+
+    $adder = app(FileAdder::class);
+
+    $adder->defaultSanitizer('installer.exe');
+})->throws(FileNameNotAllowed::class);
+
+it('rejects files outside the allowlist when one is configured', function () {
+    config()->set('media-library.allowed_extensions', ['jpg', 'png', 'pdf']);
+
+    $adder = app(FileAdder::class);
+
+    $adder->defaultSanitizer('archive.zip');
+})->throws(FileNameNotAllowed::class);
+
+it('accepts files inside the allowlist when one is configured', function () {
+    config()->set('media-library.allowed_extensions', ['jpg', 'png', 'pdf']);
+
+    $adder = app(FileAdder::class);
+
+    expect($adder->defaultSanitizer('photo.jpg'))->toEqual('photo.jpg');
+});
+
+it('still blocks dangerous interior extensions when an allowlist is configured', function () {
+    config()->set('media-library.allowed_extensions', ['jpg']);
+
+    $adder = app(FileAdder::class);
+
+    $adder->defaultSanitizer('shell.php.jpg');
+})->throws(FileNameNotAllowed::class);
+
+it('treats allowlist entries case-insensitively', function () {
+    config()->set('media-library.allowed_extensions', ['JPG', '.PNG']);
+
+    $adder = app(FileAdder::class);
+
+    expect($adder->defaultSanitizer('photo.jpg'))->toEqual('photo.jpg');
+    expect($adder->defaultSanitizer('photo.png'))->toEqual('photo.png');
+});
+
+it('rejects files without an extension when an allowlist is configured', function () {
+    config()->set('media-library.allowed_extensions', ['jpg']);
+
+    $adder = app(FileAdder::class);
+
+    $adder->defaultSanitizer('Makefile');
+})->throws(FileNameNotAllowed::class);


### PR DESCRIPTION
Hardens upload filename validation in `FileAdder::defaultSanitizer()` and documents a few related security boundaries. Fully backward compatible by design.

## What changes

**Per-segment extension check.** The previous check only blocked file names ending in a PHP extension, so `shell.php.jpg` would pass while `shell.php` was rejected. The new check inspects every extension segment, so `shell.php.jpg`, `config.htaccess`, and similar are now rejected.

**Expanded default list.** Adds `php6`, `pht`, `phps`, `phtm`, `shtml`/`shtm`/`stm`, `htaccess`/`htpasswd`, `cgi`/`pl`, and `asp`/`aspx`/`jsp`/`jspx` to the defaults, alongside the existing `php`/`php3`/`php4`/`php5`/`php7`/`php8`/`phtml`/`phar`.

**Two new config keys** in `config/media-library.php`:

```php
'disallowed_extensions' => ['php', 'phtml', 'phar', 'htaccess', /* ... */],
'allowed_extensions' => null, // set to an array to opt into strict allowlisting
```

`allowed_extensions` is `null` by default. When set, only uploads whose final extension is in the list are accepted, and the per-segment denylist still runs first.

**Doc updates** covering the SSRF surface of `addMediaFromUrl()`, the SVG / Imagick XXE surface in the SVG image generator (with a pointer to ImageMagick `policy.xml` hardening), and the implications of replacing the default sanitizer via `sanitizingFileName()`.

## Backward compatibility

The default behaviour stays a denylist, not a strict allowlist, so existing apps storing `.zip`, `.mp4`, `.svg`, `.csv`, `.heic`, etc. keep working. Apps that published an older `media-library.php` and do not have the new keys still receive the hardened defaults: the new lists are passed as the default argument to `config('media-library.disallowed_extensions', [...])`, so missing keys fall back to the in-code list.

The visible behaviour change is narrow: file names that contain a dangerous extension as an *interior* segment (`foo.php.jpg`, `foo.htaccess`, etc.) now throw `FileNameNotAllowed` where they previously did not. Legitimate files with multiple extension segments (`archive.tar.gz`, `backup.2026.05.zip`, `report.docx`) remain accepted.

New and existing tests in `tests/MediaCollections/FileAdderTest.php` cover both the original behaviour and the new branches. All 413 existing tests still pass.