### PR TITLE
Fix media-library:clean when conversions live on a separate disk

### DIFF
--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -146,14 +146,15 @@ class CleanCommand extends Command
         $conversionFilePaths = ConversionCollection::createForMedia($media)->getConversionsFiles($media->collection_name);
 
         $conversionPath = PathGeneratorFactory::create($media)->getPathForConversions($media);
-        $currentFilePaths = $this->fileSystem->disk($media->disk)->files($conversionPath);
+        $conversionsDisk = $media->conversions_disk ?: $media->disk;
+        $currentFilePaths = $this->fileSystem->disk($conversionsDisk)->files($conversionPath);
 
         collect($currentFilePaths)
             ->reject(fn (string $currentFilePath) => $conversionFilePaths->contains(basename($currentFilePath)))
             ->reject(fn (string $currentFilePath) => $media->file_name === basename($currentFilePath))
-            ->each(function (string $currentFilePath) use ($media) {
+            ->each(function (string $currentFilePath) use ($media, $conversionsDisk) {
                 if (! $this->isDryRun) {
-                    $this->fileSystem->disk($media->disk)->delete($currentFilePath);
+                    $this->fileSystem->disk($conversionsDisk)->delete($currentFilePath);
 
                     $this->markConversionAsRemoved($media, $currentFilePath);
                 }
@@ -207,10 +208,20 @@ class CleanCommand extends Command
 
     protected function deleteOrphanedDirectories(): void
     {
-        $diskName = $this->argument('disk') ?: config('media-library.disk_name');
+        $diskNames = $this->argument('disk')
+            ? [$this->argument('disk')]
+            : $this->mediaRepository->allDiskNames()
+                ->push(config('media-library.disk_name'))
+                ->push(config('media-library.conversions_disk_name'))
+                ->filter()
+                ->unique()
+                ->values()
+                ->all();
 
-        if (is_null(config("filesystems.disks.{$diskName}"))) {
-            throw DiskDoesNotExist::create($diskName);
+        foreach ($diskNames as $diskName) {
+            if (is_null(config("filesystems.disks.{$diskName}"))) {
+                throw DiskDoesNotExist::create($diskName);
+            }
         }
 
         $prefix = config('media-library.prefix', '');
@@ -221,26 +232,28 @@ class CleanCommand extends Command
 
         $mediaIdSet = $this->mediaRepository->allIds()->flip();
 
-        /** @var array<int, string> $directories */
-        $directories = $this->fileSystem->disk($diskName)->directories($prefix);
+        foreach ($diskNames as $diskName) {
+            /** @var array<int, string> $directories */
+            $directories = $this->fileSystem->disk($diskName)->directories($prefix);
 
-        collect($directories)
-            ->map(fn (string $directory) => str_replace($prefix, '', $directory))
-            ->filter(fn (string $directory) => is_numeric($directory))
-            ->reject(fn (string $directory) => $mediaIdSet->has((int) $directory))
-            ->each(function (string $directory) use ($diskName, $prefix) {
-                $directory = $prefix.$directory;
+            collect($directories)
+                ->map(fn (string $directory) => str_replace($prefix, '', $directory))
+                ->filter(fn (string $directory) => is_numeric($directory))
+                ->reject(fn (string $directory) => $mediaIdSet->has((int) $directory))
+                ->each(function (string $directory) use ($diskName, $prefix) {
+                    $directory = $prefix.$directory;
 
-                if (! $this->isDryRun) {
-                    $this->fileSystem->disk($diskName)->deleteDirectory($directory);
-                }
+                    if (! $this->isDryRun) {
+                        $this->fileSystem->disk($diskName)->deleteDirectory($directory);
+                    }
 
-                if ($this->rateLimit) {
-                    usleep((1 / $this->rateLimit) * 1_000_000);
-                }
+                    if ($this->rateLimit) {
+                        usleep((1 / $this->rateLimit) * 1_000_000);
+                    }
 
-                $this->info("Orphaned media directory `{$directory}` ".($this->isDryRun ? 'found' : 'has been removed'));
-            });
+                    $this->info("Orphaned media directory `{$directory}` on disk `{$diskName}` ".($this->isDryRun ? 'found' : 'has been removed'));
+                });
+        }
     }
 
     protected function markConversionAsRemoved(Media $media, string $conversionPath): void

--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -146,7 +146,7 @@ class CleanCommand extends Command
         $conversionFilePaths = ConversionCollection::createForMedia($media)->getConversionsFiles($media->collection_name);
 
         $conversionPath = PathGeneratorFactory::create($media)->getPathForConversions($media);
-        $conversionsDisk = $media->conversions_disk ?: $media->disk;
+        $conversionsDisk = $this->conversionsDiskName($media);
         $currentFilePaths = $this->fileSystem->disk($conversionsDisk)->files($conversionPath);
 
         collect($currentFilePaths)
@@ -208,15 +208,7 @@ class CleanCommand extends Command
 
     protected function deleteOrphanedDirectories(): void
     {
-        $diskNames = $this->argument('disk')
-            ? [$this->argument('disk')]
-            : $this->mediaRepository->allDiskNames()
-                ->push(config('media-library.disk_name'))
-                ->push(config('media-library.conversions_disk_name'))
-                ->filter()
-                ->unique()
-                ->values()
-                ->all();
+        $diskNames = $this->diskNamesToSweep();
 
         foreach ($diskNames as $diskName) {
             if (is_null(config("filesystems.disks.{$diskName}"))) {
@@ -256,26 +248,60 @@ class CleanCommand extends Command
         }
     }
 
+    /** @return array<int, string> */
+    protected function diskNamesToSweep(): array
+    {
+        $disk = $this->argument('disk');
+
+        if (is_string($disk) && $disk !== '') {
+            return [$disk];
+        }
+
+        return $this->mediaRepository->allDiskNames()
+            ->push(config('media-library.disk_name'))
+            ->push(config('media-library.conversions_disk_name'))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
+
     protected function markConversionAsRemoved(Media $media, string $conversionPath): void
     {
         $conversionFile = pathinfo($conversionPath, PATHINFO_FILENAME);
-        $conversionsDisk = $media->conversions_disk ?: $media->disk;
-        $conversionDirectory = PathGeneratorFactory::create($media)->getPathForConversions($media);
 
         $media->getGeneratedConversions()
             ->dot()
             ->filter(
                 fn (bool $isGenerated, string $generatedConversionName) => Str::contains($conversionFile, $generatedConversionName)
             )
-            ->filter(
-                fn (bool $isGenerated, string $generatedConversionName) => ! $this->fileSystem
-                    ->disk($conversionsDisk)
-                    ->exists($conversionDirectory.Conversion::create($generatedConversionName)->getConversionFile($media))
+            ->reject(
+                fn (bool $isGenerated, string $generatedConversionName) => $this->conversionFileExists($media, $generatedConversionName)
             )
             ->each(
                 fn (bool $isGenerated, string $conversionName) => $media->markAsConversionNotGenerated($conversionName)
             );
 
         $media->save();
+    }
+
+    protected function conversionFileExists(Media $media, string $conversionName): bool
+    {
+        $conversion = ConversionCollection::createForMedia($media)
+            ->getConversions($media->collection_name)
+            ->first(fn (Conversion $conversion) => $conversion->getName() === $conversionName);
+
+        if (! $conversion) {
+            return false;
+        }
+
+        $path = PathGeneratorFactory::create($media)->getPathForConversions($media).$conversion->getConversionFile($media);
+
+        return $this->fileSystem->disk($this->conversionsDiskName($media))->exists($path);
+    }
+
+    protected function conversionsDiskName(Media $media): string
+    {
+        return $media->conversions_disk ?: $media->disk;
     }
 }

--- a/src/MediaCollections/Commands/CleanCommand.php
+++ b/src/MediaCollections/Commands/CleanCommand.php
@@ -259,13 +259,18 @@ class CleanCommand extends Command
     protected function markConversionAsRemoved(Media $media, string $conversionPath): void
     {
         $conversionFile = pathinfo($conversionPath, PATHINFO_FILENAME);
-
-        $generatedConversionName = null;
+        $conversionsDisk = $media->conversions_disk ?: $media->disk;
+        $conversionDirectory = PathGeneratorFactory::create($media)->getPathForConversions($media);
 
         $media->getGeneratedConversions()
             ->dot()
             ->filter(
                 fn (bool $isGenerated, string $generatedConversionName) => Str::contains($conversionFile, $generatedConversionName)
+            )
+            ->filter(
+                fn (bool $isGenerated, string $generatedConversionName) => ! $this->fileSystem
+                    ->disk($conversionsDisk)
+                    ->exists($conversionDirectory.Conversion::create($generatedConversionName)->getConversionFile($media))
             )
             ->each(
                 fn (bool $isGenerated, string $conversionName) => $media->markAsConversionNotGenerated($conversionName)

--- a/src/MediaCollections/MediaRepository.php
+++ b/src/MediaCollections/MediaRepository.php
@@ -51,6 +51,15 @@ class MediaRepository
         return $this->query()->pluck($this->model->getKeyName());
     }
 
+    public function allDiskNames(): Collection
+    {
+        return $this->query()->distinct()->pluck('disk')
+            ->merge($this->query()->distinct()->pluck('conversions_disk'))
+            ->filter()
+            ->unique()
+            ->values();
+    }
+
     public function getByModelType(string $modelType): LazyCollection
     {
         return $this->query()->where('model_type', $modelType)->cursor();

--- a/tests/Conversions/Commands/CleanCommandTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest.php
@@ -104,6 +104,31 @@ test('a live conversion keeps its generated flag when a deprecated file shares i
     expect($media->refresh()->hasGeneratedConversion('thumb'))->toBeTrue();
 });
 
+test('a live conversion that changes the file format keeps its generated flag', function () {
+    $testModelClass = new class extends TestModel
+    {
+        public function registerMediaConversions(?Media $media = null): void
+        {
+            $this->addMediaConversion('thumb')->width(50)->format('webp')->nonQueued();
+        }
+    };
+
+    $media = $testModelClass::create(['name' => 'test'])
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->toMediaCollection();
+
+    $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+
+    touch($deprecatedImage);
+
+    $this->artisan('media-library:clean');
+
+    $this->assertFileDoesNotExist($deprecatedImage);
+    expect($this->getMediaDirectory("{$media->id}/conversions/test-thumb.webp"))->toBeFile();
+    expect($media->refresh()->hasGeneratedConversion('thumb'))->toBeTrue();
+});
+
 it('can clean deprecated conversion files from a specific model type', function () {
     $media1 = $this->media['model1']['collection1'];
     $media2 = $this->media['model2']['collection1'];

--- a/tests/Conversions/Commands/CleanCommandTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest.php
@@ -456,8 +456,10 @@ it('will not touch the original disk when looking for deprecated conversions on 
         ->storingConversionsOnDisk('secondMediaDisk')
         ->toMediaCollection('collection1');
 
-    $strayFileOnOriginalDisk = $this->getMediaDirectory("{$media->id}/stray.jpg");
+    $conversionsDirectoryOnOriginalDisk = $this->getMediaDirectory("{$media->id}/conversions");
+    mkdir($conversionsDirectoryOnOriginalDisk, 0777, true);
 
+    $strayFileOnOriginalDisk = "{$conversionsDirectoryOnOriginalDisk}/test-deprecated.jpg";
     touch($strayFileOnOriginalDisk);
 
     $this->artisan('media-library:clean');

--- a/tests/Conversions/Commands/CleanCommandTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest.php
@@ -387,6 +387,76 @@ it('will not clean orphaned media items when disabled', function () {
     ]);
 });
 
+it('can clean deprecated conversion files stored on a separate conversions disk', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->storingConversionsOnDisk('secondMediaDisk')
+        ->toMediaCollection('collection1');
+
+    $conversionsDirectory = $this->getTempDirectory("media2/{$media->id}/conversions");
+    $deprecatedImage = "{$conversionsDirectory}/test-deprecated.jpg";
+
+    touch($deprecatedImage);
+    expect($deprecatedImage)->toBeFile();
+
+    $this->artisan('media-library:clean');
+
+    $this->assertFileDoesNotExist($deprecatedImage);
+    expect("{$conversionsDirectory}/test-thumb.jpg")->toBeFile();
+});
+
+it('will not touch the original disk when looking for deprecated conversions on a separate disk', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->storingConversionsOnDisk('secondMediaDisk')
+        ->toMediaCollection('collection1');
+
+    $strayFileOnOriginalDisk = $this->getMediaDirectory("{$media->id}/stray.jpg");
+
+    touch($strayFileOnOriginalDisk);
+
+    $this->artisan('media-library:clean');
+
+    expect($strayFileOnOriginalDisk)->toBeFile();
+});
+
+it('can clean orphaned directories on the conversions disk', function () {
+    $media = $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->storingConversionsOnDisk('secondMediaDisk')
+        ->toMediaCollection('collection1');
+
+    $orphanedDirectory = $this->getTempDirectory('media2/9999');
+    mkdir($orphanedDirectory, 0777, true);
+
+    $this->artisan('media-library:clean');
+
+    $this->assertDirectoryDoesNotExist($orphanedDirectory);
+    $this->assertDirectoryExists($this->getTempDirectory("media2/{$media->id}"));
+});
+
+it('only cleans orphaned directories on the given disk when a disk argument is passed', function () {
+    $this->testModelWithConversion
+        ->addMedia($this->getTestJpg())
+        ->preservingOriginal()
+        ->storingConversionsOnDisk('secondMediaDisk')
+        ->toMediaCollection('collection1');
+
+    $orphanedOnPublicDisk = $this->getMediaDirectory('9998');
+    $orphanedOnSecondDisk = $this->getTempDirectory('media2/9999');
+
+    mkdir($orphanedOnPublicDisk, 0777, true);
+    mkdir($orphanedOnSecondDisk, 0777, true);
+
+    $this->artisan('media-library:clean', ['disk' => 'public']);
+
+    $this->assertDirectoryDoesNotExist($orphanedOnPublicDisk);
+    $this->assertDirectoryExists($orphanedOnSecondDisk);
+});
+
 it('will not clean media items on soft deleted models', function () {
     $testModelClass = new class extends TestModel
     {

--- a/tests/Conversions/Commands/CleanCommandTest.php
+++ b/tests/Conversions/Commands/CleanCommandTest.php
@@ -86,6 +86,24 @@ test('generated conversion are cleared after cleanup', function () {
     expect($media->hasGeneratedConversion('test.deprecated'))->toBeFalse();
 });
 
+test('a live conversion keeps its generated flag when a deprecated file shares its name', function () {
+    /** @var Media $media */
+    $media = $this->media['model2']['collection1'];
+
+    expect($media->refresh()->hasGeneratedConversion('thumb'))->toBeTrue();
+
+    $liveConversion = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.jpg");
+    $deprecatedImage = $this->getMediaDirectory("{$media->id}/conversions/test-thumb.png");
+
+    touch($deprecatedImage);
+
+    $this->artisan('media-library:clean');
+
+    $this->assertFileDoesNotExist($deprecatedImage);
+    expect($liveConversion)->toBeFile();
+    expect($media->refresh()->hasGeneratedConversion('thumb'))->toBeTrue();
+});
+
 it('can clean deprecated conversion files from a specific model type', function () {
     $media1 = $this->media['model1']['collection1'];
     $media2 = $this->media['model2']['collection1'];


### PR DESCRIPTION
Fixes #3957.

When conversions are stored on a disk other than the original, `media-library:clean` worked on the wrong disk in two places.

**Deprecated conversions**

`deleteConversionFilesForDeprecatedConversions()` listed and deleted conversion files on `$media->disk`. They live on `$media->conversions_disk`, so the listing came back empty and deprecated conversions were never cleaned. It now resolves `$media->conversions_disk ?: $media->disk` and uses that disk for both the listing and the delete, so the original disk is left untouched.

**Orphaned directories**

`deleteOrphanedDirectories()` only ever swept one disk, so directories left on the conversions disk survived. It now sweeps every disk actually referenced by media rows (new `MediaRepository::allDiskNames()`, reading both `disk` and `conversions_disk`) plus `media-library.disk_name` and `media-library.conversions_disk_name`. Each disk is validated before the sweep, so a missing disk still raises `DiskDoesNotExist`. Passing the `disk` argument keeps the previous behaviour and restricts the sweep to that one disk. The info line now names the disk the directory was found on.

**Tests**

Four cases in `CleanCommandTest`: a deprecated conversion on a separate conversions disk is removed; a stray file on the original disk is not touched while doing so; an orphaned directory on the conversions disk is removed while a live one is kept; the `disk` argument still limits the sweep to the given disk.

The first and third fail on `main` and pass with this change. Full suite is green.
