### PR TITLE
test: freeze time in regenerate updated_at test to avoid clock flake

### DIFF
--- a/tests/Conversions/Commands/RegenerateCommandTest.php
+++ b/tests/Conversions/Commands/RegenerateCommandTest.php
@@ -362,13 +362,16 @@ it('can set updated_at column when regenerating', function () {
         ->addMedia($this->getTestFilesDirectory('test.jpg'))
         ->toMediaCollection('images');
 
-    $this->travelBack();
+    // Freeze "now" at a fixed, later instant so the regenerated updated_at is
+    // deterministic, rather than comparing against the real clock with a
+    // several-second slop that can flake when the command is slow under load.
+    $this->travelTo('2020-06-01 12:00:00');
 
     $this->artisan('media-library:regenerate');
 
     $media->refresh();
 
-    expect($media->updated_at)->toBeGreaterThanOrEqual(now()->subSeconds(5));
+    expect($media->updated_at->timestamp)->toBe(now()->timestamp);
 });
 
 it('can force queue non-queued conversions', function () {


### PR DESCRIPTION
The `can set updated_at column when regenerating` test creates media in the past, travels back to the **real** clock, regenerates, then asserts:

```php
expect($media->updated_at)->toBeGreaterThanOrEqual(now()->subSeconds(5));
```

That 5-second slop exists only to absorb the command's runtime — but it flakes if the regenerate command takes longer than 5s on a loaded CI runner, failing on a timing margin rather than a real regression.

This travels to a fixed later instant (freezing `now()`) instead of returning to the real clock, and asserts `updated_at` equals that frozen `now()` exactly. It still verifies the point of the test — regeneration bumps `updated_at` away from the 2020 creation time — but deterministically.

Verified locally (`vendor/bin/pest --filter "can set updated_at column when regenerating"`): **1 passed**.

### AI assistance

Drafted with Claude Code (Anthropic, Opus 4.x): spotting the real-clock tolerance as a flake source and replacing it with frozen time. I reviewed the diff and ran the test. Disclosed per my disclose-by-default practice; also in the commit trailer.