### PR TITLE
Fix flaky S3 temporary-URL tests by comparing without timing params

### DIFF
--- a/tests/Feature/S3Integration/S3IntegrationTest.php
+++ b/tests/Feature/S3Integration/S3IntegrationTest.php
@@ -142,7 +142,8 @@ it('can get the temporary url to first media in a collection', function () {
     $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images', 's3_disk');
     $secondMedia->save();
 
-    expect($this->testModel->getFirstTemporaryUrl(Carbon::now()->addMinutes(5), 'images'))->toEqual($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5)));
+    expect(s3UrlWithoutTimingParams($this->testModel->getFirstTemporaryUrl(Carbon::now()->addMinutes(5), 'images')))
+        ->toEqual(s3UrlWithoutTimingParams($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5))));
 });
 
 it('can get the temporary url to first media in a collection when no expiration passed', function () {
@@ -152,15 +153,16 @@ it('can get the temporary url to first media in a collection when no expiration 
     $secondMedia = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images', 's3_disk');
     $secondMedia->save();
 
-    expect($this->testModel->getFirstTemporaryUrl(collectionName: 'images'))->toEqual($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5)));
+    expect(s3UrlWithoutTimingParams($this->testModel->getFirstTemporaryUrl(collectionName: 'images')))
+        ->toEqual(s3UrlWithoutTimingParams($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5))));
 });
 
 it('retrieves a temporary url for media when no expiration passed', function () {
     $media = $this->testModel->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection('images', 's3_disk');
     $media->save();
 
-    expect($media->getTemporaryUrl())
-        ->toEqual($media->getTemporaryUrl(Carbon::now()->addMinutes(5)));
+    expect(s3UrlWithoutTimingParams($media->getTemporaryUrl()))
+        ->toEqual(s3UrlWithoutTimingParams($media->getTemporaryUrl(Carbon::now()->addMinutes(5))));
 });
 
 it('retrieves a temporary media conversion url from s3', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -50,6 +50,24 @@ function s3BaseUrl(): string
     return 'https://laravel-medialibrary-tests.s3.eu-west-1.amazonaws.com';
 }
 
+/*
+ * Strips the parts of a presigned S3 URL that depend on the moment the URL was
+ * signed, so two URLs generated milliseconds apart can be compared for equality
+ * without the test failing when a wall-clock second ticks between them.
+ */
+function s3UrlWithoutTimingParams(string $url): string
+{
+    [$base, $query] = array_pad(explode('?', $url, 2), 2, '');
+
+    parse_str($query, $params);
+
+    foreach (['X-Amz-Date', 'X-Amz-Expires', 'X-Amz-Signature'] as $param) {
+        unset($params[$param]);
+    }
+
+    return $params === [] ? $base : $base.'?'.http_build_query($params);
+}
+
 function cleanUpS3(): void
 {
     collect(Storage::disk('s3_disk')->allDirectories(getS3BaseTestDirectory()))


### PR DESCRIPTION
Three tests in `tests/Feature/S3Integration/S3IntegrationTest.php` (lines 138, 148, 158 on main) generate two presigned S3 URLs and assert they are exactly equal:

```php
expect($this->testModel->getFirstTemporaryUrl(Carbon::now()->addMinutes(5), 'images'))
    ->toEqual($firstMedia->getTemporaryUrl(Carbon::now()->addMinutes(5)));
```

Each presigned URL embeds the moment it was signed in `X-Amz-Date`, `X-Amz-Expires`, and `X-Amz-Signature`. When the two calls happen to cross a wall-clock second, those three query parameters diverge by one second / get re-signed, and the strict string comparison fails:

```
-X-Amz-Expires=300&X-Amz-Signature=1e15f8cb...
+X-Amz-Expires=299&X-Amz-Signature=b98711a6...
```

CI has hit this intermittently. Latest example: run [25359557617](https://github.com/spatie/laravel-medialibrary/actions/runs/25359557617) on main (2026-05-05).

The tests are about delegation correctness (does `getFirstTemporaryUrl` return the same URL as `getTemporaryUrl` on the first media, does the no-argument form work like the explicit 5-minute form), not about the SDK's signing output. This PR adds a small `s3UrlWithoutTimingParams` helper in `tests/Pest.php` that strips `X-Amz-Date`, `X-Amz-Expires`, and `X-Amz-Signature` from a URL before the equality check. The remaining query parameters (`X-Amz-Algorithm`, `X-Amz-Credential`, `X-Amz-SignedHeaders`) and the full URL path stay under assertion, so a real delegation regression would still be caught.

No behaviour change to the package itself, test-only.