### PR TITLE
Attribute-based media configuration (new major version)

### DIFF
--- a/docs/basic-usage/configuring-with-attributes.md
+++ b/docs/basic-usage/configuring-with-attributes.md
@@ -1,0 +1,80 @@
+---
+title: Configuring with attributes
+weight: 4
+---
+
+Media collections and conversions can be declared directly on your model using PHP attributes, instead of (or alongside) the `registerMediaCollections()` and `registerMediaConversions()` methods.
+
+```php
+use Spatie\Image\Enums\Fit;
+use Spatie\MediaLibrary\Attributes\MediaCollection;
+use Spatie\MediaLibrary\Attributes\MediaConversion;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+
+#[MediaCollection(name: 'avatar', singleFile: true, fallbackUrl: '/default-avatar.png')]
+#[MediaCollection(name: 'downloads')]
+#[MediaConversion(name: 'thumb', collections: ['avatar'], width: 150, height: 150, fit: Fit::Crop, format: 'webp')]
+#[MediaConversion(name: 'preview', width: 500)]
+class User extends Model implements HasMedia
+{
+    use InteractsWithMedia;
+}
+```
+
+Both attributes are repeatable, so you can declare as many collections and conversions as you need.
+
+## MediaCollection attribute
+
+The `#[MediaCollection]` attribute accepts the following arguments.
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | The name of the collection. Required. |
+| `singleFile` | `bool` | Keep only the latest file in the collection. |
+| `onlyKeepLatest` | `?int` | Keep only the latest N files in the collection. Takes precedence over `singleFile`. |
+| `acceptsMimeTypes` | `array` | Restrict the collection to these mime types. |
+| `disk` | `?string` | The disk the collection stores its files on. |
+| `conversionsDisk` | `?string` | The disk the collection stores its conversions on. |
+| `fallbackUrl` | `?string` | A fallback url for when the collection is empty. |
+| `fallbackPath` | `?string` | A fallback path for when the collection is empty. |
+| `responsiveImages` | `bool` | Generate responsive images for the collection. |
+
+## MediaConversion attribute
+
+The `#[MediaConversion]` attribute accepts the following arguments.
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | The name of the conversion. Required. |
+| `collections` | `array` | The collections this conversion applies to. When omitted, it applies to all collections. |
+| `width` | `?int` | The desired width. |
+| `height` | `?int` | The desired height. |
+| `fit` | `?Fit` | A `Spatie\Image\Enums\Fit` case. When set, the width and height are passed to the fit. |
+| `format` | `?string` | The output format, such as `webp`. |
+| `quality` | `?int` | The output quality. |
+| `queued` | `?bool` | Whether the conversion is queued. When omitted, the package default applies. |
+| `responsiveImages` | `bool` | Generate responsive images for the conversion. |
+| `keepOriginalImageFormat` | `bool` | Keep the original image format instead of converting it. |
+
+## Combining attributes with methods
+
+Attributes and the `registerMediaCollections()` / `registerMediaConversions()` methods can be used together. Attributes are resolved first, then the methods run on top. A collection or conversion declared in a method overrides an attribute declared one with the same name. This lets you cover the common cases with attributes while keeping the methods for anything dynamic.
+
+```php
+#[MediaCollection(name: 'images')]
+#[MediaConversion(name: 'thumb', width: 150, height: 150)]
+class NewsItem extends Model implements HasMedia
+{
+    use InteractsWithMedia;
+
+    public function registerMediaConversions(?Media $media = null): void
+    {
+        $this->addMediaConversion('watermarked')->watermark(storage_path('logo.png'));
+    }
+}
+```
+
+## When to use methods instead
+
+The attribute arguments cover geometry, format, and the collection level toggles. They do not expose the full set of [spatie/image](https://spatie.be/docs/image/v3) manipulations (such as `blur`, `greyscale`, `border`, or `watermark`). For those, and for conversions that depend on the `$media` instance, or collections that use `acceptsFile()` with a closure, keep using the `registerMediaConversions()` and `registerMediaCollections()` methods.

--- a/src/Attributes/MediaCollection.php
+++ b/src/Attributes/MediaCollection.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\MediaLibrary\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class MediaCollection
+{
+    public function __construct(
+        public string $name,
+        public bool $singleFile = false,
+        public ?int $onlyKeepLatest = null,
+        public array $acceptsMimeTypes = [],
+        public ?string $disk = null,
+        public ?string $conversionsDisk = null,
+        public ?string $fallbackUrl = null,
+        public ?string $fallbackPath = null,
+        public bool $responsiveImages = false,
+    ) {}
+}

--- a/src/Attributes/MediaCollection.php
+++ b/src/Attributes/MediaCollection.php
@@ -11,6 +11,7 @@ class MediaCollection
         public string $name,
         public bool $singleFile = false,
         public ?int $onlyKeepLatest = null,
+        /** @var array<int, string> */
         public array $acceptsMimeTypes = [],
         public ?string $disk = null,
         public ?string $conversionsDisk = null,

--- a/src/Attributes/MediaConversion.php
+++ b/src/Attributes/MediaConversion.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\MediaLibrary\Attributes;
+
+use Attribute;
+use Spatie\Image\Enums\Fit;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class MediaConversion
+{
+    public function __construct(
+        public string $name,
+        /** @var array<int, string> */
+        public array $collections = [],
+        public ?int $width = null,
+        public ?int $height = null,
+        public ?Fit $fit = null,
+        public ?string $format = null,
+        public ?int $quality = null,
+        public ?bool $queued = null,
+        public bool $responsiveImages = false,
+        public bool $keepOriginalImageFormat = false,
+    ) {}
+}

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -25,6 +25,7 @@ use Spatie\MediaLibrary\MediaCollections\FileAdderFactory;
 use Spatie\MediaLibrary\MediaCollections\MediaCollection;
 use Spatie\MediaLibrary\MediaCollections\MediaRepository;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Support\MediaAttributes\MediaAttributeResolver;
 use Spatie\MediaLibrary\Support\MediaLibraryPro;
 use Spatie\MediaLibraryPro\PendingMediaLibraryRequestHandler;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -410,14 +411,14 @@ trait InteractsWithMedia
 
     public function getRegisteredMediaCollections(): Collection
     {
-        $this->registerMediaCollections();
+        $this->registerAllMediaCollections();
 
         return collect($this->mediaCollections);
     }
 
     public function getMediaCollection(string $collectionName = 'default'): ?MediaCollection
     {
-        $this->registerMediaCollections();
+        $this->registerAllMediaCollections();
 
         return collect($this->mediaCollections)
             ->first(fn (MediaCollection $collection) => $collection->name === $collectionName);
@@ -700,9 +701,28 @@ trait InteractsWithMedia
 
     public function registerMediaCollections(): void {}
 
+    protected function mediaAttributeResolver(): MediaAttributeResolver
+    {
+        return new MediaAttributeResolver(static::class);
+    }
+
+    protected function registerMediaCollectionsFromAttributes(): void
+    {
+        foreach ($this->mediaAttributeResolver()->toMediaCollections() as $name => $mediaCollection) {
+            $this->mediaCollections[$name] = $mediaCollection;
+        }
+    }
+
+    public function registerAllMediaCollections(): void
+    {
+        $this->registerMediaCollectionsFromAttributes();
+
+        $this->registerMediaCollections();
+    }
+
     public function registerAllMediaConversions(?Media $media = null): void
     {
-        $this->registerMediaCollections();
+        $this->registerAllMediaCollections();
 
         collect($this->mediaCollections)->each(function (MediaCollection $mediaCollection) use ($media) {
             $actualMediaConversions = $this->mediaConversions;

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -17,6 +17,7 @@ use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenClearedEvent;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidBase64Data;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidUrl;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeDeleted;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeUpdated;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\MimeTypeNotAllowed;
@@ -720,9 +721,41 @@ trait InteractsWithMedia
         $this->registerMediaCollections();
     }
 
+    protected function guardAgainstAttributeConversionsForUnknownCollections(): void
+    {
+        $validCollectionNames = [...array_keys($this->mediaCollections), 'default'];
+
+        foreach ($this->mediaAttributeResolver()->conversionAttributes() as $conversionAttribute) {
+            foreach ($conversionAttribute->collections as $collectionName) {
+                if (! in_array($collectionName, $validCollectionNames, true)) {
+                    throw InvalidMediaAttribute::unknownCollection(
+                        $conversionAttribute->name,
+                        $collectionName,
+                        static::class,
+                    );
+                }
+            }
+        }
+    }
+
+    protected function dedupeConversionsByName(array $conversions): array
+    {
+        $byName = [];
+
+        foreach ($conversions as $conversion) {
+            $byName[$conversion->getName()] = $conversion;
+        }
+
+        return array_values($byName);
+    }
+
     public function registerAllMediaConversions(?Media $media = null): void
     {
         $this->registerAllMediaCollections();
+
+        $this->guardAgainstAttributeConversionsForUnknownCollections();
+
+        $this->mediaConversions = $this->mediaAttributeResolver()->toConversions();
 
         collect($this->mediaCollections)->each(function (MediaCollection $mediaCollection) use ($media) {
             $actualMediaConversions = $this->mediaConversions;
@@ -740,6 +773,8 @@ trait InteractsWithMedia
         });
 
         $this->registerMediaConversions($media);
+
+        $this->mediaConversions = $this->dedupeConversionsByName($this->mediaConversions);
     }
 
     public function __sleep(): array

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -742,15 +742,20 @@ trait InteractsWithMedia
      * @param  Conversion[]  $conversions
      * @return Conversion[]
      */
-    protected function dedupeConversionsByName(array $conversions): array
+    protected function dedupeConversions(array $conversions): array
     {
-        $byName = [];
+        $deduped = [];
 
         foreach ($conversions as $conversion) {
-            $byName[$conversion->getName()] = $conversion;
+            $performOnCollections = $conversion->getPerformOnCollections();
+            sort($performOnCollections);
+
+            $key = $conversion->getName().'|'.implode(',', $performOnCollections);
+
+            $deduped[$key] = $conversion;
         }
 
-        return array_values($byName);
+        return array_values($deduped);
     }
 
     public function registerAllMediaConversions(?Media $media = null): void
@@ -778,7 +783,7 @@ trait InteractsWithMedia
 
         $this->registerMediaConversions($media);
 
-        $this->mediaConversions = $this->dedupeConversionsByName($this->mediaConversions);
+        $this->mediaConversions = $this->dedupeConversions($this->mediaConversions);
     }
 
     public function __sleep(): array

--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -16,8 +16,8 @@ use Spatie\MediaLibrary\Enums\CollectionPosition;
 use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenClearedEvent;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileCannotBeAdded;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidBase64Data;
-use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidUrl;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidUrl;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeDeleted;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\MediaCannotBeUpdated;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\MimeTypeNotAllowed;
@@ -738,6 +738,10 @@ trait InteractsWithMedia
         }
     }
 
+    /**
+     * @param  Conversion[]  $conversions
+     * @return Conversion[]
+     */
     protected function dedupeConversionsByName(array $conversions): array
     {
         $byName = [];

--- a/src/MediaCollections/Exceptions/InvalidMediaAttribute.php
+++ b/src/MediaCollections/Exceptions/InvalidMediaAttribute.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\MediaLibrary\MediaCollections\Exceptions;
+
+use Exception;
+
+class InvalidMediaAttribute extends Exception
+{
+    public static function duplicateCollection(string $collectionName, string $modelClass): self
+    {
+        return new static("The media collection `{$collectionName}` is declared more than once via attributes on `{$modelClass}`.");
+    }
+
+    public static function unknownCollection(string $conversionName, string $collectionName, string $modelClass): self
+    {
+        return new static("The media conversion `{$conversionName}` on `{$modelClass}` references unknown collection `{$collectionName}`.");
+    }
+}

--- a/src/Support/MediaAttributes/MediaAttributeResolver.php
+++ b/src/Support/MediaAttributes/MediaAttributeResolver.php
@@ -6,6 +6,7 @@ use ReflectionClass;
 use Spatie\MediaLibrary\Attributes\MediaCollection;
 use Spatie\MediaLibrary\Attributes\MediaConversion;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
+use Spatie\MediaLibrary\MediaCollections\MediaCollection as MediaCollectionBuilder;
 
 class MediaAttributeResolver
 {
@@ -20,6 +21,50 @@ class MediaAttributeResolver
     public function collectionAttributes(): array
     {
         return $this->parse()['collections'];
+    }
+
+    /** @return array<string, MediaCollectionBuilder> */
+    public function toMediaCollections(): array
+    {
+        $collections = [];
+
+        foreach ($this->collectionAttributes() as $attribute) {
+            $builder = MediaCollectionBuilder::create($attribute->name);
+
+            if ($attribute->onlyKeepLatest !== null) {
+                $builder->onlyKeepLatest($attribute->onlyKeepLatest);
+            } elseif ($attribute->singleFile) {
+                $builder->singleFile();
+            }
+
+            if ($attribute->acceptsMimeTypes !== []) {
+                $builder->acceptsMimeTypes($attribute->acceptsMimeTypes);
+            }
+
+            if ($attribute->disk !== null) {
+                $builder->useDisk($attribute->disk);
+            }
+
+            if ($attribute->conversionsDisk !== null) {
+                $builder->storeConversionsOnDisk($attribute->conversionsDisk);
+            }
+
+            if ($attribute->fallbackUrl !== null) {
+                $builder->useFallbackUrl($attribute->fallbackUrl);
+            }
+
+            if ($attribute->fallbackPath !== null) {
+                $builder->useFallbackPath($attribute->fallbackPath);
+            }
+
+            if ($attribute->responsiveImages) {
+                $builder->withResponsiveImages();
+            }
+
+            $collections[$attribute->name] = $builder;
+        }
+
+        return $collections;
     }
 
     /** @return MediaConversion[] */

--- a/src/Support/MediaAttributes/MediaAttributeResolver.php
+++ b/src/Support/MediaAttributes/MediaAttributeResolver.php
@@ -6,6 +6,7 @@ use ReflectionClass;
 use Spatie\MediaLibrary\Attributes\MediaCollection;
 use Spatie\MediaLibrary\Attributes\MediaConversion;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
+use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\MediaCollections\MediaCollection as MediaCollectionBuilder;
 
 class MediaAttributeResolver
@@ -65,6 +66,58 @@ class MediaAttributeResolver
         }
 
         return $collections;
+    }
+
+    /** @return Conversion[] */
+    public function toConversions(): array
+    {
+        $conversions = [];
+
+        foreach ($this->conversionAttributes() as $attribute) {
+            $conversion = Conversion::create($attribute->name);
+
+            if ($attribute->fit !== null) {
+                $conversion->fit($attribute->fit, $attribute->width, $attribute->height);
+            } else {
+                if ($attribute->width !== null) {
+                    $conversion->width($attribute->width);
+                }
+
+                if ($attribute->height !== null) {
+                    $conversion->height($attribute->height);
+                }
+            }
+
+            if ($attribute->format !== null) {
+                $conversion->format($attribute->format);
+            }
+
+            if ($attribute->quality !== null) {
+                $conversion->quality($attribute->quality);
+            }
+
+            if ($attribute->queued === true) {
+                $conversion->queued();
+            } elseif ($attribute->queued === false) {
+                $conversion->nonQueued();
+            }
+
+            if ($attribute->responsiveImages) {
+                $conversion->withResponsiveImages();
+            }
+
+            if ($attribute->keepOriginalImageFormat) {
+                $conversion->keepOriginalImageFormat();
+            }
+
+            if ($attribute->collections !== []) {
+                $conversion->performOnCollections(...$attribute->collections);
+            }
+
+            $conversions[] = $conversion;
+        }
+
+        return $conversions;
     }
 
     /** @return MediaConversion[] */

--- a/src/Support/MediaAttributes/MediaAttributeResolver.php
+++ b/src/Support/MediaAttributes/MediaAttributeResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Spatie\MediaLibrary\Support\MediaAttributes;
+
+use ReflectionClass;
+use Spatie\MediaLibrary\Attributes\MediaCollection;
+use Spatie\MediaLibrary\Attributes\MediaConversion;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
+
+class MediaAttributeResolver
+{
+    /** @var array<class-string, array{collections: MediaCollection[], conversions: MediaConversion[]}> */
+    protected static array $cache = [];
+
+    public function __construct(
+        protected string $modelClass,
+    ) {}
+
+    /** @return MediaCollection[] */
+    public function collectionAttributes(): array
+    {
+        return $this->parse()['collections'];
+    }
+
+    /** @return MediaConversion[] */
+    public function conversionAttributes(): array
+    {
+        return $this->parse()['conversions'];
+    }
+
+    /** @return array{collections: MediaCollection[], conversions: MediaConversion[]} */
+    protected function parse(): array
+    {
+        if (isset(static::$cache[$this->modelClass])) {
+            return static::$cache[$this->modelClass];
+        }
+
+        $reflection = new ReflectionClass($this->modelClass);
+
+        $collections = array_map(
+            fn ($attribute) => $attribute->newInstance(),
+            $reflection->getAttributes(MediaCollection::class),
+        );
+
+        $conversions = array_map(
+            fn ($attribute) => $attribute->newInstance(),
+            $reflection->getAttributes(MediaConversion::class),
+        );
+
+        $this->guardAgainstDuplicateCollections($collections);
+
+        return static::$cache[$this->modelClass] = [
+            'collections' => $collections,
+            'conversions' => $conversions,
+        ];
+    }
+
+    /** @param MediaCollection[] $collections */
+    protected function guardAgainstDuplicateCollections(array $collections): void
+    {
+        $seen = [];
+
+        foreach ($collections as $collection) {
+            if (in_array($collection->name, $seen, true)) {
+                throw InvalidMediaAttribute::duplicateCollection($collection->name, $this->modelClass);
+            }
+
+            $seen[] = $collection->name;
+        }
+    }
+
+    public static function clearCache(): void
+    {
+        static::$cache = [];
+    }
+}

--- a/src/Support/MediaAttributes/MediaAttributeResolver.php
+++ b/src/Support/MediaAttributes/MediaAttributeResolver.php
@@ -10,7 +10,7 @@ use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
 class MediaAttributeResolver
 {
     /** @var array<class-string, array{collections: MediaCollection[], conversions: MediaConversion[]}> */
-    protected static array $cache = [];
+    private static array $cache = [];
 
     public function __construct(
         protected string $modelClass,
@@ -31,8 +31,8 @@ class MediaAttributeResolver
     /** @return array{collections: MediaCollection[], conversions: MediaConversion[]} */
     protected function parse(): array
     {
-        if (isset(static::$cache[$this->modelClass])) {
-            return static::$cache[$this->modelClass];
+        if (isset(self::$cache[$this->modelClass])) {
+            return self::$cache[$this->modelClass];
         }
 
         $reflection = new ReflectionClass($this->modelClass);
@@ -49,7 +49,7 @@ class MediaAttributeResolver
 
         $this->guardAgainstDuplicateCollections($collections);
 
-        return static::$cache[$this->modelClass] = [
+        return self::$cache[$this->modelClass] = [
             'collections' => $collections,
             'conversions' => $conversions,
         ];
@@ -71,6 +71,6 @@ class MediaAttributeResolver
 
     public static function clearCache(): void
     {
-        static::$cache = [];
+        self::$cache = [];
     }
 }

--- a/src/Support/MediaAttributes/MediaAttributeResolver.php
+++ b/src/Support/MediaAttributes/MediaAttributeResolver.php
@@ -5,8 +5,8 @@ namespace Spatie\MediaLibrary\Support\MediaAttributes;
 use ReflectionClass;
 use Spatie\MediaLibrary\Attributes\MediaCollection;
 use Spatie\MediaLibrary\Attributes\MediaConversion;
-use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
 use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
 use Spatie\MediaLibrary\MediaCollections\MediaCollection as MediaCollectionBuilder;
 
 class MediaAttributeResolver

--- a/tests/Attributes/AttributeCoexistenceTest.php
+++ b/tests/Attributes/AttributeCoexistenceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\Support\MediaAttributes\MediaAttributeResolver;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithAttributesAndMethods;
+
+beforeEach(fn () => MediaAttributeResolver::clearCache());
+
+it('merges attribute-defined and method-defined collections and conversions', function () {
+    $model = new TestModelWithAttributesAndMethods;
+
+    $collectionNames = $model->getRegisteredMediaCollections()->pluck('name')->all();
+
+    expect($collectionNames)->toContain('images', 'documents');
+
+    $model->registerAllMediaConversions();
+
+    $conversionNames = collect($model->mediaConversions)
+        ->map(fn (Conversion $conversion) => $conversion->getName())
+        ->all();
+
+    expect($conversionNames)->toContain('thumb', 'large');
+});

--- a/tests/Attributes/AttributeRegistrationTest.php
+++ b/tests/Attributes/AttributeRegistrationTest.php
@@ -1,7 +1,11 @@
 <?php
 
+use Spatie\MediaLibrary\Conversions\Conversion;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
 use Spatie\MediaLibrary\MediaCollections\MediaCollection;
 use Spatie\MediaLibrary\Support\MediaAttributes\MediaAttributeResolver;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionAttributeAndMethod;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionForUnknownCollection;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMediaAttributes;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithOverridingCollectionMethod;
 
@@ -25,3 +29,30 @@ it('lets a method-defined collection override a same-named attribute collection'
 
     expect($model->getMediaCollection('avatar')->singleFile)->toBeFalse();
 });
+
+it('registers conversions declared via attributes', function () {
+    $model = new TestModelWithMediaAttributes;
+
+    $model->registerAllMediaConversions();
+
+    $names = collect($model->mediaConversions)->map(fn (Conversion $conversion) => $conversion->getName())->all();
+
+    expect($names)->toContain('thumb', 'preview');
+});
+
+it('lets a method-defined conversion override a same-named attribute conversion', function () {
+    $model = new TestModelWithConversionAttributeAndMethod;
+
+    $model->registerAllMediaConversions();
+
+    $thumbs = collect($model->mediaConversions)->filter(fn (Conversion $conversion) => $conversion->getName() === 'thumb');
+
+    expect($thumbs)->toHaveCount(1)
+        ->and($thumbs->first()->shouldBeQueued())->toBeFalse();
+});
+
+it('throws when an attribute conversion references an unknown collection', function () {
+    $model = new TestModelWithConversionForUnknownCollection;
+
+    $model->registerAllMediaConversions();
+})->throws(InvalidMediaAttribute::class);

--- a/tests/Attributes/AttributeRegistrationTest.php
+++ b/tests/Attributes/AttributeRegistrationTest.php
@@ -8,6 +8,8 @@ use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionAttr
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionForUnknownCollection;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMediaAttributes;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithOverridingCollectionMethod;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionScopedToDefault;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithSameConversionNamePerCollection;
 
 beforeEach(fn () => MediaAttributeResolver::clearCache());
 
@@ -56,3 +58,29 @@ it('throws when an attribute conversion references an unknown collection', funct
 
     $model->registerAllMediaConversions();
 })->throws(InvalidMediaAttribute::class);
+
+it('keeps same-named conversions that target different collections', function () {
+    $model = new TestModelWithSameConversionNamePerCollection;
+
+    $model->registerAllMediaConversions();
+
+    $thumbs = collect($model->mediaConversions)->filter(fn (Conversion $conversion) => $conversion->getName() === 'thumb');
+
+    expect($thumbs)->toHaveCount(2);
+
+    $forA = $thumbs->first(fn (Conversion $conversion) => $conversion->shouldBePerformedOn('collA') && ! $conversion->shouldBePerformedOn('collB'));
+    $forB = $thumbs->first(fn (Conversion $conversion) => $conversion->shouldBePerformedOn('collB') && ! $conversion->shouldBePerformedOn('collA'));
+
+    expect($forA)->not->toBeNull()
+        ->and($forB)->not->toBeNull();
+});
+
+it('allows an attribute conversion scoped to the implicit default collection', function () {
+    $model = new TestModelWithConversionScopedToDefault;
+
+    $model->registerAllMediaConversions();
+
+    $names = collect($model->mediaConversions)->map(fn (Conversion $conversion) => $conversion->getName())->all();
+
+    expect($names)->toContain('square');
+});

--- a/tests/Attributes/AttributeRegistrationTest.php
+++ b/tests/Attributes/AttributeRegistrationTest.php
@@ -6,9 +6,9 @@ use Spatie\MediaLibrary\MediaCollections\MediaCollection;
 use Spatie\MediaLibrary\Support\MediaAttributes\MediaAttributeResolver;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionAttributeAndMethod;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionForUnknownCollection;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionScopedToDefault;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMediaAttributes;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithOverridingCollectionMethod;
-use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversionScopedToDefault;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithSameConversionNamePerCollection;
 
 beforeEach(fn () => MediaAttributeResolver::clearCache());

--- a/tests/Attributes/AttributeRegistrationTest.php
+++ b/tests/Attributes/AttributeRegistrationTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Spatie\MediaLibrary\MediaCollections\MediaCollection;
+use Spatie\MediaLibrary\Support\MediaAttributes\MediaAttributeResolver;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMediaAttributes;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithOverridingCollectionMethod;
+
+beforeEach(fn () => MediaAttributeResolver::clearCache());
+
+it('registers collections declared via attributes', function () {
+    $model = new TestModelWithMediaAttributes;
+
+    $collections = $model->getRegisteredMediaCollections();
+
+    expect($collections->pluck('name')->all())->toContain('avatar', 'downloads');
+
+    $avatar = $model->getMediaCollection('avatar');
+
+    expect($avatar)->toBeInstanceOf(MediaCollection::class)
+        ->and($avatar->singleFile)->toBeTrue();
+});
+
+it('lets a method-defined collection override a same-named attribute collection', function () {
+    $model = new TestModelWithOverridingCollectionMethod;
+
+    expect($model->getMediaCollection('avatar')->singleFile)->toBeFalse();
+});

--- a/tests/Attributes/InvalidMediaAttributeTest.php
+++ b/tests/Attributes/InvalidMediaAttributeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
+
+it('builds a duplicate collection message', function () {
+    $exception = InvalidMediaAttribute::duplicateCollection('avatar', 'App\\Models\\User');
+
+    expect($exception)->toBeInstanceOf(InvalidMediaAttribute::class)
+        ->and($exception->getMessage())->toContain('avatar')
+        ->and($exception->getMessage())->toContain('App\\Models\\User');
+});
+
+it('builds an unknown collection message', function () {
+    $exception = InvalidMediaAttribute::unknownCollection('thumb', 'missing', 'App\\Models\\User');
+
+    expect($exception->getMessage())->toContain('thumb')
+        ->and($exception->getMessage())->toContain('missing');
+});

--- a/tests/Attributes/MediaAttributeResolverTest.php
+++ b/tests/Attributes/MediaAttributeResolverTest.php
@@ -7,6 +7,8 @@ use Spatie\MediaLibrary\Support\MediaAttributes\MediaAttributeResolver;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMediaAttributes;
 
+afterEach(fn () => MediaAttributeResolver::clearCache());
+
 it('reads collection and conversion attributes from a model class', function () {
     $resolver = new MediaAttributeResolver(TestModelWithMediaAttributes::class);
 

--- a/tests/Attributes/MediaAttributeResolverTest.php
+++ b/tests/Attributes/MediaAttributeResolverTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Spatie\MediaLibrary\Attributes\MediaCollection;
+use Spatie\MediaLibrary\Attributes\MediaConversion;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
+use Spatie\MediaLibrary\Support\MediaAttributes\MediaAttributeResolver;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithMediaAttributes;
+
+it('reads collection and conversion attributes from a model class', function () {
+    $resolver = new MediaAttributeResolver(TestModelWithMediaAttributes::class);
+
+    expect($resolver->collectionAttributes())->toHaveCount(2)
+        ->and($resolver->collectionAttributes()[0])->toBeInstanceOf(MediaCollection::class)
+        ->and($resolver->conversionAttributes())->toHaveCount(2)
+        ->and($resolver->conversionAttributes()[0])->toBeInstanceOf(MediaConversion::class);
+});
+
+it('returns empty arrays for a model without attributes', function () {
+    $resolver = new MediaAttributeResolver(TestModel::class);
+
+    expect($resolver->collectionAttributes())->toBe([])
+        ->and($resolver->conversionAttributes())->toBe([]);
+});
+
+it('throws on a duplicate collection name', function () {
+    $resolver = new MediaAttributeResolver(TestModelWithDuplicateCollectionAttribute::class);
+
+    $resolver->collectionAttributes();
+})->throws(InvalidMediaAttribute::class);
+
+it('caches parsed attributes per class', function () {
+    $first = new MediaAttributeResolver(TestModelWithMediaAttributes::class);
+    $second = new MediaAttributeResolver(TestModelWithMediaAttributes::class);
+
+    expect($first->conversionAttributes())->toBe($second->conversionAttributes());
+});
+
+#[\Spatie\MediaLibrary\Attributes\MediaCollection(name: 'avatar')]
+#[\Spatie\MediaLibrary\Attributes\MediaCollection(name: 'avatar')]
+class TestModelWithDuplicateCollectionAttribute extends TestModel
+{
+}

--- a/tests/Attributes/MediaAttributeResolverTest.php
+++ b/tests/Attributes/MediaAttributeResolverTest.php
@@ -2,6 +2,7 @@
 
 use Spatie\MediaLibrary\Attributes\MediaCollection;
 use Spatie\MediaLibrary\Attributes\MediaConversion;
+use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidMediaAttribute;
 use Spatie\MediaLibrary\Support\MediaAttributes\MediaAttributeResolver;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
@@ -45,7 +46,7 @@ it('builds media collection builder objects from attributes', function () {
 
     expect($collections)->toHaveKey('avatar')
         ->and($collections)->toHaveKey('downloads')
-        ->and($collections['avatar'])->toBeInstanceOf(\Spatie\MediaLibrary\MediaCollections\MediaCollection::class)
+        ->and($collections['avatar'])->toBeInstanceOf(Spatie\MediaLibrary\MediaCollections\MediaCollection::class)
         ->and($collections['avatar']->name)->toBe('avatar')
         ->and($collections['avatar']->singleFile)->toBeTrue()
         ->and($collections['avatar']->fallbackUrls['default'])->toBe('/default.png');
@@ -61,14 +62,12 @@ it('builds conversion builder objects from attributes', function () {
     $thumb = collect($conversions)->firstWhere(fn ($conversion) => $conversion->getName() === 'thumb');
     $preview = collect($conversions)->firstWhere(fn ($conversion) => $conversion->getName() === 'preview');
 
-    expect($thumb)->toBeInstanceOf(\Spatie\MediaLibrary\Conversions\Conversion::class)
+    expect($thumb)->toBeInstanceOf(Conversion::class)
         ->and($thumb->shouldBePerformedOn('avatar'))->toBeTrue()
         ->and($thumb->shouldBePerformedOn('downloads'))->toBeFalse()
         ->and($preview->shouldBePerformedOn('downloads'))->toBeTrue();
 });
 
-#[\Spatie\MediaLibrary\Attributes\MediaCollection(name: 'avatar')]
-#[\Spatie\MediaLibrary\Attributes\MediaCollection(name: 'avatar')]
-class TestModelWithDuplicateCollectionAttribute extends TestModel
-{
-}
+#[MediaCollection(name: 'avatar')]
+#[MediaCollection(name: 'avatar')]
+class TestModelWithDuplicateCollectionAttribute extends TestModel {}

--- a/tests/Attributes/MediaAttributeResolverTest.php
+++ b/tests/Attributes/MediaAttributeResolverTest.php
@@ -38,6 +38,19 @@ it('caches parsed attributes per class', function () {
     expect($first->conversionAttributes())->toBe($second->conversionAttributes());
 });
 
+it('builds media collection builder objects from attributes', function () {
+    $resolver = new MediaAttributeResolver(TestModelWithMediaAttributes::class);
+
+    $collections = $resolver->toMediaCollections();
+
+    expect($collections)->toHaveKey('avatar')
+        ->and($collections)->toHaveKey('downloads')
+        ->and($collections['avatar'])->toBeInstanceOf(\Spatie\MediaLibrary\MediaCollections\MediaCollection::class)
+        ->and($collections['avatar']->name)->toBe('avatar')
+        ->and($collections['avatar']->singleFile)->toBeTrue()
+        ->and($collections['avatar']->fallbackUrls['default'])->toBe('/default.png');
+});
+
 #[\Spatie\MediaLibrary\Attributes\MediaCollection(name: 'avatar')]
 #[\Spatie\MediaLibrary\Attributes\MediaCollection(name: 'avatar')]
 class TestModelWithDuplicateCollectionAttribute extends TestModel

--- a/tests/Attributes/MediaAttributeResolverTest.php
+++ b/tests/Attributes/MediaAttributeResolverTest.php
@@ -51,6 +51,22 @@ it('builds media collection builder objects from attributes', function () {
         ->and($collections['avatar']->fallbackUrls['default'])->toBe('/default.png');
 });
 
+it('builds conversion builder objects from attributes', function () {
+    $resolver = new MediaAttributeResolver(TestModelWithMediaAttributes::class);
+
+    $conversions = $resolver->toConversions();
+
+    expect($conversions)->toHaveCount(2);
+
+    $thumb = collect($conversions)->firstWhere(fn ($conversion) => $conversion->getName() === 'thumb');
+    $preview = collect($conversions)->firstWhere(fn ($conversion) => $conversion->getName() === 'preview');
+
+    expect($thumb)->toBeInstanceOf(\Spatie\MediaLibrary\Conversions\Conversion::class)
+        ->and($thumb->shouldBePerformedOn('avatar'))->toBeTrue()
+        ->and($thumb->shouldBePerformedOn('downloads'))->toBeFalse()
+        ->and($preview->shouldBePerformedOn('downloads'))->toBeTrue();
+});
+
 #[\Spatie\MediaLibrary\Attributes\MediaCollection(name: 'avatar')]
 #[\Spatie\MediaLibrary\Attributes\MediaCollection(name: 'avatar')]
 class TestModelWithDuplicateCollectionAttribute extends TestModel

--- a/tests/Attributes/MediaCollectionAttributeTest.php
+++ b/tests/Attributes/MediaCollectionAttributeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Spatie\MediaLibrary\Attributes\MediaCollection;
+
+it('stores its configuration as readonly data', function () {
+    $attribute = new MediaCollection(
+        name: 'avatar',
+        singleFile: true,
+        onlyKeepLatest: 5,
+        acceptsMimeTypes: ['image/jpeg'],
+        disk: 'media',
+        conversionsDisk: 'media-conversions',
+        fallbackUrl: '/default.png',
+        fallbackPath: '/var/default.png',
+        responsiveImages: true,
+    );
+
+    expect($attribute->name)->toBe('avatar')
+        ->and($attribute->singleFile)->toBeTrue()
+        ->and($attribute->onlyKeepLatest)->toBe(5)
+        ->and($attribute->acceptsMimeTypes)->toBe(['image/jpeg'])
+        ->and($attribute->disk)->toBe('media')
+        ->and($attribute->conversionsDisk)->toBe('media-conversions')
+        ->and($attribute->fallbackUrl)->toBe('/default.png')
+        ->and($attribute->fallbackPath)->toBe('/var/default.png')
+        ->and($attribute->responsiveImages)->toBeTrue();
+});
+
+it('defaults optional configuration', function () {
+    $attribute = new MediaCollection(name: 'images');
+
+    expect($attribute->singleFile)->toBeFalse()
+        ->and($attribute->onlyKeepLatest)->toBeNull()
+        ->and($attribute->acceptsMimeTypes)->toBe([])
+        ->and($attribute->disk)->toBeNull()
+        ->and($attribute->responsiveImages)->toBeFalse();
+});

--- a/tests/Attributes/MediaConversionAttributeTest.php
+++ b/tests/Attributes/MediaConversionAttributeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Spatie\Image\Enums\Fit;
+use Spatie\MediaLibrary\Attributes\MediaConversion;
+
+it('stores its configuration as readonly data', function () {
+    $attribute = new MediaConversion(
+        name: 'thumb',
+        collections: ['avatar'],
+        width: 150,
+        height: 100,
+        fit: Fit::Crop,
+        format: 'webp',
+        quality: 80,
+        queued: false,
+        responsiveImages: true,
+        keepOriginalImageFormat: true,
+    );
+
+    expect($attribute->name)->toBe('thumb')
+        ->and($attribute->collections)->toBe(['avatar'])
+        ->and($attribute->width)->toBe(150)
+        ->and($attribute->height)->toBe(100)
+        ->and($attribute->fit)->toBe(Fit::Crop)
+        ->and($attribute->format)->toBe('webp')
+        ->and($attribute->quality)->toBe(80)
+        ->and($attribute->queued)->toBeFalse()
+        ->and($attribute->responsiveImages)->toBeTrue()
+        ->and($attribute->keepOriginalImageFormat)->toBeTrue();
+});
+
+it('defaults optional configuration', function () {
+    $attribute = new MediaConversion(name: 'thumb');
+
+    expect($attribute->collections)->toBe([])
+        ->and($attribute->width)->toBeNull()
+        ->and($attribute->height)->toBeNull()
+        ->and($attribute->fit)->toBeNull()
+        ->and($attribute->format)->toBeNull()
+        ->and($attribute->quality)->toBeNull()
+        ->and($attribute->queued)->toBeNull()
+        ->and($attribute->responsiveImages)->toBeFalse()
+        ->and($attribute->keepOriginalImageFormat)->toBeFalse();
+});

--- a/tests/TestSupport/TestModels/TestModelWithAttributesAndMethods.php
+++ b/tests/TestSupport/TestModels/TestModelWithAttributesAndMethods.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\Attributes\MediaCollection;
+use Spatie\MediaLibrary\Attributes\MediaConversion;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+#[MediaCollection(name: 'images')]
+#[MediaConversion(name: 'thumb', width: 150, height: 150)]
+class TestModelWithAttributesAndMethods extends TestModel
+{
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('documents');
+    }
+
+    public function registerMediaConversions(?Media $media = null): void
+    {
+        $this->addMediaConversion('large')->width(2000)->nonQueued();
+    }
+}

--- a/tests/TestSupport/TestModels/TestModelWithConversionAttributeAndMethod.php
+++ b/tests/TestSupport/TestModels/TestModelWithConversionAttributeAndMethod.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\Attributes\MediaConversion;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+#[MediaConversion(name: 'thumb', width: 150, queued: true)]
+class TestModelWithConversionAttributeAndMethod extends TestModel
+{
+    public function registerMediaConversions(?Media $media = null): void
+    {
+        // Re-declares `thumb` as non-queued, which must win over the attribute.
+        $this->addMediaConversion('thumb')->width(150)->nonQueued();
+    }
+}

--- a/tests/TestSupport/TestModels/TestModelWithConversionAttributeAndMethod.php
+++ b/tests/TestSupport/TestModels/TestModelWithConversionAttributeAndMethod.php
@@ -10,7 +10,6 @@ class TestModelWithConversionAttributeAndMethod extends TestModel
 {
     public function registerMediaConversions(?Media $media = null): void
     {
-        // Re-declares `thumb` as non-queued, which must win over the attribute.
         $this->addMediaConversion('thumb')->width(150)->nonQueued();
     }
 }

--- a/tests/TestSupport/TestModels/TestModelWithConversionForUnknownCollection.php
+++ b/tests/TestSupport/TestModels/TestModelWithConversionForUnknownCollection.php
@@ -5,6 +5,4 @@ namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
 use Spatie\MediaLibrary\Attributes\MediaConversion;
 
 #[MediaConversion(name: 'thumb', collections: ['does-not-exist'], width: 150)]
-class TestModelWithConversionForUnknownCollection extends TestModel
-{
-}
+class TestModelWithConversionForUnknownCollection extends TestModel {}

--- a/tests/TestSupport/TestModels/TestModelWithConversionForUnknownCollection.php
+++ b/tests/TestSupport/TestModels/TestModelWithConversionForUnknownCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\Attributes\MediaConversion;
+
+#[MediaConversion(name: 'thumb', collections: ['does-not-exist'], width: 150)]
+class TestModelWithConversionForUnknownCollection extends TestModel
+{
+}

--- a/tests/TestSupport/TestModels/TestModelWithConversionScopedToDefault.php
+++ b/tests/TestSupport/TestModels/TestModelWithConversionScopedToDefault.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\Attributes\MediaConversion;
+
+#[MediaConversion(name: 'square', collections: ['default'], width: 100)]
+class TestModelWithConversionScopedToDefault extends TestModel
+{
+}

--- a/tests/TestSupport/TestModels/TestModelWithConversionScopedToDefault.php
+++ b/tests/TestSupport/TestModels/TestModelWithConversionScopedToDefault.php
@@ -5,6 +5,4 @@ namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
 use Spatie\MediaLibrary\Attributes\MediaConversion;
 
 #[MediaConversion(name: 'square', collections: ['default'], width: 100)]
-class TestModelWithConversionScopedToDefault extends TestModel
-{
-}
+class TestModelWithConversionScopedToDefault extends TestModel {}

--- a/tests/TestSupport/TestModels/TestModelWithMediaAttributes.php
+++ b/tests/TestSupport/TestModels/TestModelWithMediaAttributes.php
@@ -12,4 +12,5 @@ use Spatie\MediaLibrary\Attributes\MediaConversion;
 #[MediaConversion(name: 'preview', width: 500)]
 class TestModelWithMediaAttributes extends TestModel
 {
+    public function registerMediaCollections(): void {}
 }

--- a/tests/TestSupport/TestModels/TestModelWithMediaAttributes.php
+++ b/tests/TestSupport/TestModels/TestModelWithMediaAttributes.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\Image\Enums\Fit;
+use Spatie\MediaLibrary\Attributes\MediaCollection;
+use Spatie\MediaLibrary\Attributes\MediaConversion;
+
+#[MediaCollection(name: 'avatar', singleFile: true, fallbackUrl: '/default.png')]
+#[MediaCollection(name: 'downloads')]
+#[MediaConversion(name: 'thumb', collections: ['avatar'], width: 150, height: 150, fit: Fit::Crop, format: 'webp')]
+#[MediaConversion(name: 'preview', width: 500)]
+class TestModelWithMediaAttributes extends TestModel
+{
+}

--- a/tests/TestSupport/TestModels/TestModelWithOverridingCollectionMethod.php
+++ b/tests/TestSupport/TestModels/TestModelWithOverridingCollectionMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\Attributes\MediaCollection;
+
+#[MediaCollection(name: 'avatar', singleFile: true)]
+class TestModelWithOverridingCollectionMethod extends TestModel
+{
+    public function registerMediaCollections(): void
+    {
+        // Re-declares `avatar` without singleFile, which must win over the attribute.
+        $this->addMediaCollection('avatar');
+    }
+}

--- a/tests/TestSupport/TestModels/TestModelWithOverridingCollectionMethod.php
+++ b/tests/TestSupport/TestModels/TestModelWithOverridingCollectionMethod.php
@@ -9,7 +9,6 @@ class TestModelWithOverridingCollectionMethod extends TestModel
 {
     public function registerMediaCollections(): void
     {
-        // Re-declares `avatar` without singleFile, which must win over the attribute.
         $this->addMediaCollection('avatar');
     }
 }

--- a/tests/TestSupport/TestModels/TestModelWithSameConversionNamePerCollection.php
+++ b/tests/TestSupport/TestModels/TestModelWithSameConversionNamePerCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport\TestModels;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class TestModelWithSameConversionNamePerCollection extends TestModel
+{
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('collA')->registerMediaConversions(function (?Media $media = null) {
+            $this->addMediaConversion('thumb')->width(100);
+        });
+
+        $this->addMediaCollection('collB')->registerMediaConversions(function (?Media $media = null) {
+            $this->addMediaConversion('thumb')->width(500);
+        });
+    }
+}


### PR DESCRIPTION
## A new major version of Media Library

This is the first PR toward a new major version of Media Library. The new major focuses on more ergonomic configuration and better control over what happens after you add a file. Breaking changes are on the table.

This PR ships the first headline feature (attribute-based configuration). A second feature (derivative completion callbacks) is in development in #3944 and previewed below. **Feedback and feature ideas are very welcome** (see the bottom of this description).

## Feature 1: Attribute-based configuration (in this PR)

Declare media collections and conversions with PHP attributes, as an alternative to (and coexisting with) `registerMediaCollections()` / `registerMediaConversions()`.

```php
use Spatie\Image\Enums\Fit;
use Spatie\MediaLibrary\Attributes\MediaCollection;
use Spatie\MediaLibrary\Attributes\MediaConversion;

#[MediaCollection(name: 'avatar', singleFile: true, fallbackUrl: '/default-avatar.png')]
#[MediaConversion(name: 'thumb', collections: ['avatar'], width: 150, height: 150, fit: Fit::Crop, format: 'webp')]
class User extends Model implements HasMedia
{
    use InteractsWithMedia;
}
```

### More examples

Both attributes are repeatable, so declare as many as you need.

A conversion with no `collections` applies to every collection on the model.

```php
#[MediaCollection(name: 'images')]
#[MediaCollection(name: 'banners')]
#[MediaConversion(name: 'optimized', width: 2000, format: 'webp', quality: 80)]
class Page extends Model implements HasMedia
{
    use InteractsWithMedia;
}
```

Collections can carry their own constraints, and conversions can opt into responsive images or run outside the queue.

```php
#[MediaCollection(name: 'documents', onlyKeepLatest: 10, acceptsMimeTypes: ['application/pdf'])]
#[MediaCollection(name: 'photos', disk: 'media', conversionsDisk: 'media', responsiveImages: true)]
#[MediaConversion(name: 'hero', collections: ['photos'], width: 1600, responsiveImages: true, queued: false)]
class Article extends Model implements HasMedia
{
    use InteractsWithMedia;
}
```

Attributes and methods combine. The static configuration lives in attributes, while the dynamic tail (the full spatie/image manipulation set, per-media conversions, `acceptsFile()` closures) stays in methods. A method declaration overrides a same-named attribute.

```php
#[MediaCollection(name: 'gallery')]
#[MediaConversion(name: 'thumb', collections: ['gallery'], width: 150, height: 150)]
class Product extends Model implements HasMedia
{
    use InteractsWithMedia;

    public function registerMediaConversions(?Media $media = null): void
    {
        $this->addMediaConversion('watermarked')
            ->watermark(storage_path('logo.png'));
    }
}
```

### How it works

- **Repeatable, class-level attributes.** `#[MediaCollection]` and `#[MediaConversion]` carry plain config data. A `MediaAttributeResolver` reads them via reflection (cached per model class) and turns them into the same builder objects the methods already produce.
- **Coexistence and precedence.** Attributes and the existing methods can be combined. Attributes resolve first, and a collection or conversion declared in a method overrides a same-named attribute one.
- **The dynamic tail stays in methods.** The attribute surface covers geometry, format, and the collection-level toggles (the common case).
- **Validation.** Clear exceptions for a conversion referencing an unknown collection and for duplicate collection names.
- **Argument surface.** `#[MediaCollection]`: `name`, `singleFile`, `onlyKeepLatest`, `acceptsMimeTypes`, `disk`, `conversionsDisk`, `fallbackUrl`, `fallbackPath`, `responsiveImages`. `#[MediaConversion]`: `name`, `collections`, `width`, `height`, `fit`, `format`, `quality`, `queued`, `responsiveImages`, `keepOriginalImageFormat`.
- Docs: `docs/basic-usage/configuring-with-attributes.md`. Full suite green.

## Feature 2: Derivative completion callbacks, `then()` / `catch()` (#3944)

Run code after a media item's conversions and responsive images finish generating, with failure handling. This mirrors the `then` / `catch` ergonomics of `spatie/laravel-pdf`, adapted to how Media Library generates derivatives.

```php
use Spatie\MediaLibrary\MediaCollections\Models\Media;

$model->addMedia($request->file('avatar'))
    ->then(function (Media $media) {
        // runs after the derivatives are generated
    })
    ->catch(function (Throwable $exception) {
        // runs if derivative generation fails
    })
    ->toMediaCollection('avatars');
```

Using `then()` runs the derivatives on the queue and fires the callback when they finish. With the `sync` queue driver it runs inline. `toMediaCollection()` still returns the `Media` synchronously. See #3944.

## Feedback welcome

The new major version is taking shape and nothing is locked in yet. If you have feature ideas, API feedback, or use cases the current design does not cover, please comment here or open a discussion. We would love your input on what the next version of Media Library should include.