### PR TITLE
test: remove real sleep(1) from regenerate command tests

### DIFF
--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -8,13 +8,14 @@ it('can regenerate all files', function () {
     $media = $this->testModelWithConversion->addMedia($this->getTestFilesDirectory('test.jpg'))->toMediaCollection('images');
 
     $derivedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+    // Backdate the existing conversion so the regenerated file is guaranteed a
+    // newer mtime, without waiting out filemtime()'s one-second granularity.
+    touch($derivedImage, time() - 5);
     $createdAt = filemtime($derivedImage);
 
     unlink($derivedImage);
 
     $this->assertFileDoesNotExist($derivedImage);
-
-    sleep(1);
 
     $this->artisan('media-library:regenerate');
 
@@ -39,13 +40,14 @@ it('can regenerate only missing files', function () {
 
     $existsCreatedAt = filemtime($derivedImageExists);
 
+    // Backdate the existing conversion so the regenerated file is guaranteed a
+    // newer mtime, without waiting out filemtime()'s one-second granularity.
+    touch($derivedMissingImage, time() - 5);
     $missingCreatedAt = filemtime($derivedMissingImage);
 
     unlink($derivedMissingImage);
 
     $this->assertFileDoesNotExist($derivedMissingImage);
-
-    sleep(1);
 
     $this->artisan('media-library:regenerate', [
         '--only-missing' => true,
@@ -75,13 +77,14 @@ it('can regenerate missing files queued', function () {
 
     $existsCreatedAt = filemtime($derivedImageExists);
 
+    // Backdate the existing conversion so the regenerated file is guaranteed a
+    // newer mtime, without waiting out filemtime()'s one-second granularity.
+    touch($derivedMissingImage, time() - 5);
     $missingCreatedAt = filemtime($derivedMissingImage);
 
     unlink($derivedMissingImage);
 
     $this->assertFileDoesNotExist($derivedMissingImage);
-
-    sleep(1);
 
     $this->artisan('media-library:regenerate', [
         '--only-missing' => true,
@@ -133,6 +136,9 @@ it('can regenerate only missing files of named conversions', function () {
     $derivedMissingImageOriginal = $this->getMediaDirectory("{$mediaMissing->id}/conversions/test-keep_original_format.png");
 
     $existsCreatedAt = filemtime($derivedImageExists);
+    // Backdate the existing conversion so the regenerated file is guaranteed a
+    // newer mtime, without waiting out filemtime()'s one-second granularity.
+    touch($derivedMissingImage, time() - 5);
     $missingCreatedAt = filemtime($derivedMissingImage);
 
     unlink($derivedMissingImage);
@@ -140,8 +146,6 @@ it('can regenerate only missing files of named conversions', function () {
 
     $this->assertFileDoesNotExist($derivedMissingImage);
     $this->assertFileDoesNotExist($derivedMissingImageOriginal);
-
-    sleep(1);
 
     $this->artisan('media-library:regenerate', [
         '--only-missing' => true,


### PR DESCRIPTION
Four tests in `RegenerateCommandTest` call `sleep(1)` so that a regenerated conversion ends up with a strictly greater `filemtime()` than the original. That is needed only because `filemtime()` has one-second granularity — regenerating within the same wall-clock second produces an equal mtime and fails `toBeGreaterThan`.

Rather than waiting a real second each time, this backdates the original conversion before capturing its mtime:

```php
touch($derivedImage, time() - 5);
$createdAt = filemtime($derivedImage);
```

so the freshly regenerated file is deterministically newer without any sleeping.

**No behaviour change** — the same assertions run, and the "only-missing" tests still assert the untouched conversion keeps its original mtime (`toBe`). Only the missing/regenerated file is backdated.

Verified locally with `vendor/bin/pest tests/Conversions/Commands/RegenerateCommandTest.php`:
- before: **15 passed, 56 assertions — 7.09s**
- after: **15 passed, 56 assertions — 3.24s** (~3.9s faster)

### AI assistance

This change was drafted with Claude Code (Anthropic, Opus 4.x): identifying the fixed-sleep pattern, replacing it with `touch()`-based backdating, and verifying the suite locally before/after. I reviewed the diff and the timing results. Disclosed per my disclose-by-default practice; also noted in the commit trailer (`Assisted-by:`).