### PR TITLE
Strip path-traversal segments from zip_filename_prefix

### DIFF
--- a/src/Support/MediaStream.php
+++ b/src/Support/MediaStream.php
@@ -132,6 +132,18 @@ class MediaStream implements Responsable
 
     protected function getZipFileNamePrefix(Collection $mediaItems, int $currentIndex): string
     {
-        return $mediaItems[$currentIndex]->hasCustomProperty('zip_filename_prefix') ? $mediaItems[$currentIndex]->getCustomProperty('zip_filename_prefix') : '';
+        $media = $mediaItems[$currentIndex];
+
+        if (! $media->hasCustomProperty('zip_filename_prefix')) {
+            return '';
+        }
+
+        $prefix = str_replace('\\', '/', (string) $media->getCustomProperty('zip_filename_prefix'));
+
+        $prefix = collect(explode('/', $prefix))
+            ->reject(fn (string $segment) => $segment === '.' || $segment === '..')
+            ->implode('/');
+
+        return ltrim($prefix, '/');
     }
 }

--- a/tests/Support/MediaStreamTest.php
+++ b/tests/Support/MediaStreamTest.php
@@ -139,6 +139,29 @@ test('media with zip file folder prefix property saved in correct zip folder and
     $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'folder/subfolder/test (1).jpg');
 });
 
+test('path traversal sequences in the zip file prefix property are stripped', function () {
+    $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->withCustomProperties([
+            'zip_filename_prefix' => '../../../etc/cron.d/',
+        ])
+        ->toMediaCollection();
+
+    $zipStreamResponse = MediaStream::create('my-media.zip')->addMedia(Media::all());
+
+    ob_start();
+    @$zipStreamResponse->toResponse(request())->sendContent();
+    $content = ob_get_contents();
+    ob_end_clean();
+
+    $temporaryDirectory = (new TemporaryDirectory)->create();
+    file_put_contents($temporaryDirectory->path('response.zip'), $content);
+
+    $this->assertFileDoesntExistsInZip($temporaryDirectory->path('response.zip'), '../../../etc/cron.d/test.jpg');
+    $this->assertFileExistsInZipRecognizeFolder($temporaryDirectory->path('response.zip'), 'etc/cron.d/test.jpg');
+});
+
 test('media with zip file prefix property saved with correct prefix', function () {
     $this->testModel
         ->addMedia($this->getTestJpg())


### PR DESCRIPTION
Hardens `MediaStream::getZipFileNamePrefix()` against zip-slip. The `zip_filename_prefix` custom property was concatenated into ZIP entry names with no sanitization, so an application that stored attacker-controlled input there could emit an archive with `../` traversal entries. Now strips `.`/`..` segments while preserving legitimate subfolder prefixes (`folder/subfolder/`) and literal non-slash prefixes.

Not exploitable by the library alone (requires the app to feed untrusted input into the custom property and a naive extractor); shipped as defense-in-depth since the library produces the archive.