### PR TITLE
Run code after conversions with then() / catch() (new major version)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "illuminate/database": "^10.2|^11.0|^12.0|^13.0",
         "illuminate/pipeline": "^10.2|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.2|^11.0|^12.0|^13.0",
+        "laravel/serializable-closure": "^1.3|^2.0",
         "maennchen/zipstream-php": "^3.1",
         "spatie/image": "^3.3.2",
         "spatie/laravel-package-tools": "^1.16.1",

--- a/docs/advanced-usage/running-code-after-conversions.md
+++ b/docs/advanced-usage/running-code-after-conversions.md
@@ -33,9 +33,11 @@ With the `sync` queue driver the derivatives run inline, and the callback still 
 
 If a media item has no conversions and no responsive images, the `then` callback fires immediately with the media.
 
-## Failure handling on the sync driver
+## Failure handling
 
-On a real queue, a failing derivative is handled in the worker, and your `catch` callback runs there. On the `sync` driver, the callback still runs, but the underlying exception also propagates out of `toMediaCollection()` (this is how the sync queue behaves). In production, where derivatives run on a real queue, this propagation does not happen.
+If a derivative fails to generate, your `catch` callback runs with the throwable, on the queue worker when queued, or inline when using the `sync` driver. The behavior is the same in both cases.
+
+If you do not register a `catch` callback, a failing derivative surfaces as a regular failed job (or, on the `sync` driver, the exception propagates as usual).
 
 ## Serialization constraint
 

--- a/docs/advanced-usage/running-code-after-conversions.md
+++ b/docs/advanced-usage/running-code-after-conversions.md
@@ -1,0 +1,42 @@
+---
+title: Running code after conversions
+weight: 20
+---
+
+When you add media, you can register a callback that runs after the media item's derivatives (its conversions and responsive images) have been generated, and a callback to handle failures.
+
+```php
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Throwable;
+
+$model->addMedia($request->file('avatar'))
+    ->then(function (Media $media) {
+        // Runs after the derivatives have been generated.
+    })
+    ->catch(function (Throwable $exception) {
+        // Runs if derivative generation fails.
+    })
+    ->toMediaCollection('avatars');
+```
+
+The `then` callback receives the `Media`. The `catch` callback receives the `Throwable`.
+
+## Derivatives run on the queue
+
+Using `then()` runs the media's derivatives on the queue, and the callback fires once they finish. This is true even for conversions that would otherwise run inline. It is the same idea as queueing the work and continuing afterwards.
+
+With the `sync` queue driver the derivatives run inline, and the callback still fires. This makes the feature behave predictably in local development and in tests.
+
+`toMediaCollection()` still returns the `Media` synchronously. The callbacks are additive and do not change that.
+
+## Media without derivatives
+
+If a media item has no conversions and no responsive images, the `then` callback fires immediately with the media.
+
+## Failure handling on the sync driver
+
+On a real queue, a failing derivative is handled in the worker, and your `catch` callback runs there. On the `sync` driver, the callback still runs, but the underlying exception also propagates out of `toMediaCollection()` (this is how the sync queue behaves). In production, where derivatives run on a real queue, this propagation does not happen.
+
+## Serialization constraint
+
+The callbacks are serialized so they can run on the queue. Because of this they cannot capture state that is not serializable, such as a database connection or an open file handle. Capture simple, serializable values (ids, strings, arrays) and resolve services inside the callback.

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -2,9 +2,12 @@
 
 namespace Spatie\MediaLibrary\Conversions;
 
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use RuntimeException;
+use Spatie\MediaLibrary\Conversions\Jobs\RunMediaCallbacksJob;
+use Throwable;
 use Spatie\MediaLibrary\Conversions\Actions\PerformConversionAction;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
 use Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob;
@@ -22,6 +25,12 @@ class FileManipulator
         bool $withResponsiveImages = false,
         bool $queueAll = false,
     ): void {
+        if ($media->mediaDerivativeCallbacks) {
+            $this->dispatchCallbackChain($media);
+
+            return;
+        }
+
         if (! $this->canConvertMedia($media)) {
             return;
         }
@@ -178,6 +187,50 @@ class FileManipulator
             : dispatch($job);
 
         return $this;
+    }
+
+    protected function dispatchCallbackChain(Media $media): void
+    {
+        $callbacks = $media->mediaDerivativeCallbacks;
+
+        $jobs = [];
+
+        if ($this->canConvertMedia($media)) {
+            $conversions = ConversionCollection::createForMedia($media)
+                ->filter(fn (Conversion $conversion) => $conversion->shouldBePerformedOn($media->collection_name));
+
+            if ($conversions->isNotEmpty()) {
+                $performConversionsJobClass = config(
+                    'media-library.jobs.perform_conversions',
+                    PerformConversionsJob::class
+                );
+
+                $jobs[] = new $performConversionsJobClass($conversions, $media);
+            }
+
+            if ($callbacks['responsiveImages']) {
+                $generateResponsiveImagesJobClass = config(
+                    'media-library.jobs.generate_responsive_images',
+                    GenerateResponsiveImagesJob::class
+                );
+
+                $jobs[] = new $generateResponsiveImagesJobClass($media);
+            }
+        }
+
+        $jobs[] = new RunMediaCallbacksJob($callbacks['then'], $media);
+
+        $chain = Bus::chain($jobs)
+            ->onConnection(config('media-library.queue_connection_name'))
+            ->onQueue($callbacks['queue']);
+
+        if ($catchCallback = $callbacks['catch']) {
+            $chain->catch(function (Throwable $exception) use ($catchCallback) {
+                ($catchCallback->getClosure())($exception);
+            });
+        }
+
+        $chain->dispatch();
     }
 
     protected function canConvertMedia(Media $media): bool

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\MediaLibrary\Conversions;
 
-use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use RuntimeException;
@@ -14,7 +13,6 @@ use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob;
 use Spatie\MediaLibrary\Support\TemporaryDirectory;
-use Throwable;
 
 class FileManipulator
 {
@@ -26,7 +24,7 @@ class FileManipulator
         bool $queueAll = false,
     ): void {
         if ($media->mediaDerivativeCallbacks) {
-            $this->dispatchCallbackChain($media);
+            $this->dispatchMediaCallbacks($media);
 
             return;
         }
@@ -189,11 +187,11 @@ class FileManipulator
         return $this;
     }
 
-    protected function dispatchCallbackChain(Media $media): void
+    protected function dispatchMediaCallbacks(Media $media): void
     {
         $callbacks = $media->mediaDerivativeCallbacks;
 
-        $jobs = [];
+        $derivativeJobs = [];
 
         if ($this->canConvertMedia($media)) {
             $conversions = ConversionCollection::createForMedia($media)
@@ -205,7 +203,7 @@ class FileManipulator
                     PerformConversionsJob::class
                 );
 
-                $jobs[] = new $performConversionsJobClass($conversions, $media);
+                $derivativeJobs[] = new $performConversionsJobClass($conversions, $media);
             }
 
             if ($callbacks['responsiveImages']) {
@@ -214,23 +212,15 @@ class FileManipulator
                     GenerateResponsiveImagesJob::class
                 );
 
-                $jobs[] = new $generateResponsiveImagesJobClass($media);
+                $derivativeJobs[] = new $generateResponsiveImagesJobClass($media);
             }
         }
 
-        $jobs[] = new RunMediaCallbacksJob($callbacks['then'], $media);
-
-        $chain = Bus::chain($jobs)
+        $job = (new RunMediaCallbacksJob($derivativeJobs, $callbacks['then'], $callbacks['catch'], $media))
             ->onConnection(config('media-library.queue_connection_name'))
             ->onQueue($callbacks['queue']);
 
-        if ($catchCallback = $callbacks['catch']) {
-            $chain->catch(function (Throwable $exception) use ($catchCallback) {
-                ($catchCallback->getClosure())($exception);
-            });
-        }
-
-        $chain->dispatch();
+        dispatch($job);
     }
 
     protected function canConvertMedia(Media $media): bool

--- a/src/Conversions/FileManipulator.php
+++ b/src/Conversions/FileManipulator.php
@@ -6,15 +6,15 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use RuntimeException;
-use Spatie\MediaLibrary\Conversions\Jobs\RunMediaCallbacksJob;
-use Throwable;
 use Spatie\MediaLibrary\Conversions\Actions\PerformConversionAction;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
 use Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob;
+use Spatie\MediaLibrary\Conversions\Jobs\RunMediaCallbacksJob;
 use Spatie\MediaLibrary\MediaCollections\Filesystem;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob;
 use Spatie\MediaLibrary\Support\TemporaryDirectory;
+use Throwable;
 
 class FileManipulator
 {

--- a/src/Conversions/Jobs/RunMediaCallbacksJob.php
+++ b/src/Conversions/Jobs/RunMediaCallbacksJob.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\MediaLibrary\Conversions\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Laravel\SerializableClosure\SerializableClosure;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class RunMediaCallbacksJob implements ShouldQueue
+{
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public $deleteWhenMissingModels = true;
+
+    public function __construct(
+        protected ?SerializableClosure $thenCallback,
+        protected Media $media,
+    ) {}
+
+    public function handle(): void
+    {
+        if (! $this->thenCallback) {
+            return;
+        }
+
+        ($this->thenCallback->getClosure())($this->media);
+    }
+}

--- a/src/Conversions/Jobs/RunMediaCallbacksJob.php
+++ b/src/Conversions/Jobs/RunMediaCallbacksJob.php
@@ -8,6 +8,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Laravel\SerializableClosure\SerializableClosure;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Throwable;
 
 class RunMediaCallbacksJob implements ShouldQueue
 {
@@ -17,17 +18,32 @@ class RunMediaCallbacksJob implements ShouldQueue
 
     public $deleteWhenMissingModels = true;
 
+    /**
+     * @param  array<int, object>  $derivativeJobs
+     */
     public function __construct(
+        protected array $derivativeJobs,
         protected ?SerializableClosure $thenCallback,
+        protected ?SerializableClosure $catchCallback,
         protected Media $media,
     ) {}
 
     public function handle(): void
     {
-        if (! $this->thenCallback) {
-            return;
-        }
+        try {
+            foreach ($this->derivativeJobs as $derivativeJob) {
+                app()->call([$derivativeJob, 'handle']);
+            }
 
-        ($this->thenCallback->getClosure())($this->media);
+            if ($this->thenCallback) {
+                ($this->thenCallback->getClosure())($this->media);
+            }
+        } catch (Throwable $exception) {
+            if (! $this->catchCallback) {
+                throw $exception;
+            }
+
+            ($this->catchCallback->getClosure())($exception);
+        }
     }
 }

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -4,9 +4,9 @@ namespace Spatie\MediaLibrary\MediaCollections;
 
 use Closure;
 use Illuminate\Database\Eloquent\Model;
-use Laravel\SerializableClosure\SerializableClosure;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Traits\Macroable;
+use Laravel\SerializableClosure\SerializableClosure;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Image as ImageGenerator;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskCannotBeAccessed;

--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -4,6 +4,7 @@ namespace Spatie\MediaLibrary\MediaCollections;
 
 use Closure;
 use Illuminate\Database\Eloquent\Model;
+use Laravel\SerializableClosure\SerializableClosure;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Traits\Macroable;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Image as ImageGenerator;
@@ -53,6 +54,10 @@ class FileAdder
     protected string $diskName = '';
 
     protected ?string $onQueue = null;
+
+    protected ?SerializableClosure $thenCallback = null;
+
+    protected ?SerializableClosure $catchCallback = null;
 
     protected ?int $fileSize = null;
 
@@ -221,6 +226,26 @@ class FileAdder
     public function onQueue(?string $queue = null): self
     {
         $this->onQueue = $queue;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function then(Closure $callback): self
+    {
+        $this->thenCallback = new SerializableClosure($callback);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function catch(Closure $callback): self
+    {
+        $this->catchCallback = new SerializableClosure($callback);
 
         return $this;
     }
@@ -602,6 +627,15 @@ class FileAdder
             $media->setConnection($model->getConnectionName());
         }
 
+        if ($this->thenCallback || $this->catchCallback) {
+            $media->mediaDerivativeCallbacks = [
+                'then' => $this->thenCallback,
+                'catch' => $this->catchCallback,
+                'responsiveImages' => $this->generateResponsiveImages,
+                'queue' => $this->onQueue ?? config('media-library.queue_name'),
+            ];
+        }
+
         $model->media()->save($media);
 
         if ($fileAdder->file instanceof RemoteFile) {
@@ -626,7 +660,7 @@ class FileAdder
             }
         }
 
-        if ($this->generateResponsiveImages && (new ImageGenerator)->canConvert($media)) {
+        if (! $media->mediaDerivativeCallbacks && $this->generateResponsiveImages && (new ImageGenerator)->canConvert($media)) {
             $generateResponsiveImagesJobClass = config('media-library.jobs.generate_responsive_images', GenerateResponsiveImagesJob::class);
 
             $job = new $generateResponsiveImagesJobClass($media);

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -87,6 +87,9 @@ class Media extends Model implements Attachable, Htmlable, Responsable
 
     protected int $streamChunkSize = (1024 * 1024); // default to 1MB chunks.
 
+    /** @var array{then: ?\Laravel\SerializableClosure\SerializableClosure, catch: ?\Laravel\SerializableClosure\SerializableClosure, responsiveImages: bool, queue: ?string}|null */
+    public ?array $mediaDerivativeCallbacks = null;
+
     /** @phpstan-ignore method.childReturnType */
     public function newCollection(array $models = []): MediaCollection
     {

--- a/src/MediaCollections/Models/Media.php
+++ b/src/MediaCollections/Models/Media.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Laravel\SerializableClosure\SerializableClosure;
 use Spatie\MediaLibrary\Conversions\Conversion;
 use Spatie\MediaLibrary\Conversions\ConversionCollection;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
@@ -87,7 +88,7 @@ class Media extends Model implements Attachable, Htmlable, Responsable
 
     protected int $streamChunkSize = (1024 * 1024); // default to 1MB chunks.
 
-    /** @var array{then: ?\Laravel\SerializableClosure\SerializableClosure, catch: ?\Laravel\SerializableClosure\SerializableClosure, responsiveImages: bool, queue: ?string}|null */
+    /** @var array{then: ?SerializableClosure, catch: ?SerializableClosure, responsiveImages: bool, queue: ?string}|null */
     public ?array $mediaDerivativeCallbacks = null;
 
     /** @phpstan-ignore method.childReturnType */

--- a/tests/Callbacks/MediaCallbacksTest.php
+++ b/tests/Callbacks/MediaCallbacksTest.php
@@ -4,6 +4,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
 use Spatie\MediaLibrary\Tests\TestSupport\ThrowingConversionsJob;
+use Throwable;
 
 beforeEach(function () {
     config()->set('queue.default', 'sync');
@@ -44,20 +45,16 @@ it('runs the catch callback when a derivative job fails', function () {
 
     $model = TestModelWithConversion::create(['name' => 'test']);
 
-    try {
-        $model
-            ->addMedia($this->getTestJpg())
-            ->preservingOriginal()
-            ->then(function (Media $media) {
-                cache()->put('then-called', true);
-            })
-            ->catch(function (Throwable $exception) {
-                cache()->put('catch-message', $exception->getMessage());
-            })
-            ->toMediaCollection();
-    } catch (Throwable) {
-        // Under the sync driver the exception propagates after the catch callback fires.
-    }
+    $model
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->then(function (Media $media) {
+            cache()->put('then-called', true);
+        })
+        ->catch(function (Throwable $exception) {
+            cache()->put('catch-message', $exception->getMessage());
+        })
+        ->toMediaCollection();
 
     expect(cache()->get('catch-message'))->toBe('Conversion failed on purpose')
         ->and(cache()->get('then-called'))->toBeNull();

--- a/tests/Callbacks/MediaCallbacksTest.php
+++ b/tests/Callbacks/MediaCallbacksTest.php
@@ -3,6 +3,7 @@
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
+use Spatie\MediaLibrary\Tests\TestSupport\ThrowingConversionsJob;
 
 beforeEach(function () {
     config()->set('queue.default', 'sync');
@@ -36,4 +37,43 @@ it('runs the then callback immediately for media without derivatives', function 
         ->toMediaCollection();
 
     expect(cache()->get('then-called'))->toBeTrue();
+});
+
+it('runs the catch callback when a derivative job fails', function () {
+    config()->set('media-library.jobs.perform_conversions', ThrowingConversionsJob::class);
+
+    $model = TestModelWithConversion::create(['name' => 'test']);
+
+    try {
+        $model
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->then(function (Media $media) {
+                cache()->put('then-called', true);
+            })
+            ->catch(function (Throwable $exception) {
+                cache()->put('catch-message', $exception->getMessage());
+            })
+            ->toMediaCollection();
+    } catch (Throwable) {
+        // Under the sync driver the exception propagates after the catch callback fires.
+    }
+
+    expect(cache()->get('catch-message'))->toBe('Conversion failed on purpose')
+        ->and(cache()->get('then-called'))->toBeNull();
+});
+
+it('runs the then callback after responsive images', function () {
+    $model = TestModelWithConversion::create(['name' => 'test']);
+
+    $model
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withResponsiveImages()
+        ->then(function (Media $media) {
+            cache()->put('then-after-responsive', $media->getKey());
+        })
+        ->toMediaCollection();
+
+    expect(cache()->get('then-after-responsive'))->not->toBeNull();
 });

--- a/tests/Callbacks/MediaCallbacksTest.php
+++ b/tests/Callbacks/MediaCallbacksTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModelWithConversion;
+
+beforeEach(function () {
+    config()->set('queue.default', 'sync');
+    cache()->flush();
+});
+
+it('runs the then callback after conversions, receiving the media', function () {
+    $model = TestModelWithConversion::create(['name' => 'test']);
+
+    $media = $model
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->then(function (Media $media) {
+            cache()->put('then-called-with', $media->getKey());
+        })
+        ->toMediaCollection();
+
+    expect($media)->toBeInstanceOf(Media::class)
+        ->and(cache()->get('then-called-with'))->toBe($media->getKey());
+});
+
+it('runs the then callback immediately for media without derivatives', function () {
+    $model = TestModel::create(['name' => 'test']);
+
+    $media = $model
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->then(function (Media $media) {
+            cache()->put('then-called', true);
+        })
+        ->toMediaCollection();
+
+    expect(cache()->get('then-called'))->toBeTrue();
+});

--- a/tests/Callbacks/RunMediaCallbacksJobTest.php
+++ b/tests/Callbacks/RunMediaCallbacksJobTest.php
@@ -3,30 +3,91 @@
 use Laravel\SerializableClosure\SerializableClosure;
 use Spatie\MediaLibrary\Conversions\Jobs\RunMediaCallbacksJob;
 use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
+use Throwable;
 
-it('runs the then closure with the media', function () {
+it('runs the derivative jobs and then the then closure with the media', function () {
     $model = TestModel::create(['name' => 'test']);
     $media = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
 
-    cache()->forget('then-media-id');
+    cache()->forget('order');
+
+    $derivativeJob = new class
+    {
+        public function handle(): void
+        {
+            cache()->put('order', ['derivative']);
+        }
+    };
 
     $job = new RunMediaCallbacksJob(
+        [$derivativeJob],
         new SerializableClosure(function ($media) {
+            cache()->put('order', [...cache()->get('order', []), 'then']);
             cache()->put('then-media-id', $media->getKey());
+        }),
+        null,
+        $media,
+    );
+
+    $job->handle();
+
+    expect(cache()->get('order'))->toBe(['derivative', 'then'])
+        ->and(cache()->get('then-media-id'))->toBe($media->getKey());
+});
+
+it('runs the catch closure when a derivative job throws, and skips the then closure', function () {
+    $model = TestModel::create(['name' => 'test']);
+    $media = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
+
+    cache()->flush();
+
+    $throwingJob = new class
+    {
+        public function handle(): void
+        {
+            throw new RuntimeException('boom');
+        }
+    };
+
+    $job = new RunMediaCallbacksJob(
+        [$throwingJob],
+        new SerializableClosure(function () {
+            cache()->put('then-called', true);
+        }),
+        new SerializableClosure(function (Throwable $exception) {
+            cache()->put('catch-message', $exception->getMessage());
         }),
         $media,
     );
 
     $job->handle();
 
-    expect(cache()->get('then-media-id'))->toBe($media->getKey());
+    expect(cache()->get('catch-message'))->toBe('boom')
+        ->and(cache()->get('then-called'))->toBeNull();
 });
 
-it('does nothing when the then closure is null', function () {
+it('rethrows when a derivative job throws and there is no catch closure', function () {
     $model = TestModel::create(['name' => 'test']);
     $media = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
 
-    $job = new RunMediaCallbacksJob(null, $media);
+    $throwingJob = new class
+    {
+        public function handle(): void
+        {
+            throw new RuntimeException('boom');
+        }
+    };
+
+    $job = new RunMediaCallbacksJob([$throwingJob], null, null, $media);
+
+    $job->handle();
+})->throws(RuntimeException::class, 'boom');
+
+it('does nothing when there are no derivative jobs and no then closure', function () {
+    $model = TestModel::create(['name' => 'test']);
+    $media = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
+
+    $job = new RunMediaCallbacksJob([], null, null, $media);
 
     $job->handle();
 })->throwsNoExceptions();

--- a/tests/Callbacks/RunMediaCallbacksJobTest.php
+++ b/tests/Callbacks/RunMediaCallbacksJobTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Laravel\SerializableClosure\SerializableClosure;
+use Spatie\MediaLibrary\Conversions\Jobs\RunMediaCallbacksJob;
+use Spatie\MediaLibrary\Tests\TestSupport\TestModels\TestModel;
+
+it('runs the then closure with the media', function () {
+    $model = TestModel::create(['name' => 'test']);
+    $media = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
+
+    cache()->forget('then-media-id');
+
+    $job = new RunMediaCallbacksJob(
+        new SerializableClosure(function ($media) {
+            cache()->put('then-media-id', $media->getKey());
+        }),
+        $media,
+    );
+
+    $job->handle();
+
+    expect(cache()->get('then-media-id'))->toBe($media->getKey());
+});
+
+it('does nothing when the then closure is null', function () {
+    $model = TestModel::create(['name' => 'test']);
+    $media = $model->addMedia($this->getTestJpg())->preservingOriginal()->toMediaCollection();
+
+    $job = new RunMediaCallbacksJob(null, $media);
+
+    $job->handle();
+})->throwsNoExceptions();

--- a/tests/TestSupport/ThrowingConversionsJob.php
+++ b/tests/TestSupport/ThrowingConversionsJob.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\MediaLibrary\Tests\TestSupport;
+
+use RuntimeException;
+use Spatie\MediaLibrary\Conversions\FileManipulator;
+use Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob;
+
+class ThrowingConversionsJob extends PerformConversionsJob
+{
+    public function handle(FileManipulator $fileManipulator): bool
+    {
+        throw new RuntimeException('Conversion failed on purpose');
+    }
+}


### PR DESCRIPTION
## A new major version of Media Library

This is the companion PR to #3943, the second headline feature of the new major version of Media Library. **Feedback and feature ideas are very welcome** (see the bottom).

## Run code after a media item's derivatives are generated

You can now register a callback that runs after a media item's derivatives (its conversions and responsive images) have been generated, plus a callback for failures. This mirrors the `then` / `catch` ergonomics of `spatie/laravel-pdf`, adapted to how Media Library generates derivatives.

```php
use Spatie\MediaLibrary\MediaCollections\Models\Media;
use Throwable;

$model->addMedia($request->file('avatar'))
    ->then(function (Media $media) {
        // Runs after the derivatives have been generated.
    })
    ->catch(function (Throwable $exception) {
        // Runs if derivative generation fails.
    })
    ->toMediaCollection('avatars');
```

The `then` callback receives the `Media`. The `catch` callback receives the `Throwable`.

## How it works

- `then()` / `catch()` store the callbacks as `SerializableClosure`s on the `FileAdder`.
- When set, all of the media's derivative work (the conversions job, and the responsive images job when enabled) plus a final callback job are dispatched as one `Bus::chain(...)->catch(...)`. The `then` closure runs in the final job, the chain `catch` runs the `catch` closure.
- A `Bus::chain` is used rather than a batch, so no `job_batches` migration is required.

## Behavior

- **Derivatives run on the queue.** Using `then()` runs the derivatives on the queue and fires the callback when they finish, even for conversions that would otherwise run inline. With the `sync` queue driver they run inline and the callback still fires.
- **`toMediaCollection()` still returns the `Media` synchronously.** The callbacks are additive.
- **No derivatives:** if a media item produces no conversions and no responsive images, `then` fires immediately with the media.
- **Failure handling:** on a real queue, a failing derivative is handled in the worker and your `catch` runs there. On the `sync` driver, `catch` still runs, but the underlying exception also propagates out of `toMediaCollection()` (this is how the sync queue behaves).
- **Serialization constraint:** callbacks are serialized to run on the queue, so they cannot capture non serializable state (resolve services inside the callback).

## Notes

- Adds `laravel/serializable-closure` to require (already present transitively via the framework).
- Docs added at `docs/advanced-usage/running-code-after-conversions.md`.
- Full suite green.

## Feedback welcome

The new major version is taking shape and nothing is locked in yet. If you have feature ideas, API feedback, or use cases this design does not cover, please comment here or open a discussion. We would love your input on the next version of Media Library.