### PR TITLE
Keep the just-added media when enforcing a collection size limit

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -648,7 +648,13 @@ class FileAdder
             $collectionMedia = $subject->getMedia($media->collection_name);
 
             if ($collectionMedia->count() > $collectionSizeLimit) {
-                $model->clearMediaCollectionExcept($media->collection_name, $collectionMedia->slice(-$collectionSizeLimit, $collectionSizeLimit));
+                $mediaToKeep = $collectionMedia
+                    ->reject(fn (Media $collectionItem) => $collectionItem->is($media))
+                    ->sortByDesc($media->getKeyName())
+                    ->take($collectionSizeLimit - 1)
+                    ->push($media);
+
+                $model->clearMediaCollectionExcept($media->collection_name, $mediaToKeep);
             }
         }
     }

--- a/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
+++ b/tests/Feature/FileAdder/MediaConversions/MediaCollectionTest.php
@@ -235,6 +235,49 @@ test('if the single file method is specified it will delete all other media and 
     expect($model->getMedia('images'))->toHaveCount(1);
 });
 
+test('a single file collection keeps the media that was just added even when it has a lower order column', function () {
+    $testModel = new class extends TestModelWithConversion
+    {
+        public function registerMediaCollections(): void
+        {
+            $this
+                ->addMediaCollection('avatar')
+                ->singleFile();
+        }
+    };
+
+    $bucket = $testModel::create(['name' => 'bucket']);
+
+    $bucketMedia = [];
+    foreach (range(1, 5) as $index) {
+        $bucketMedia[$index] = $bucket
+            ->addMedia($this->getTestJpg())
+            ->preservingOriginal()
+            ->usingFileName("bucket-{$index}.jpg")
+            ->toMediaCollection('incoming');
+    }
+
+    $destination = $testModel::create(['name' => 'destination']);
+    $bucketMedia[5]->copy($destination, 'avatar');
+
+    $bucketMedia[3]->delete();
+    $bucketMedia[4]->delete();
+    $bucketMedia[5]->delete();
+
+    $newBucketMedia = $bucket
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->usingFileName('bucket-new.jpg')
+        ->toMediaCollection('incoming');
+
+    expect($newBucketMedia->order_column)->toBeLessThan(5);
+
+    $newBucketMedia->copy($destination, 'avatar');
+
+    expect($destination->fresh()->getMedia('avatar'))->toHaveCount(1);
+    expect($destination->fresh()->getFirstMedia('avatar')->file_name)->toBe('bucket-new.jpg');
+});
+
 test('if the only keeps latest method is specified it will delete all other media and will only keep the latest n ones', function () {
     $testModel = new class extends TestModelWithConversion
     {


### PR DESCRIPTION
Fixes #3954.

`singleFile()`/`collectionSizeLimit` enforcement kept the tail of the `order_column` sort, assuming the highest `order_column` is the most recently added item. That breaks because `order_column` is a mutable per-model `MAX()` (deletions lower the next value) and `copy()`/`move()` carry a source item's `order_column` into the destination scope verbatim. A newly copied file could then have a lower `order_column` than an item already in the collection, so the old file was kept and the new one silently discarded, with the size limit never visibly violated.

Now the item that was just added is always kept, and any remaining slots are filled with the most recently inserted others by primary key.