### PR TITLE
Decode remote url path before stripping directory in addMediaFromUrl

### DIFF
--- a/src/InteractsWithMedia.php
+++ b/src/InteractsWithMedia.php
@@ -159,8 +159,7 @@ trait InteractsWithMedia
         $temporaryFile = (new $downloader)->getTempFile($url);
         $this->guardAgainstInvalidMimeType($temporaryFile, $allowedMimeTypes);
 
-        $filename = basename(parse_url($url, PHP_URL_PATH));
-        $filename = urldecode($filename);
+        $filename = basename(urldecode((string) parse_url($url, PHP_URL_PATH)));
 
         if ($filename === '') {
             $filename = 'file';

--- a/tests/Feature/FileAdder/IntegrationTest.php
+++ b/tests/Feature/FileAdder/IntegrationTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Image\Enums\BorderType;
+use Spatie\MediaLibrary\Downloaders\HttpFacadeDownloader;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\ImageGeneratorFactory;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskCannotBeAccessed;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\DiskDoesNotExist;
@@ -317,6 +319,24 @@ it('can add a remote file with a space in the name to the media library', functi
         ->toMediaCollection();
 
     expect($this->getMediaDirectory("{$media->id}/test-with-space.jpg"))->toBeFile();
+});
+
+it('does not let an encoded path in a remote url escape the media directory', function () {
+    config()->set('media-library.media_downloader', HttpFacadeDownloader::class);
+
+    $bytes = file_get_contents($this->getTestJpg());
+
+    Http::fake(['*' => Http::response($bytes, 200, ['Content-Type' => 'image/jpeg'])]);
+
+    $url = 'https://example.com/uploads%2F..%2F..%2Fevil.jpg';
+
+    $media = $this->testModel
+        ->addMediaFromUrl($url)
+        ->toMediaCollection();
+
+    expect($media->file_name)->not->toContain('/');
+    expect($media->file_name)->toEqual('evil.jpg');
+    expect($this->getMediaDirectory("{$media->id}/evil.jpg"))->toBeFile();
 });
 
 it('will thrown an exception when a remote file could not be added', function () {


### PR DESCRIPTION
addMediaFromUrl in src/InteractsWithMedia.php runs basename() on the raw url path and only urldecodes afterwards. that ordering defeats basename, since percent-encoded separators survive the strip and only turn into real slashes once decoded. a url like https://host/uploads%2F..%2F..%2Fevil.jpg comes out as uploads/../../evil.jpg instead of just evil.jpg, so the directory portion basename is supposed to remove leaks into the derived filename.

the default sanitizer still swaps out the slashes, so this is mostly hardening rather than a break under the shipped config, but anyone using a custom sanitizer via sanitizingFileName() that keeps separators would inherit the traversal. decoding first, then calling basename, gives you the last path segment like it was meant to.

added a test covering the encoded-separator case.
