### PR TITLE
docs: fix HasMedia interface import in custom image generator

### DIFF
--- a/docs/converting-other-file-types/creating-a-custom-image-generator.md
+++ b/docs/converting-other-file-types/creating-a-custom-image-generator.md
@@ -98,7 +98,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Spatie\MediaLibrary\InteractsWithMedia;
-use Spatie\MediaLibrary\Interfaces\HasMedia;
+use Spatie\MediaLibrary\HasMedia;
 
 class News extends Model implements HasMedia
 {


### PR DESCRIPTION
The custom image generator example imports the `HasMedia` interface as `Spatie\MediaLibrary\Interfaces\HasMedia`, but there is no `Interfaces` namespace. The interface is `Spatie\MediaLibrary\HasMedia` (`src/HasMedia.php`), which is how it is imported throughout the rest of the docs. The example's `class News extends Model implements HasMedia` needs this corrected import to run.
