### PR TITLE
Fix double URL encoding for getTemporaryUrl() with non-ASCII filenames on local disk

### DIFF
--- a/src/Support/UrlGenerator/DefaultUrlGenerator.php
+++ b/src/Support/UrlGenerator/DefaultUrlGenerator.php
@@ -16,7 +16,7 @@ class DefaultUrlGenerator extends BaseUrlGenerator
 
     public function getTemporaryUrl(DateTimeInterface $expiration, array $options = []): string
     {
-        return $this->getDisk()->temporaryUrl($this->getUrlEncodedPathRelativeToRoot(), $expiration, $options);
+        return $this->getDisk()->temporaryUrl($this->getPathRelativeToRoot(), $expiration, $options);
     }
 
     public function getBaseMediaDirectoryUrl(): string

--- a/tests/Feature/Media/GetUrlTest.php
+++ b/tests/Feature/Media/GetUrlTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Storage;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\InvalidConversion;
 
 it('can get an url of an original item', function () {
@@ -45,4 +46,22 @@ it('throws an exception when trying to get a temporary url on local disk', funct
     $this->expectException(RuntimeException::class);
 
     $media->getTemporaryUrl(Carbon::now()->addMinutes(5));
+});
+
+it('passes the raw path to the disk when generating a temporary url on local disk', function () {
+    $media = $this->testModel
+        ->addMedia($this->getTestJpg())
+        ->usingFileName('tést.jpg')
+        ->toMediaCollection();
+
+    $disk = Mockery::mock(Storage::disk('public'))->makePartial();
+    $disk->shouldReceive('temporaryUrl')
+        ->once()
+        ->withArgs(fn (string $path) => $path === "{$media->id}/tést.jpg")
+        ->andReturn('https://example.com/temporary-url');
+
+    Storage::set('public', $disk);
+
+    expect($media->getTemporaryUrl(Carbon::now()->addMinutes(5)))
+        ->toEqual('https://example.com/temporary-url');
 });


### PR DESCRIPTION
# Fix double URL encoding for temporary URLs on local disk

## Description
Fixes #3949

### The Problem
Calling `$media->getTemporaryUrl()` for files with non-ASCII characters (like Cyrillic or special symbols) on a `local` disk results in a 404 error. 

This occurs due to double URL-encoding: 
1. `DefaultUrlGenerator::getTemporaryUrl()` calls `$this->getUrlEncodedPathRelativeToRoot()`, which encodes the path for `local` drivers.
2. This encoded path is passed to `$disk->temporaryUrl()`.
3. Laravel's built-in `LocalFilesystemAdapter::temporaryUrl()` encodes the path a second time internally (`rawurlencode($path)`).

Because the path is encoded twice, Laravel's route parser only decodes it once. `Storage::exists()` is then called with a still-encoded string instead of the raw filename, resulting in a `404 Not Found`.

### The Fix
Changed `DefaultUrlGenerator::getTemporaryUrl()` to pass `$this->getPathRelativeToRoot()` instead of `$this->getUrlEncodedPathRelativeToRoot()`.

**File changed:** `src/Support/UrlGenerator/DefaultUrlGenerator.php`
```diff
    public function getTemporaryUrl(DateTimeInterface $expiration, array $options = []): string
    {
-       return $this->getDisk()->temporaryUrl($this->getUrlEncodedPathRelativeToRoot(), $expiration, $options);
+       return $this->getDisk()->temporaryUrl($this->getPathRelativeToRoot(), $expiration, $options);
    }
```

### Why this is safe for all drivers
This change only affects the `local` driver. 

If we look at `getUrlEncodedPathRelativeToRoot()`, we can see it already skips encoding for non-local drivers:
```php
    protected function getUrlEncodedPathRelativeToRoot(): string
    {
        $driver = config("filesystems.disks.{$this->getDiskName()}.driver");

        // 👇 For S3, MinIO, etc. it ALREADY returns the raw path!
        if ($driver !== 'local') {
            return $this->getPathRelativeToRoot();
        }
        
        // ... local driver encoding logic ...
    }
```
Because non-local drivers (like S3) were already receiving the raw `getPathRelativeToRoot()` via the early return, their behavior remains 100% unchanged. This PR simply aligns the `local` driver to also pass the raw path, which Laravel's `LocalFilesystemAdapter` explicitly expects.
